### PR TITLE
Add search result filter

### DIFF
--- a/src/web/src/components/Search/Search.css
+++ b/src/web/src/components/Search/Search.css
@@ -59,3 +59,8 @@
 .search-loader {
   margin-top: 50px !important;
 }
+
+.search-filter {
+  width: 100%;
+  margin-top: 1rem;
+}

--- a/src/web/src/components/Search/Search.js
+++ b/src/web/src/components/Search/Search.js
@@ -32,6 +32,7 @@ const initialState = {
     hiddenResults: [],
     hideLocked: true,
     fetching: false,
+    resultFilters: undefined
 };
 
 const sortOptions = {
@@ -151,8 +152,10 @@ class Search extends Component {
     }
 
     sortAndFilterResults = () => {
-        const { results = [], hideNoFreeSlots, resultSort, hideLocked, hiddenResults = [] } = this.state;
+        const { results = [], hideNoFreeSlots, resultSort, resultFilters = '', hideLocked, hiddenResults = [] } = this.state;
         const { field, order } = sortOptions[resultSort];
+
+        const filters = search.parseFiltersFromString(resultFilters);
 
         return results
             .filter(r => !hiddenResults.includes(r.username))
@@ -162,6 +165,7 @@ class Search extends Component {
                 }
                 return r;
             })
