### PR TITLE
Make Dockerfile more friendly to non-root users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,22 +55,20 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /slskd
 COPY --from=publish /slskd/dist/${TARGETPLATFORM} .
 
-RUN mkdir -p /var/slskd/{incomplete,downloads,shared} \ 
-  && chmod 666 /var/slskd \
-  && chmod 666 /var/slskd/{incomplete,downloads,shared}
+RUN bash -c 'mkdir -p /var/slskd/{incomplete,downloads,shared} \ 
+  && chmod 777 /var/slskd \
+  && chmod 777 /var/slskd/{incomplete,downloads,shared}'
 
-ENV DOTNET_BUNDLE_EXTRACT_BASE_DIR=/var/tmp/.net
-
-ENV SLSKD_HTTP_PORT=5000
-ENV SLSKD_APP_DIR=/var/slskd
-ENV SLSKD_INCOMPLETE_DIR=/var/slskd/incomplete
-ENV SLSKD_DOWNLOADS_DIR=/var/slskd/downloads
-ENV SLSKD_SHARED_DIR=/var/slskd/shared
-
-ENV SLSKD_DOCKER_TAG=$TAG
-ENV SLSKD_DOCKER_VERSION=$VERSION
-ENV SLSKD_DOCKER_REVISON=$REVISION
-ENV SLSKD_DOCKER_BUILD_DATE=$BUILD_DATE
+ENV DOTNET_BUNDLE_EXTRACT_BASE_DIR=/var/tmp/.net \
+    SLSKD_HTTP_PORT=5000 \
+    SLSKD_APP_DIR=/var/slskd \
+    SLSKD_INCOMPLETE_DIR=/var/slskd/incomplete \
+    SLSKD_DOWNLOADS_DIR=/var/slskd/downloads \
+    SLSKD_SHARED_DIR=/var/slskd/shared \
+    SLSKD_DOCKER_TAG=$TAG \
+    SLSKD_DOCKER_VERSION=$VERSION \
+    SLSKD_DOCKER_REVISON=$REVISION \
+    SLSKD_DOCKER_BUILD_DATE=$BUILD_DATE
 
 HEALTHCHECK --interval=60s --timeout=3s --start-period=5s --retries=3 CMD wget -q -O - http://localhost:5000/health
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,7 @@ WORKDIR /slskd
 COPY --from=publish /slskd/dist/${TARGETPLATFORM} .
 
 RUN bash -c 'mkdir -p /var/slskd/{incomplete,downloads,shared} \ 
-  && chmod 777 /var/slskd \
-  && chmod 777 /var/slskd/{incomplete,downloads,shared}'
+  && chmod -R 777 /var/slskd'
 
 ENV DOTNET_BUNDLE_EXTRACT_BASE_DIR=/var/tmp/.net \
     SLSKD_HTTP_PORT=5000 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,11 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /slskd
 COPY --from=publish /slskd/dist/${TARGETPLATFORM} .
 
-RUN mkdir -p /var/slskd/{incomplete,downloads,shared}
+RUN mkdir -p /var/slskd/{incomplete,downloads,shared} \ 
+  && chmod 666 /var/slskd \
+  && chmod 666 /var/slskd/{incomplete,downloads,shared}
+
+ENV DOTNET_BUNDLE_EXTRACT_BASE_DIR=/var/tmp/.net
 
 ENV SLSKD_HTTP_PORT=5000
 ENV SLSKD_APP_DIR=/var/slskd


### PR DESCRIPTION
This PR sets the environment variable `DOTNET_BUNDLE_EXTRACT_BASE_DIR` to `/var/tmp/.net`, which matches the behavior prior to .NET 5, and works around the issue of `$HOME`-less users.

Through testing I discovered a previous change to make the creation of internal directories less verbose wasn't working (because it relied on `bash` expansion, and I wasn't using bash), so that's fixed, and I added a command to `chmod 777` the internal directories so that users other than root can r/w/x them.

I tested with:

```
docker run -it \
  -u $(id -u):$(id -g) \
  -p 5000:5000 \
  -p 5001:5001 \
  -v ~/Downloads:/var/slskd/downloads \
  -v ~/Shared:/var/slskd/shared \
  -e "SLSKD_SLSK_USERNAME=<redacted>" \
  -e "SLSKD_SLSK_PASSWORD=<redacted>" \
  --name slskd \
  slskd/slskd:latest
```

And confirmed that downloaded files were owned by the user that executed the command.

Closes #110 
Closes #49 