### PR TITLE
Move XML documentation and configuration to subdirectories

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -51,6 +51,11 @@ namespace slskd
         public static readonly string AppName = "slskd";
 
         /// <summary>
+        ///     The default database filename.
+        /// </summary>
+        public static readonly string DefaultDatabaseFile = Path.Combine(AppContext.BaseDirectory, "data", $"{AppName}.db");
+
+        /// <summary>
         ///     The default configuration filename.
         /// </summary>
         public static readonly string DefaultConfigurationFile = Path.Combine(AppContext.BaseDirectory, "config", $"{AppName}.yml");

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -209,7 +209,7 @@ namespace slskd
                         outputTemplate: "[{SourceContext}] [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
                     .WriteTo.Async(config =>
                         config.File(
-                            $"logs/{AppName}-.log",
+                            Path.Combine(AppContext.BaseDirectory, "logs", $"{AppName}-.log"),
                             outputTemplate: "[{SourceContext}] [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
                             rollingInterval: RollingInterval.Day))
                     .WriteTo.Conditional(
@@ -234,7 +234,7 @@ namespace slskd
                         outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
                     .WriteTo.Async(config =>
                         config.File(
-                            $"logs/{AppName}-.log",
+                            Path.Combine(AppContext.BaseDirectory, "logs", $"{AppName}-.log"),
                             outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
                             rollingInterval: RollingInterval.Day))
                     .WriteTo.Conditional(

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -53,7 +53,12 @@ namespace slskd
         /// <summary>
         ///     The default configuration filename.
         /// </summary>
-        public static readonly string DefaultConfigurationFile = $"{AppName}.yml";
+        public static readonly string DefaultConfigurationFile = Path.Combine(AppContext.BaseDirectory, "config", $"{AppName}.yml");
+
+        /// <summary>
+        ///     The default XML documentation filename.
+        /// </summary>
+        public static readonly string DefaultXmlDocumentaitonFile =  Path.Combine(AppContext.BaseDirectory, "etc", $"{AppName}.xml");
 
         /// <summary>
         ///     The global prefix for environment variables.

--- a/src/slskd/Startup.cs
+++ b/src/slskd/Startup.cs
@@ -52,7 +52,6 @@ namespace slskd
     /// </summary>
     public class Startup
     {
-        private static readonly string XmlDocFile = Path.Combine(AppContext.BaseDirectory, Program.AppName + ".xml");
         private static readonly int MaxReconnectAttempts = 3;
         private static int currentReconnectAttempts = 0;
 
@@ -165,13 +164,13 @@ namespace slskd
                             Version = "v0",
                         });
 
-                    if (System.IO.File.Exists(XmlDocFile))
+                    if (System.IO.File.Exists(Program.DefaultXmlDocumentaitonFile))
                     {
-                        options.IncludeXmlComments(XmlDocFile);
+                        options.IncludeXmlComments(Program.DefaultXmlDocumentaitonFile);
                     }
                     else
                     {
-                        logger.Warning($"Unable to find XML documentation in {XmlDocFile}, Swagger will not include metadata");
+                        logger.Warning($"Unable to find XML documentation in {Program.DefaultXmlDocumentaitonFile}, Swagger will not include metadata");
                     }
                 });
             }

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -32,11 +32,13 @@
 
   <Target Name="CopyAfterBuild" AfterTargets="AfterBuild">
     <Copy SourceFiles="..\..\LICENSE" DestinationFolder="$(OutDir)" />
-    <Copy SourceFiles="Properties\slskd.yml" DestinationFolder="$(OutDir)" />
+    <Copy SourceFiles="Properties\slskd.yml" DestinationFolder="$(OutDir)\config" />
+    <Copy SourceFiles="$(OutDir)\slskd.xml" DestinationFolder="$(OutDir)\etc" />
   </Target>
   <Target Name="CopyOnPublish" AfterTargets="Publish">
     <Copy SourceFiles="..\..\LICENSE" DestinationFolder="$(PublishDir)" />
-    <Copy SourceFiles="Properties\slskd.yml" DestinationFolder="$(PublishDir)" />
+    <Copy SourceFiles="Properties\slskd.yml" DestinationFolder="$(PublishDir)\config" />
+    <Move SourceFiles="$(PublishDir)\slskd.xml" DestinationFolder="$(PublishDir)\etc" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
`slskd.yml` configuration is now stored in `/config`, `slskd.xml` is now stored in `/etc`, and the SQLite database will eventually be stored in `/data`.

This PR also ensures that logs are stored relative to the app executable, rather than to the project root.