### PR TITLE
Verify filesystem at startup

### DIFF
--- a/src/slskd/Common/Validation/X509CertificateAttribute.cs
+++ b/src/slskd/Common/Validation/X509CertificateAttribute.cs
@@ -1,9 +1,29 @@
-﻿namespace slskd.Validation
+﻿// <copyright file="X509CertificateAttribute.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd.Validation
 {
     using System.ComponentModel.DataAnnotations;
     using slskd.Common.Cryptography;
     using static slskd.Options.WebOptions.HttpsOptions;
 
+    /// <summary>
+    ///     Validates X509 certificate parameters specified through <see cref="CertificateOptions"/>.
+    /// </summary>
     public class X509CertificateAttribute : ValidationAttribute
     {
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
@@ -11,8 +31,6 @@
             if (value != null)
             {
                 var cert = (CertificateOptions)value;
-
-                System.Console.WriteLine($"pass: {cert.Password} {string.IsNullOrEmpty(cert.Password)}");
 
                 if (!string.IsNullOrEmpty(cert.Pfx) && !X509.TryValidate(cert.Pfx, cert.Password, out var certResult))
                 {

--- a/src/slskd/Common/Validation/X509CertificateAttribute.cs
+++ b/src/slskd/Common/Validation/X509CertificateAttribute.cs
@@ -1,0 +1,26 @@
+﻿namespace slskd.Validation
+{
+    using System.ComponentModel.DataAnnotations;
+    using slskd.Common.Cryptography;
+    using static slskd.Options.WebOptions.HttpsOptions;
+
+    public class X509CertificateAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            if (value != null)
+            {
+                var cert = (CertificateOptions)value;
+
+                System.Console.WriteLine($"pass: {cert.Password} {string.IsNullOrEmpty(cert.Password)}");
+
+                if (!string.IsNullOrEmpty(cert.Pfx) && !X509.TryValidate(cert.Pfx, cert.Password, out var certResult))
+                {
+                    return new ValidationResult($"Invalid HTTPs certificate: {certResult}");
+                }
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -521,6 +521,7 @@ namespace slskd
                 /// <summary>
                 ///     Certificate options.
                 /// </summary>
+                [X509Certificate]
                 public class CertificateOptions
                 {
                     /// <summary>

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -1,4 +1,4 @@
-// <copyright file="Program.cs" company="slskd Team">
+﻿// <copyright file="Program.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -252,59 +252,27 @@ namespace slskd
                 PrintLogo(Version);
             }
 
-            if (Options.Debug)
-            {
-                Console.WriteLine("Configuration:");
-                Console.WriteLine(Configuration.GetDebugView());
-
-                Log.Logger = new LoggerConfiguration()
-                    .MinimumLevel.Debug()
-                    .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-                    .MinimumLevel.Override("slskd.API.Authentication.PassthroughAuthenticationHandler", LogEventLevel.Information)
-                    .Enrich.WithProperty("Version", Version)
-                    .Enrich.WithProperty("InstanceName", Options.InstanceName)
-                    .Enrich.WithProperty("InvocationId", InvocationId)
-                    .Enrich.WithProperty("ProcessId", ProcessId)
-                    .Enrich.FromLogContext()
-                    .WriteTo.Console(
-                        outputTemplate: "[{SourceContext}] [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
-                    .WriteTo.Async(config =>
-                        config.File(
-                            Path.Combine(AppContext.BaseDirectory, "logs", $"{AppName}-.log"),
-                            outputTemplate: "[{SourceContext}] [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
-                            rollingInterval: RollingInterval.Day))
-                    .WriteTo.Conditional(
-                        e => !string.IsNullOrEmpty(Options.Logger.Loki),
-                        config => config.GrafanaLoki(
-                            Options.Logger.Loki ?? string.Empty,
-                            outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"))
-                    .CreateLogger();
-            }
-            else
-            {
-                Log.Logger = new LoggerConfiguration()
-                    .MinimumLevel.Information()
-                    .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-                    .MinimumLevel.Override("slskd.API.Authentication.PassthroughAuthenticationHandler", LogEventLevel.Information)
-                    .Enrich.WithProperty("Version", Version)
-                    .Enrich.WithProperty("InstanceName", Options.InstanceName)
-                    .Enrich.WithProperty("InvocationId", InvocationId)
-                    .Enrich.WithProperty("ProcessId", ProcessId)
-                    .Enrich.FromLogContext()
-                    .WriteTo.Console(
-                        outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
-                    .WriteTo.Async(config =>
-                        config.File(
-                            Path.Combine(AppContext.BaseDirectory, "logs", $"{AppName}-.log"),
-                            outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
-                            rollingInterval: RollingInterval.Day))
-                    .WriteTo.Conditional(
-                        e => !string.IsNullOrEmpty(Options.Logger.Loki),
-                        config => config.GrafanaLoki(
-                            Options.Logger.Loki ?? string.Empty,
-                            outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"))
-                    .CreateLogger();
-            }
+            Log.Logger = (Options.Debug ? new LoggerConfiguration().MinimumLevel.Debug() : new LoggerConfiguration().MinimumLevel.Information())
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+                .MinimumLevel.Override("slskd.API.Authentication.PassthroughAuthenticationHandler", LogEventLevel.Information)
+                .Enrich.WithProperty("Version", Version)
+                .Enrich.WithProperty("InstanceName", Options.InstanceName)
+                .Enrich.WithProperty("InvocationId", InvocationId)
+                .Enrich.WithProperty("ProcessId", ProcessId)
+                .Enrich.FromLogContext()
+                .WriteTo.Console(
+                    outputTemplate: (Options.Debug ? "[{SourceContext}] [{SoulseekContext}] " : string.Empty) + "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+                .WriteTo.Async(config =>
+                    config.File(
+                        Path.Combine(AppContext.BaseDirectory, "logs", $"{AppName}-.log"),
+                        outputTemplate: (Options.Debug ? "[{SourceContext}] " : string.Empty) + "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
+                        rollingInterval: RollingInterval.Day))
+                .WriteTo.Conditional(
+                    e => !string.IsNullOrEmpty(Options.Logger.Loki),
+                    config => config.GrafanaLoki(
+                        Options.Logger.Loki ?? string.Empty,
+                        outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"))
+                .CreateLogger();
 
             var logger = Log.ForContext(typeof(Program));
 

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -207,6 +207,12 @@ namespace slskd
                     Console.WriteLine($"Invalid HTTPs certificate: {certResult}");
                     return;
                 }
+
+                if (Options.Debug)
+                {
+                    Console.WriteLine("Configuration:");
+                    Console.WriteLine(Configuration.GetDebugView());
+                }
             }
             catch (Exception ex)
             {

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -224,11 +224,6 @@ namespace slskd
                 return;
             }
 
-            if (!Options.NoLogo)
-            {
-                PrintLogo(Version);
-            }
-
             Log.Logger = (Options.Debug ? new LoggerConfiguration().MinimumLevel.Debug() : new LoggerConfiguration().MinimumLevel.Information())
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
                 .MinimumLevel.Override("slskd.API.Authentication.PassthroughAuthenticationHandler", LogEventLevel.Information)
@@ -252,6 +247,11 @@ namespace slskd
                 .CreateLogger();
 
             var logger = Log.ForContext(typeof(Program));
+
+            if (!Options.NoLogo)
+            {
+                PrintLogo(Version);
+            }
 
             if (ConfigurationFile != DefaultConfigurationFile && !File.Exists(ConfigurationFile))
             {
@@ -455,11 +455,24 @@ namespace slskd
 
             var centeredVersion = new string(' ', paddingLeft) + version + new string(' ', paddingRight);
 
-            var banner = @$"
+            var logos = new[]
+            {
+                $@"
                 ▄▄▄▄               ▄▄▄▄          ▄▄▄▄
      ▄▄▄▄▄▄▄    █  █    ▄▄▄▄▄▄▄    █  █▄▄▄    ▄▄▄█  █
      █__ --█    █  █    █__ --█    █    ◄█    █  -  █
-     █▄▄▄▄▄█    █▄▄█    █▄▄▄▄▄█    █▄▄█▄▄█    █▄▄▄▄▄█
+     █▄▄▄▄▄█    █▄▄█    █▄▄▄▄▄█    █▄▄█▄▄█    █▄▄▄▄▄█",
+                @$"
+                     ▄▄▄▄     ▄▄▄▄     ▄▄▄▄
+               ▄▄▄▄▄▄█  █▄▄▄▄▄█  █▄▄▄▄▄█  █
+               █__ --█  █__ --█    ◄█  -  █
+               █▄▄▄▄▄█▄▄█▄▄▄▄▄█▄▄█▄▄█▄▄▄▄▄█",
+            };
+
+            var logo = logos[new Random().Next(0, logos.Length)];
+
+            var banner = @$"
+{logo}
 ╒════════════════════════════════════════════════════════╕
 │           GNU AFFERO GENERAL PUBLIC LICENSE            │
 │                   https://slskd.org                    │

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -232,15 +232,11 @@ namespace slskd
             catch (Exception ex)
             {
                 Console.WriteLine($"App directory {Options.Directories.App} does not exist, and could not be created: {ex.Message}");
+                return;
             }
 
             try
             {
-                if (!Directory.Exists(Options.Directories.App))
-                {
-                    Directory.CreateDirectory(Options.Directories.App);
-                }
-
                 var probe = Path.Combine(Options.Directories.App, "probe");
                 File.WriteAllText(Path.Combine(Options.Directories.App, "probe"), string.Empty);
                 File.Delete(probe);

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Program.cs" company="slskd Team">
+// <copyright file="Program.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -55,7 +55,7 @@ namespace slskd
         /// <summary>
         ///     The default application data directory.
         /// </summary>
-        public static readonly string DefaultAppDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), AppName);
+        public static readonly string DefaultAppDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify), AppName);
 
         /// <summary>
         ///     The default configuration filename.


### PR DESCRIPTION
Ensures that the app, incomplete, downloads and shared directories exist, and if not, attempts to create them.  Ensures that the app, incomplete, and downloads directories are writeable.

Helps prevent regressions like #73 

Also includes some minor refactoring to make the bootstrap logic more readable.