### PR TITLE
Save incomplete downloads in a separate directory

### DIFF
--- a/src/slskd/Common/Extensions.cs
+++ b/src/slskd/Common/Extensions.cs
@@ -105,7 +105,7 @@ namespace slskd
                 sanitizedFilename = sanitizedFilename.Replace(c, '_');
             }
 
-            return Path.Combine(path, sanitizedFilename).TrimStart('\\');
+            return Path.Combine(path, sanitizedFilename).TrimStart('\\').TrimStart('/');
         }
 
         /// <summary>

--- a/src/slskd/Common/Extensions.cs
+++ b/src/slskd/Common/Extensions.cs
@@ -87,6 +87,41 @@ namespace slskd
         }
 
         /// <summary>
+        ///     Converts a fully qualified remote filename to a local filename, swapping directory characters for those specific
+        ///     to the local OS, removing any characters that are invalid for the local OS, and making the path relative to the
+        ///     remote store (including the filename and the parent folder).
+        /// </summary>
+        /// <param name="remoteFilename">The fully qualified remote filename to convert.</param>
+        /// <returns>The converted filename.</returns>
+        public static string ToLocalRelativeFilename(this string remoteFilename)
+        {
+            var localFilename = remoteFilename.ToLocalOSPath();
+            var path = $"{Path.GetDirectoryName(localFilename).Replace(Path.GetDirectoryName(Path.GetDirectoryName(localFilename)), string.Empty)}";
+
+            var sanitizedFilename = Path.GetFileName(localFilename);
+
+            foreach (var c in Path.GetInvalidFileNameChars())
+            {
+                sanitizedFilename = sanitizedFilename.Replace(c, '_');
+            }
+
+            return Path.Combine(path, sanitizedFilename).TrimStart('\\');
+        }
+
+        /// <summary>
+        ///     Converts a fully qualified remote filename to a local filename based in the provided <paramref name="baseDirectory"/>, swapping directory characters for those specific
+        ///     to the local OS, removing any characters that are invalid for the local OS, and making the path relative to the
+        ///     remote store (including the filename and the parent folder).
+        /// </summary>
+        /// <param name="remoteFilename">The fully qualified remote filename to convert.</param>
+        /// <param name="baseDirectory">The base directory for the local filename.</param>
+        /// <returns>The converted filename.</returns>
+        public static string ToLocalFilename(this string remoteFilename, string baseDirectory)
+        {
+            return Path.Combine(baseDirectory, remoteFilename.ToLocalRelativeFilename());
+        }
+
+        /// <summary>
         ///     Converts the given path to the local format (normalizes path separators).
         /// </summary>
         /// <param name="path">The path to convert.</param>

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -371,7 +371,7 @@ namespace slskd
             [Argument(default, "content-path")]
             [EnvironmentVariable("CONTENT_PATH")]
             [Description("path to static web content")]
-            [Required]
+            [StringLength(255, MinimumLength = 1)]
             public string ContentPath { get; private set; } = "wwwroot";
 
             /// <summary>
@@ -399,7 +399,7 @@ namespace slskd
                 [Argument('u', "username")]
                 [EnvironmentVariable("USERNAME")]
                 [Description("username for web UI")]
-                [Required]
+                [StringLength(255, MinimumLength = 1)]
                 public string Username { get; private set; } = Program.AppName;
 
                 /// <summary>
@@ -408,7 +408,7 @@ namespace slskd
                 [Argument('p', "password")]
                 [EnvironmentVariable("PASSWORD")]
                 [Description("password for web UI")]
-                [Required]
+                [StringLength(255, MinimumLength = 1)]
                 public string Password { get; private set; } = Program.AppName;
 
                 /// <summary>
@@ -428,7 +428,7 @@ namespace slskd
                     [Argument(default, "jwt-key")]
                     [EnvironmentVariable("JWT_KEY")]
                     [Description("JWT signing key")]
