### PR TITLE
Temporarily disable HTTPS

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -167,9 +167,10 @@
                     })
                     .UseSerilog()
                     .UseStartup<Startup>()
-                    .UseUrls(
-                        $"http://0.0.0.0:{options.Web.Port}", 
-                        $"https://0.0.0.0:{options.Web.Https.Port}")
+                    //.UseUrls(
+                    //    $"http://0.0.0.0:{options.Web.Port}", 
+                    //    $"https://0.0.0.0:{options.Web.Https.Port}")
+                    .UseUrls($"http://0.0.0.0:{options.Web.Port}")
                     .Build()
                     .Run();
             }


### PR DESCRIPTION
```Unable to configure HTTPS endpoint. No server certificate was specified, and the default developer certificate could not be found or is out of date.```

I thought this seemed a little too easy.  I'll need to put this off until I can add certificate handling.