+            .map(response => search.filterResponse({ response, filters }))
             .filter(r => r.fileCount + r.lockedFileCount > 0)
             .filter(r => !(hideNoFreeSlots && r.freeUploadSlots === 0))
             .sort((a, b) => {
@@ -220,34 +224,40 @@ class Search extends Component {
                     </Loader>
                 :
                     <div>
-                        {(results && results.length > 0) ? <Segment className='search-options' raised>
-                            <Dropdown
-                                button
-                                className='search-options-sort icon'
-                                floating
-                                labeled
-                                icon='sort'
-                                options={sortDropdownOptions}
-                                onChange={(e, { value }) => this.setState({ resultSort: value }, () => this.saveState())}
-                                text={sortDropdownOptions.find(o => o.value === resultSort).text}
-                            />
-                            <div className='search-option-toggles'>
-                                <Checkbox
-                                    className='search-options-hide-locked'
-                                    toggle
-                                    onChange={() => this.setState({ hideLocked: !hideLocked }, () => this.saveState())}
-                                    checked={hideLocked}
-                                    label='Hide Locked Results'
+                        {(results && results.length > 0) ? 
+                            <Segment className='search-options' raised>
+                                <Dropdown
+                                    button
+                                    className='search-options-sort icon'
+                                    floating
+                                    labeled
+                                    icon='sort'
+                                    options={sortDropdownOptions}
+                                    onChange={(e, { value }) => this.setState({ resultSort: value }, () => this.saveState())}
+                                    text={sortDropdownOptions.find(o => o.value === resultSort).text}
                                 />
-                                <Checkbox
-                                    className='search-options-hide-no-slots'
-                                    toggle
-                                    onChange={() => this.setState({ hideNoFreeSlots: !hideNoFreeSlots }, () => this.saveState())}
-                                    checked={hideNoFreeSlots}
-                                    label='Hide Results with No Free Slots'
+                                <div className='search-option-toggles'>
+                                    <Checkbox
+                                        className='search-options-hide-locked'
+                                        toggle
+                                        onChange={() => this.setState({ hideLocked: !hideLocked }, () => this.saveState())}
+                                        checked={hideLocked}
+                                        label='Hide Locked Results'
+                                    />
+                                    <Checkbox
+                                        className='search-options-hide-no-slots'
+                                        toggle
+                                        onChange={() => this.setState({ hideNoFreeSlots: !hideNoFreeSlots }, () => this.saveState())}
+                                        checked={hideNoFreeSlots}
+                                        label='Hide Results with No Free Slots'
+                                    />
+                                </div>
+                                <Input 
+                                    label='Filters' 
+                                    className='search-filter'
                                 />
-                            </div>
-                        </Segment> : <PlaceholderSegment icon='search'/>}
+                            </Segment> : <PlaceholderSegment icon='search'/>
+                        }
                         {sortedAndFilteredResults.slice(0, displayCount).map((r, i) =>
                             <Response
                                 key={i}

--- a/src/web/src/components/Search/Search.js
+++ b/src/web/src/components/Search/Search.js
@@ -32,7 +32,7 @@ const initialState = {
     hiddenResults: [],
     hideLocked: true,
     fetching: false,
-    resultFilters: undefined
+    resultFilters: ''
 };
 
 const sortOptions = {
@@ -70,6 +70,10 @@ class Search extends Component {
 
     onSearchPhraseChange = (event, data) => {
         this.setState({ searchPhrase: data.value });
+    }
+
+    onResultFilterChange = (event, data) => {
+        this.setState({ resultFilters: data.value }, () => this.saveState());
     }
 
     saveState = () => {
@@ -188,7 +192,7 @@ class Search extends Component {
     }
 
     render = () => {
-        let { searchState, searchStatus, results = [], displayCount, resultSort, hideNoFreeSlots, hideLocked, hiddenResults = [], fetching } = this.state;
+        let { searchState, searchStatus, results = [], displayCount, resultSort, hideNoFreeSlots, hideLocked, hiddenResults = [], fetching, resultFilters } = this.state;
         let pending = fetching || searchState === 'pending';
 
         const sortedAndFilteredResults = this.sortAndFilterResults();
@@ -255,6 +259,9 @@ class Search extends Component {
                                 <Input 
                                     label='Filters' 
                                     className='search-filter'
+                                    value={resultFilters}
+                                    onChange={this.onResultFilterChange}
+                                    action={!!resultFilters && { icon: 'x', color: 'red', onClick: () => this.setState({ resultFilters: '' }) }}
                                 />
                             </Segment> : <PlaceholderSegment icon='search'/>
                         }

--- a/src/web/src/components/Search/Search.js
+++ b/src/web/src/components/Search/Search.js
@@ -76,6 +76,10 @@ class Search extends Component {
         this.setState({ resultFilters: data.value }, () => this.saveState());
     }
 
+    clearResultFilter = () => {
+        this.setState({ resultFilters: '' }, () => this.saveState());
+    }
+
     saveState = () => {
         try {
             localStorage.setItem('soulseek-example-search-state', JSON.stringify({ ...this.state, results: [] }));
@@ -262,7 +266,7 @@ class Search extends Component {
                                     label={{ icon: 'filter', content: 'Filter' }}
                                     value={resultFilters}
                                     onChange={this.onResultFilterChange}
-                                    action={!!resultFilters && { icon: 'x', color: 'red', onClick: () => this.setState({ resultFilters: '' }) }}
+                                    action={!!resultFilters && { icon: 'x', color: 'red', onClick: this.clearResultFilter }}
                                 />
                             </Segment> : <PlaceholderSegment icon='search'/>
                         }

--- a/src/web/src/components/Search/Search.js
+++ b/src/web/src/components/Search/Search.js
@@ -257,8 +257,9 @@ class Search extends Component {
                                     />
                                 </div>
                                 <Input 
-                                    label='Filters' 
                                     className='search-filter'
+                                    placeholder='lackluster container -bothersome iscbr|isvbr minbitrate:320 minfilesize:10 minfilesinfolder:8 minlength:5000'
+                                    label={{ icon: 'filter', content: 'Filter' }}
                                     value={resultFilters}
                                     onChange={this.onResultFilterChange}
                                     action={!!resultFilters && { icon: 'x', color: 'red', onClick: () => this.setState({ resultFilters: '' }) }}

--- a/src/web/src/components/Users/Users.js
+++ b/src/web/src/components/Users/Users.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import {
   Item,
   Segment,
+  Loader,
   Input
 } from 'semantic-ui-react';
 
@@ -10,6 +11,7 @@ import { activeUserInfoKey } from '../../config';
 import * as peers from '../../lib/peers';
 
 import './Users.css';
+import PlaceholderSegment from '../Shared/PlaceholderSegment';
 
 const Users = (props) => {
   const inputRef = useRef();
@@ -93,11 +95,20 @@ const Users = (props) => {
           onKeyUp={(e) => e.key === 'Enter' ? setSelectedUsername(usernameInput) : ''}
         />
       </Segment>
-      {!fetching && !error && !!user && <Segment className='users-user' raised>
-        <Item.Group>
-          <User {...user}/>
-        </Item.Group>
-      </Segment>}
+      {fetching ? 
+        <Loader className='search-loader' active inline='centered' size='big'/> :
+        <div>
+          {error ? 
+            <span>Failed to retrieve information for {selectedUsername}</span> : 
+            !user ? 
+              <PlaceholderSegment icon='users'/> :
+              <Segment className='users-user' raised>
+                <Item.Group>
+                  <User {...user}/>
+                </Item.Group>
+              </Segment>}
+        </div>
+      }
     </div>
   );
 };

--- a/src/web/src/lib/search.js
+++ b/src/web/src/lib/search.js
@@ -107,7 +107,7 @@ export const filterResponse = ({
     if (length < minLength) return false;
 
     if (include.length > 0 && include.filter(term => filename.toLowerCase().includes(term)).length === 0) return false;
-    if (exclude.length > 0 && exclude.filter(term => !filename.toLowerCase().includes(term)).length === 0) return false;
+    if (exclude.length > 0 && exclude.filter(term => filename.toLowerCase().includes(term)).length !== 0) return false;
 
     return true;
   });

--- a/src/web/src/lib/search.js
+++ b/src/web/src/lib/search.js
@@ -1,5 +1,8 @@
 import api from './api';
 
+export const CBR = 'CBR';
+export const VBR = 'VBR';
+
 export const search = ({ id, searchText }) => {
   return api.post(`/searches`, { id, searchText });
 };
@@ -10,4 +13,111 @@ export const getStatus = async ({ id, includeResponses = false }) => {
 
 export const getResponses = async ({ id }) => {
   return (await api.get(`/searches/${encodeURIComponent(id)}/responses`)).data;
+};
+
+export const isConstantBitRate = (bitRate) => {
+  // because the caller most likely already O^2 this uses an ugly but fast approach
+  // https://en.wikipedia.org/wiki/MP3#Bit_rate
+  switch (bitRate) {
+    case 8:
+    case 16:
+    case 24:
+    case 32:
+    case 40:
+    case 48:
+    case 56:
+    case 64:
+    case 80:
+    case 96:
+    case 112:
+    case 128:
+    case 144:
+    case 160:
+    case 192:
+    case 224:
+    case 256:
+    case 320:
+      return true;
+    default:
+      return false;
+  }
+}
+
+export const parseFiltersFromString = (string) => {
+  const filters = {
+    minBitRate: 0,
+    minFileSize: 0,
+    minLength: 0,
+    minFilesInFolder: 0,
+    include: [],
+    exclude: [],
+    isVBR: false,
+    isCBR: false
+  };
+
+  filters.minBitRate = getNthMatch(string, /(minbr|minbitrate):([0-9]+)/i, 2) || filters.minBitRate;
+  filters.minFileSize = getNthMatch(string, /(minfs|minfilesize):([0-9]+)/i, 2) || filters.minFileSize;
+  filters.minLength = getNthMatch(string, /(minlen|minlength):([0-9]+)/i, 2) || filters.minLength;
+  filters.minFilesInFolder = getNthMatch(string, /(minfif|minfilesinfolder):([0-9]+)/i, 2) || filters.minFilesInFolder;
+  
+  filters.isVBR = !!string.match(/isvbr/i);
+  filters.isCBR = !!string.match(/iscbr/i);
+
+  const isReservedWord = (word) => word.includes(':') || word === 'isvbr' || word === 'iscbr';
+
+  let terms = string.toLowerCase().split(' ').filter(term => !isReservedWord(term));
+
+  filters.include = terms.filter(term => !term.startsWith('-'));
+  filters.exclude = terms.filter(term => term.startsWith('-')).map(term => term.slice(1));
+
+  return filters;
+};
+
+const getNthMatch = (string, regex, n) => {
+  const match = string.match(regex);
+
+  if (match) {
+    return parseInt(match[n], 10);
+  }
+}
+
+export const filterResponse = ({ 
+  filters = {
+    minBitRate: 0,
+    minFileSize: 0,
+    minLength: 0,
+    include: [],
+    exclude: [],
+    isVBR: false,
+    isCBR: false
+  },
+  response = { 
+    files: [] 
+  } 
+}) => {
+  let { files = [] } = response;
+
+  if (response.fileCount + response.lockedFileCount < filters.minFilesInFolder) {
+    return { ...response, files: [] }
+  }
+
+  console.log(filters);
+
+  files = files.filter(file => {
+    const { bitRate, size, length, filename } = file;
+    const { isCBR, isVBR, minBitRate, minFileSize, minLength, include = [], exclude = [] } = filters;
+  
+    if (isCBR && !isConstantBitRate(bitRate)) return false;    
+    if (isVBR && isConstantBitRate(bitRate)) return false;
+    if (bitRate < minBitRate) return false;
+    if (size < minFileSize) return false;
+    if (length < minLength) return false;
+
+    if (include.length > 0 && include.filter(term => filename.toLowerCase().includes(term)).length === 0) return false;
+    if (exclude.length > 0 && exclude.filter(term => !filename.toLowerCase().includes(term)).length === 0) return false;
+
+    return true;
+  });
+
+  return { ...response, files };
 };

--- a/src/web/src/lib/search.js
+++ b/src/web/src/lib/search.js
@@ -92,18 +92,17 @@ export const filterResponse = ({
     isCBR: false
   },
   response = { 
-    files: [] 
+    files: [],
+    lockedFiles: []
   } 
 }) => {
-  let { files = [] } = response;
+  let { files = [], lockedFiles = [] } = response;
 
   if (response.fileCount + response.lockedFileCount < filters.minFilesInFolder) {
     return { ...response, files: [] }
   }
 
-  console.log(filters);
-
-  files = files.filter(file => {
+  const filterFiles = (files) => files.filter(file => {
     const { bitRate, size, length, filename } = file;
     const { isCBR, isVBR, minBitRate, minFileSize, minLength, include = [], exclude = [] } = filters;
   
@@ -119,5 +118,13 @@ export const filterResponse = ({
     return true;
   });
 
-  return { ...response, files };
+  const filteredFiles = filterFiles(files);
+  const filteredLockedFiles = filterFiles(lockedFiles);
+
+  return { 
+    ...response,
+    fileCount: filteredFiles.length,
+    lockedFileCount: filteredLockedFiles.length,
+    files: filteredFiles, 
+    lockedFiles: filteredLockedFiles };
 };

--- a/src/web/src/lib/search.test.js
+++ b/src/web/src/lib/search.test.js
@@ -72,6 +72,8 @@ describe('filterResponse', () => {
       files: []
     });
   });
+
+  // todo: more tests
 });
 
 describe('parseFiltersFromString', () => {

--- a/src/web/src/lib/search.test.js
+++ b/src/web/src/lib/search.test.js
@@ -1,0 +1,156 @@
+import * as search from './search';
+
+describe('isConstantBitRate', () => {
+  it('returns true given a valid MPEG-3 bitrate', () => {
+    const bitrates = [8,16,24,32,40,48,56,64,80,96,112,128,144,160,192,224,256,320];
+
+    bitrates.forEach(br => {
+      expect(search.isConstantBitRate(br)).toBe(true);
+    });
+  });
+
+  it('returns false given an invalid MPEG-3 bitrate', () => {
+    const bitrates = [5,7,65,150,321];
+
+    bitrates.forEach(br => {
+      expect(search.isConstantBitRate(br)).toBe(false);
+    });
+  });
+
+  it('returns false given null or undefined', () => {
+    expect(search.isConstantBitRate(null)).toBe(false);
+    expect(search.isConstantBitRate()).toBe(false);
+  });
+});
+
+describe('filterResponse', () => {
+  it('removes VBR files if "iscbr" is specified', () => {
+    const response = {
+      files: [
+        { bitRate: 123 },
+        { bitRate: 320 }
+      ]
+    };
+
+    const filters = { isCBR: true };
+
+    expect(search.filterResponse({ response, filters })).toStrictEqual({
+      files: [
+        { bitRate: 320 }
+      ]
+    });
+  });
+
+  it('removes CBR files if "isvbr" is specified', () => {
+    const response = {
+      files: [
+        { bitRate: 123 },
+        { bitRate: 320 }
+      ]
+    };
+
+    const filters = { isVBR: true };
+
+    expect(search.filterResponse({ response, filters })).toStrictEqual({
+      files: [
+        { bitRate: 123 }
+      ]
+    });
+  });
+
+  it('removes all files if "iscbr" and "isvbr" are both specified', () => {
+    const response = {
+      files: [
+        { bitRate: 123 },
+        { bitRate: 320 }
+      ]
+    };
+
+    const filters = { isCBR: true, isVBR: true };
+
+    expect(search.filterResponse({ response, filters })).toStrictEqual({
+      files: []
+    });
+  });
+});
+
+describe('parseFiltersFromString', () => {
+  it('returns correct minBitrate', () => {
+    expect(search.parseFiltersFromString('foo minbr:42 bar')).toMatchObject({
+      minBitRate: 42
+    });
+
+    expect(search.parseFiltersFromString('foo minbitrate:123 bar')).toMatchObject({
+      minBitRate: 123
+    });
+  });
+
+  it('returns correct minFileSize', () => {
+    expect(search.parseFiltersFromString('foo minfs:42 bar')).toMatchObject({
+      minFileSize: 42
+    });
+
+    expect(search.parseFiltersFromString('foo minfilesize:123 bar')).toMatchObject({
+      minFileSize: 123
+    });
+  });
+
+  it('returns correct minLength', () => {
+    expect(search.parseFiltersFromString('foo minlen:42 bar')).toMatchObject({
+      minLength: 42
+    });
+
+    expect(search.parseFiltersFromString('foo minlength:123 bar')).toMatchObject({
+      minLength: 123
+    });
+  });
+
+  it('returns correct minFilesInFolder', () => {
+    expect(search.parseFiltersFromString('foo minfif:42 bar')).toMatchObject({
+      minFilesInFolder: 42
+    });
+
+    expect(search.parseFiltersFromString('foo minfilesinfolder:123 bar')).toMatchObject({
+      minFilesInFolder: 123
+    });
+  });
+
+  it('returns correct list of terms', () => {
+    expect(search.parseFiltersFromString('foo minbr:42 bar')).toMatchObject({
+      include: [ 'foo', 'bar']
+    });
+
+    expect(search.parseFiltersFromString('foo iscbr isvbr bar')).toMatchObject({
+      include: [ 'foo', 'bar']
+    });
+
+    expect(search.parseFiltersFromString('foo some:thing bar')).toMatchObject({
+      include: [ 'foo', 'bar']
+    });
+
+    expect(search.parseFiltersFromString('foo -bar')).toMatchObject({
+      include: [ 'foo' ],
+      exclude: [ 'bar' ]
+    });
+  });
+
+  it('returns isVBR and isCBR if terms are present', () => {
+    expect(search.parseFiltersFromString('isvbr')).toMatchObject({
+      isVBR: true
+    });
+
+    expect(search.parseFiltersFromString('iscbr')).toMatchObject({
+      isCBR: true
+    });
+  });
+
+  it('returns expected filters given a bit of everything', () => {
+    expect(search.parseFiltersFromString('big -mix of:everything isvbr iscbr minbr:42')).toMatchObject({
+      include: [ 'big' ],
+      exclude: [ 'mix' ],
+      isVBR: true,
+      isCBR: true,
+      minBitRate: 42
+    });
+  });
+});

--- a/src/web/src/lib/search.test.js
+++ b/src/web/src/lib/search.test.js
@@ -34,7 +34,7 @@ describe('filterResponse', () => {
 
     const filters = { isCBR: true };
 
-    expect(search.filterResponse({ response, filters })).toStrictEqual({
+    expect(search.filterResponse({ response, filters })).toMatchObject({
       files: [
         { bitRate: 320 }
       ]
@@ -51,7 +51,7 @@ describe('filterResponse', () => {
 
     const filters = { isVBR: true };
 
-    expect(search.filterResponse({ response, filters })).toStrictEqual({
+    expect(search.filterResponse({ response, filters })).toMatchObject({
       files: [
         { bitRate: 123 }
       ]
@@ -68,12 +68,95 @@ describe('filterResponse', () => {
 
     const filters = { isCBR: true, isVBR: true };
 
-    expect(search.filterResponse({ response, filters })).toStrictEqual({
+    expect(search.filterResponse({ response, filters })).toMatchObject({
       files: []
     });
   });
 
-  // todo: more tests
+  it('removes files with bitRate less than minBitRate', () => {
+    const response = {
+      files: [
+        { bitRate: 100 },
+        { bitRate: 99 }
+      ]
+    };
+
+    const filters = { minBitRate: 100 };
+
+    expect(search.filterResponse({ response, filters })).toMatchObject({
+      files: [
+        { bitRate: 100 }
+      ]
+    });
+  });
+
+  it('removes files with size less than minFileSize', () => {
+    const response = {
+      files: [
+        { size: 100 },
+        { size: 99 }
+      ]
+    };
+
+    const filters = { minFileSize: 100 };
+
+    expect(search.filterResponse({ response, filters })).toMatchObject({
+      files: [
+        { size: 100 }
+      ]
+    });
+  });
+
+  it('removes files with length less than minLength', () => {
+    const response = {
+      files: [
+        { length: 100 },
+        { length: 99 }
+      ]
+    };
+
+    const filters = { minLength: 100 };
+
+    expect(search.filterResponse({ response, filters })).toMatchObject({
+      files: [
+        { length: 100 }
+      ]
+    });
+  });
+
+  it('removes files with filenames not containing included phrases', () => {
+    const response = {
+      files: [
+        { filename: '/path/to/foo.mp3' },
+        { filename: '/path/to/bar.mp3' }
+      ]
+    };
+
+    const filters = { include: ['foo'] };
+
+    expect(search.filterResponse({ response, filters })).toMatchObject({
+      files: [
+        { filename: '/path/to/foo.mp3' }
+      ]
+    });
+  });
+  
+  it('removes files with filenames containing excluded phrases', () => {
+    const response = {
+      files: [
+        { filename: '/path/to/foo.mp3' },
+        { filename: '/path/to/bar.mp3' }
+      ]
+    };
+
+    const filters = { exclude: ['foo'] };
+
+    expect(search.filterResponse({ response, filters })).toMatchObject({
+      files: [
+        { filename: '/path/to/bar.mp3' }
+      ]
+    });
+  });
 });
 
 describe('parseFiltersFromString', () => {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/17145758/121113991-987b1a80-c7d8-11eb-83de-257f89b4e377.png)

Adds an input box beneath the existing filtering and sorting options for search results.  The filters match the functionality of the official client.


Closes #85 