-                    [Required]
+                    [StringLength(255, MinimumLength = 1)]
                     public string Key { get; private set; } = Guid.NewGuid().ToString();
 
                     /// <summary>

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -127,13 +127,20 @@ namespace slskd
         public class DirectoriesOptions
         {
             /// <summary>
-            ///     Gets the path to shared files.
+            ///     Gets the path where application data is saved.
             /// </summary>
-            [Argument('s', "shared")]
-            [EnvironmentVariable("SHARED_DIR")]
-            [Description("path to shared files")]
-            [Required]
-            public string Shared { get; private set; } = null;
+            [Argument(default, "app")]
+            [EnvironmentVariable("APP_DIR")]
+            [Description("path where application data is saved")]
+            public string App { get; private set; } = Program.DefaultAppDirectory;
+
+            /// <summary>
+            ///     Gets the path where incomplete downloads are saved.
+            /// </summary>
+            [Argument(default, "incomplete")]
+            [EnvironmentVariable("INCOMPLETE_DIR")]
+            [Description("path where incomplete downloads are saved")]
+            public string Incomplete { get; private set; } = Program.DefaultIncompleteDirectory;
 
             /// <summary>
             ///     Gets the path where downloaded files are saved.
@@ -141,8 +148,15 @@ namespace slskd
             [Argument('o', "downloads")]
             [EnvironmentVariable("DOWNLOADS_DIR")]
             [Description("path where downloaded files are saved")]
-            [Required]
-            public string Downloads { get; private set; } = null;
+            public string Downloads { get; private set; } = Program.DefaultDownloadsDirectory;
+
+            /// <summary>
+            ///     Gets the path to shared files.
+            /// </summary>
+            [Argument('s', "shared")]
+            [EnvironmentVariable("SHARED_DIR")]
+            [Description("path to shared files")]
+            public string Shared { get; private set; } = Program.DefaultSharedDirectory;
         }
 
         /// <summary>

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -1,4 +1,4 @@
-// <copyright file="Program.cs" company="slskd Team">
+﻿// <copyright file="Program.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -478,7 +478,7 @@ namespace slskd
 
                         var suffix = isRequired ? " (required)" : $" (default: {property.GetValue(defaults) ?? "<null>"})";
                         var item = $"{prefix}{GetName(name, property.PropertyType)}";
-                        var desc = $"{description} {(type == typeof(bool) ? string.Empty : suffix)}";
+                        var desc = $"{description}{(type == typeof(bool) ? string.Empty : suffix)}";
                         lines.Add(new(item, desc));
                     }
                     else

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Program.cs" company="slskd Team">
+// <copyright file="Program.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -52,9 +52,9 @@ namespace slskd
         public static readonly string AppName = "slskd";
 
         /// <summary>
-        ///     The default database filename.
+        ///     The default application data directory.
         /// </summary>
-        public static readonly string DefaultDatabaseFile = Path.Combine(AppContext.BaseDirectory, "data", $"{AppName}.db");
+        public static readonly string DefaultAppDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), AppName);
 
         /// <summary>
         ///     The default configuration filename.

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -64,7 +64,21 @@ namespace slskd
         /// <summary>
         ///     The default XML documentation filename.
         /// </summary>
