### PR TITLE
Don't invalidate missing directories if they are within the default path

### DIFF
--- a/src/slskd/Common/Validation/DirectoryExistsAttributes.cs
+++ b/src/slskd/Common/Validation/DirectoryExistsAttributes.cs
@@ -31,7 +31,7 @@ namespace slskd.Validation
             {
                 var dir = Path.GetFullPath(value?.ToString());
 
-                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                if (!dir.StartsWith(Program.DefaultAppDirectory) && !string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
                 {
                     return new ValidationResult($"The {validationContext.DisplayName} field specifies a non-existent directory '{dir}'.");
                 }


### PR DESCRIPTION
This was causing a failure to start when the default directories were not yet present.  This PR bypasses the validation for any directories that fall within the default app directory, as it is presumed that the app can read/write to this directory.