### PR TITLE
📝 Updated Quick Start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ docker run -d \
   -p 5000:5000 \
   -p 5001:5001 \
   -v <path/to/downloads>:/var/slskd/downloads \
+  -v <path/to/incoming>:/var/slskd/incoming \
   -v <path/to/shared>:/var/slskd/shared \
   -e "SLSKD_SLSK_USERNAME=<Soulseek username>" \
   -e "SLSKD_SLSK_PASSWORD=<Soulseek password>" \
@@ -16,7 +17,7 @@ docker run -d \
   slskd/slskd:latest
 ```
 
-This command starts a container instance of slskd on ports 5000 (http) and 5001 (https), maps shared and downloads directories to the paths you choose, and logs in to Soulseek using the credentials provided.
+This command starts a container instance of slskd on ports 5000 (http) and 5001 (https), maps shared, downloads and incoming directories to the paths you choose, and logs in to Soulseek using the credentials provided.
 
 The default credentials for the web UI are slskd/slskd.
 


### PR DESCRIPTION
Hi, I noticed that passing incoming directory is required by configuration:

```
$ docker run -d \
  -p 5000:5000 \
  -p 5001:5001 \
  -v <redacted>:/var/slskd/downloads \
  -v <redacted>:/var/slskd/shared \
  -e "SLSKD_SLSK_USERNAME=<redacted>" \
  -e "SLSKD_SLSK_PASSWORD=<redacted>" \
  --name slskd \
  slskd/slskd:latest

$ docker logs slskd
Invalid configuration:
  Directories:
    The Incomplete field specifies a non-existent directory '/var/slskd/incomplete'.
```