-        public static readonly string DefaultXmlDocumentaitonFile = Path.Combine(AppContext.BaseDirectory, "etc", $"{AppName}.xml");
+
+        /// <summary>
+        ///     The default incomplete download directory.
+        /// </summary>
+        public static readonly string DefaultIncompleteDirectory = Path.Combine(DefaultAppDirectory, "incomplete");
+
+        /// <summary>
+        ///     The default downloads directory.
+        /// </summary>
+        public static readonly string DefaultDownloadsDirectory = Path.Combine(DefaultAppDirectory, "downloads");
+
+        /// <summary>
+        ///     The default shared directory.
+        /// </summary>
+        public static readonly string DefaultSharedDirectory = Path.Combine(DefaultAppDirectory, "shared");
 
         /// <summary>
         ///     The global prefix for environment variables.

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -20,6 +20,7 @@ namespace slskd
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
+    using System.ComponentModel.DataAnnotations;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -420,6 +421,7 @@ namespace slskd
                 {
                     var attribute = property.CustomAttributes.FirstOrDefault(a => a.AttributeType == typeof(ArgumentAttribute));
                     var descriptionAttribute = property.CustomAttributes.FirstOrDefault(a => a.AttributeType == typeof(DescriptionAttribute));
+                    var isRequired = property.CustomAttributes.Any(a => a.AttributeType == typeof(RequiredAttribute));
 
                     if (attribute != default)
                     {
@@ -427,9 +429,9 @@ namespace slskd
                         var longName = (string)attribute.ConstructorArguments[1].Value;
                         var description = descriptionAttribute?.ConstructorArguments[0].Value;
 
-                        var suffix = property.PropertyType == typeof(bool) ? string.Empty : $" (default: {property.GetValue(defaults) ?? "<null>"})";
-                        var item = $"{shortName}{(shortName == default ? " " : "|")}--{GetLongName(longName, property.PropertyType)}";
-                        var desc = $"{description}{suffix}";
+                        var suffix = isRequired ? " (required)" : $" (default: {property.GetValue(defaults) ?? "<null>"})";
+                        var item = $"{(shortName == default ? "  " : $"{shortName}|")}--{GetLongName(longName, property.PropertyType)}";
+                        var desc = $"{description}{(property.PropertyType == typeof(bool) ? string.Empty : suffix)}";
                         lines.Add(new(item, desc));
                     }
                     else
@@ -467,15 +469,16 @@ namespace slskd
                 {
                     var attribute = property.CustomAttributes.FirstOrDefault(a => a.AttributeType == typeof(EnvironmentVariableAttribute));
                     var descriptionAttribute = property.CustomAttributes.FirstOrDefault(a => a.AttributeType == typeof(DescriptionAttribute));
+                    var isRequired = property.CustomAttributes.Any(a => a.AttributeType == typeof(RequiredAttribute));
 
                     if (attribute != default)
                     {
                         var name = (string)attribute.ConstructorArguments[0].Value;
                         var description = descriptionAttribute?.ConstructorArguments[0].Value;
 
-                        var suffix = type == typeof(bool) ? string.Empty : $" (default: {property.GetValue(defaults) ?? "<null>"})";
+                        var suffix = isRequired ? " (required)" : $" (default: {property.GetValue(defaults) ?? "<null>"})";
                         var item = $"{prefix}{GetName(name, property.PropertyType)}";
-                        var desc = $"{description}{suffix}";
+                        var desc = $"{description} {(type == typeof(bool) ? string.Empty : suffix)}";
                         lines.Add(new(item, desc));
                     }
                     else

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -213,6 +213,37 @@ namespace slskd
                 return;
             }
 
+            // ensure the application directory exists and is writeable. the most comprehensive way to test this is to try
+            // to write a file to it.
+            try
+            {
+                if (!Directory.Exists(Options.Directories.App))
+                {
+                    Directory.CreateDirectory(Options.Directories.App);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"App directory {Options.Directories.App} does not exist, and could not be created: {ex.Message}");
+            }
+
+            try
+            {
+                if (!Directory.Exists(Options.Directories.App))
+                {
+                    Directory.CreateDirectory(Options.Directories.App);
+                }
+
+                var probe = Path.Combine(Options.Directories.App, "probe");
+                File.WriteAllText(Path.Combine(Options.Directories.App, "probe"), string.Empty);
+                File.Delete(probe);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"App directory {Options.Directories.App} is not writeable: {ex.Message}");
+                return;
+            }
+
             if (!Options.NoLogo)
             {
                 PrintLogo(Version);

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -64,6 +64,7 @@ namespace slskd
         /// <summary>
         ///     The default XML documentation filename.
         /// </summary>
+        public static readonly string DefaultXmlDocumentationFile = Path.Combine(AppContext.BaseDirectory, "etc", $"{AppName}.xml");
 
         /// <summary>
         ///     The default incomplete download directory.

--- a/src/slskd/Properties/analysis.ruleset
+++ b/src/slskd/Properties/analysis.ruleset
@@ -32,6 +32,7 @@
   </Rules>
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
     <Rule Id="S2589" Action="None" />
+    <Rule Id="S3011" Action="None" />
     <Rule Id="S3427" Action="Info" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">

--- a/src/slskd/Properties/analysis.ruleset
+++ b/src/slskd/Properties/analysis.ruleset
@@ -18,7 +18,7 @@
     <Rule Id="CA1805" Action="None" />
     <Rule Id="CA1819" Action="None" />
     <Rule Id="CA1822" Action="None" />
-    <Rule Id="CA2007" Action="Warning" />
+    <Rule Id="CA2007" Action="None" />
     <Rule Id="CA2200" Action="Warning" />
     <Rule Id="CA2214" Action="Warning" />
     <Rule Id="CA2231" Action="Warning" />
@@ -38,6 +38,7 @@
     <Rule Id="SA1008" Action="None" />
     <Rule Id="SA1009" Action="None" />
     <Rule Id="SA1101" Action="None" />
+    <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1124" Action="None" />
     <Rule Id="SA1300" Action="None" />
     <Rule Id="SA1402" Action="None" />

--- a/src/slskd/Properties/slskd.yml
+++ b/src/slskd/Properties/slskd.yml
@@ -20,8 +20,10 @@
 #         key: ~
 #         ttl: 604800000
 #   directories:
-#     shared: ~
+#     app: ~
+#     incomplete: ~
 #     downloads: ~
+#     shared: ~
 #   logger:
 #     loki: ~
 #   feature:

--- a/src/slskd/Service.cs
+++ b/src/slskd/Service.cs
@@ -250,17 +250,18 @@ namespace slskd
 
         private void Client_TransferStateChanged(object sender, TransferStateChangedEventArgs args)
         {
-            var direction = args.Transfer.Direction.ToString().ToUpper();
-            var user = args.Transfer.Username;
-            var file = Path.GetFileName(args.Transfer.Filename);
+            var xfer = args.Transfer;
+            var direction = xfer.Direction.ToString().ToUpper();
+            var user = xfer.Username;
+            var file = Path.GetFileName(xfer.Filename);
             var oldState = args.PreviousState;
-            var state = args.Transfer.State;
+            var state = xfer.State;
 
-            var completed = args.Transfer.State.HasFlag(TransferStates.Completed);
+            var completed = xfer.State.HasFlag(TransferStates.Completed);
 
-            Console.WriteLine($"[{direction}] [{user}/{file}] {oldState} => {state}{(completed ? $" ({args.Transfer.BytesTransferred}/{args.Transfer.Size} = {args.Transfer.PercentComplete}%) @ {args.Transfer.AverageSpeed.SizeSuffix()}/s" : string.Empty)}");
+            Console.WriteLine($"[{direction}] [{user}/{file}] {oldState} => {state}{(completed ? $" ({xfer.BytesTransferred}/{xfer.Size} = {xfer.PercentComplete}%) @ {xfer.AverageSpeed.SizeSuffix()}/s" : string.Empty)}");
 
-            if (args.Transfer.State.HasFlag(TransferStates.Succeeded) && args.Transfer.Direction == TransferDirection.Upload)
+            if (xfer.Direction == TransferDirection.Upload && xfer.State.HasFlag(TransferStates.Completed | TransferStates.Succeeded))
             {
                 _ = Client.SendUploadSpeedAsync((int)args.Transfer.AverageSpeed);
             }

--- a/src/slskd/Service.cs
+++ b/src/slskd/Service.cs
@@ -127,6 +127,7 @@ namespace slskd
             await Client.ConnectAsync(Options.Soulseek.Username, Options.Soulseek.Password).ConfigureAwait(false);
 
             Logger.Information("Connected and logged in as {Username}", Options.Soulseek.Username);
+            Logger.Information("Listening on port {Port}", Options.Soulseek.ListenPort);
             Logger.Information("Client started");
         }
 

--- a/src/slskd/Startup.cs
+++ b/src/slskd/Startup.cs
@@ -145,13 +145,13 @@ namespace slskd
                             Version = "v0",
                         });
 
