### PR TITLE
Add Prometheus metrics

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -3,6 +3,7 @@
     using Microsoft.AspNetCore;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Configuration;
+    using Prometheus.DotNetRuntime;
     using Serilog;
     using Serilog.Events;
     using Serilog.Sinks.Grafana.Loki;
@@ -147,6 +148,7 @@
 
             try
             {
+                using var runtimeMetrics = DotNetRuntimeStatsBuilder.Default().StartCollecting();
                 CreateWebHostBuilder(args).Build().Run();
             }
             catch (Exception ex)

--- a/src/slskd/Startup.cs
+++ b/src/slskd/Startup.cs
@@ -31,6 +31,7 @@
     using Serilog.Events;
     using Microsoft.Extensions.Logging;
     using Prometheus;
+    using Prometheus.SystemMetrics;
 
     public class Startup
     {
@@ -168,6 +169,8 @@
                     }
                 });
             }
+
+            services.AddSystemMetrics();
 
             services.AddSingleton<ISoulseekClient, SoulseekClient>(serviceProvider => Client);
             services.AddSingleton<ITransferTracker, TransferTracker>();

--- a/src/slskd/Startup.cs
+++ b/src/slskd/Startup.cs
@@ -30,6 +30,7 @@
     using Serilog;
     using Serilog.Events;
     using Microsoft.Extensions.Logging;
+    using Prometheus;
 
     public class Startup
     {
@@ -197,6 +198,7 @@
             app.UseSerilogRequestLogging();
 
             app.UseRouting();
+            app.UseHttpMetrics();
             app.UsePathBase(BasePath);
 
             // remove any errant double forward slashes which may have been introduced
@@ -227,6 +229,7 @@
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();
+                endpoints.MapMetrics();
             });
 
             if (EnableSwagger)

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -26,6 +26,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.2.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.2" />
+    <PackageReference Include="prometheus-net" Version="4.1.1" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />
+    <PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="4.1.1" />
+    <PackageReference Include="prometheus-net.DotNetRuntime" Version="3.4.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />
     <PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="4.1.1" />
     <PackageReference Include="prometheus-net.DotNetRuntime" Version="3.4.1" />
+    <PackageReference Include="prometheus-net.SystemMetrics" Version="1.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />


### PR DESCRIPTION
Adds:

* The Prometheus metrics server (prometheus-net)
* ASP.NET Core metrics (kestrel and request) (prometheus-net.AspNetCore)
* ASP.NET health checks (to be implemented in #17) (prometheus-net.AspNetCore.HealthChecks)
* .NET Runtime metrics (prometheus-net.DotNetRuntime)
* Basic system metrics (CPU, memory, network, disk) (prometheus-net.SystemMetrics)

Custom metrics for internals of the Soulseek library and slskd are TBD.

Metrics (in Prometheus format) are available at `/metrics`