### PR TITLE
Use local username when sending search results

### DIFF
--- a/src/slskd/Service.cs
+++ b/src/slskd/Service.cs
@@ -353,7 +353,7 @@ namespace slskd
                 Console.WriteLine($"[SENDING SEARCH RESULTS]: {results.Count()} records to {username} for query {query.SearchText}");
 
                 return Task.FromResult(new SearchResponse(
-                    username,
+                    SoulseekClient.Username,
                     token,
                     freeUploadSlots: 1,
                     uploadSpeed: 0,


### PR DESCRIPTION
Fixes a regression from the Soulseek.NET example app: https://github.com/jpdillingham/Soulseek.NET/issues/493