-                    if (File.Exists(Program.DefaultXmlDocumentaitonFile))
+                    if (File.Exists(Program.DefaultXmlDocumentationFile))
                     {
-                        options.IncludeXmlComments(Program.DefaultXmlDocumentaitonFile);
+                        options.IncludeXmlComments(Program.DefaultXmlDocumentationFile);
                     }
                     else
                     {
-                        logger.Warning($"Unable to find XML documentation in {Program.DefaultXmlDocumentaitonFile}, Swagger will not include metadata");
+                        logger.Warning($"Unable to find XML documentation in {Program.DefaultXmlDocumentationFile}, Swagger will not include metadata");
                     }
                 });
             }

--- a/src/slskd/Trackers/TransferTracker.cs
+++ b/src/slskd/Trackers/TransferTracker.cs
@@ -71,7 +71,7 @@ namespace slskd.Trackers
             directedTransfers.TryGetValue(username, out var transfers);
             return transfers ?? new ConcurrentDictionary<string, (API.DTO.Transfer Transfer, CancellationTokenSource CancellationTokenSource)>();
         }
-        
+
         /// <summary>
         ///     Maps a Transfer collection to a serializable object.
         /// </summary>


### PR DESCRIPTION
This PR stores incomplete downloads in a separate (configurable) directory from completed downloads, and moves them from the incomplete directory to the complete directory upon completion.

It didn't seem reasonable to force users to specify a directory for incomplete downloads, so I added options for both "app" and "incomplete" directories, with "app" being a general directory for application data.

The "app" directory defaults to `%localappdata%\slskd` on Windows systems and `~/.local/share/slskd` on Linux-like systems.

The "incomplete", "downloads", and "shared" directories are no longer required options, and if omitted they will default to `<app>\<incomplete|downloads|shared>`, respecting whatever the "app" directory has been configured to.  Each of these three directories can still be specified independently.

Closes #64 
