### PR TITLE
Add ARM/v7 and ARM64 to Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     strategy:
       matrix:
-        runtime: ["win-x64", "linux-x64", "linux-arm", "linux-arm64", "linux-musl-x64", "linux-musl-arm", "linux-musl-arm64", "osx-x64"]
+        runtime: ["win-x64", "linux-x64", "linux-arm", "linux-arm64", "osx-x64"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,23 +8,8 @@ COPY src/web src/web/.
 
 RUN sh ./bin/build --web-only --version $VERSION
 
-#
-
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
-ARG VERSION=0.0.1.65534-local
-
-WORKDIR /slskd
-
-COPY LICENSE .
-COPY bin bin/.
-COPY src/slskd src/slskd/.
-COPY tests tests/.
-
-RUN bash ./bin/build --dotnet-only --version $VERSION
-
-#
-
-# note: this needs to be pinned to an amd64 image
+# note: this needs to be pinned to an amd64 image in order to publish armv7 binaries
+# https://github.com/dotnet/dotnet-docker/issues/1537#issuecomment-615269150
 FROM mcr.microsoft.com/dotnet/sdk:5.0-focal-amd64 AS publish
 ARG TARGETPLATFORM
 ARG VERSION=0.0.1.65534-local
@@ -34,7 +19,11 @@ WORKDIR /slskd
 COPY LICENSE .
 COPY bin bin/.
 COPY src/slskd src/slskd/.
+COPY tests tests/.
+
 COPY --from=web /slskd/src/web/build /slskd/src/slskd/wwwroot/.
+
+RUN bash ./bin/build --dotnet-only --version $VERSION
 
 RUN bash ./bin/publish --no-prebuild --platform $TARGETPLATFORM --version $VERSION --output ../../dist/${TARGETPLATFORM}
 
@@ -44,32 +33,13 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-focal AS slskd
 ARG TARGETPLATFORM
 ARG VERSION=0.0.1.65534-local
 
+LABEL org.opencontainers.image.title=slskd
+LABEL org.opencontainers.image.description="a modern client-server application for the Soulseek file sharing network"
+LABEL org.opencontainers.image.url=https://slskd.org
 LABEL org.opencontainers.image.source=https://github.com/slskd/slskd
-LABEL org.opencontainers.image.licsense=AGPL-3.0
+LABEL org.opencontainers.image.licenses=AGPL-3.0
 LABEL org.opencontainers.image.version=${VERSION}
-
-# # the following is a 1:1 copy of the .NET 5 runtime-deps dockerfile, which does not yet support alpine/armv7
-# # review this in the future to determine if we can return to using mcr.microsoft.com/dotnet/runtime-deps:5.0-alpine as the base
-# # https://github.com/dotnet/dotnet-docker/blob/56e04001eb08a0399c8887a517f2dc9a81dcdf04/src/runtime-deps/5.0/alpine3.13/amd64/Dockerfile
-# RUN apk add --no-cache \
-#         ca-certificates \
-#         \
-#         # .NET Core dependencies
-#         krb5-libs \
-#         libgcc \
-#         libintl \
-#         libssl1.1 \
-#         libstdc++ \
-#         zlib
-
-# ENV \
-#     # Configure web servers to bind to port 80 when present
-#     ASPNETCORE_URLS=http://+:80 \
-#     # Enable detection of running in a container
-#     DOTNET_RUNNING_IN_CONTAINER=true \
-#     # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)
-#     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
-# # end runtime-deps
+LABEL org.opencontainers.image.created=$(date --iso-8601=s)
 
 WORKDIR /slskd
 COPY --from=publish /slskd/dist/${TARGETPLATFORM} .


### PR DESCRIPTION
The Dockerfile now uses Ubuntu images for the build, publish and runtime stages due to various incompatibilities with Alpine.  This nearly triples the size of the resulting image (from ~20mb to ~60mb), but reduces friction and adds support for the most likely usage scenarios.

The build artifacts for `linux-musl-*` have been removed from the build output because of this move away from Alpine.