### PR TITLE
Send speed of completed uploads to the server 

### DIFF
--- a/src/slskd/Service.cs
+++ b/src/slskd/Service.cs
@@ -257,6 +257,11 @@ namespace slskd
             var completed = args.Transfer.State.HasFlag(TransferStates.Completed);
 
             Console.WriteLine($"[{direction}] [{user}/{file}] {oldState} => {state}{(completed ? $" ({args.Transfer.BytesTransferred}/{args.Transfer.Size} = {args.Transfer.PercentComplete}%) @ {args.Transfer.AverageSpeed.SizeSuffix()}/s" : string.Empty)}");
+
+            if (completed && args.Transfer.Direction == TransferDirection.Upload)
+            {
+                _ = Client.SendUploadSpeedAsync((int)args.Transfer.AverageSpeed);
+            }
         }
 
         private void Client_UserStatusChanged(object sender, UserStatusChangedEventArgs args)

--- a/src/slskd/Service.cs
+++ b/src/slskd/Service.cs
@@ -258,7 +258,7 @@ namespace slskd
 
             Console.WriteLine($"[{direction}] [{user}/{file}] {oldState} => {state}{(completed ? $" ({args.Transfer.BytesTransferred}/{args.Transfer.Size} = {args.Transfer.PercentComplete}%) @ {args.Transfer.AverageSpeed.SizeSuffix()}/s" : string.Empty)}");
 
-            if (completed && args.Transfer.Direction == TransferDirection.Upload)
+            if (args.Transfer.State.HasFlag(TransferStates.Succeeded) && args.Transfer.Direction == TransferDirection.Upload)
             {
                 _ = Client.SendUploadSpeedAsync((int)args.Transfer.AverageSpeed);
             }


### PR DESCRIPTION
This allows other users to see our average speed, and for the server to determine our role in the distributed network.