### PR TITLE
Add 'no-start' option

### DIFF
--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -86,6 +86,14 @@ namespace slskd
         public bool NoLogo { get; private set; } = false;
 
         /// <summary>
+        ///     Gets a value indicating whether the application should quit after initialization.
+        /// </summary>
+        [Argument('x', "no-start")]
+        [EnvironmentVariable("NO_START")]
+        [Description("quit the application after initialization")]
+        public bool NoStart { get; private set; } = false;
+
+        /// <summary>
         ///     Gets the unique name for this instance.
         /// </summary>
         [Argument('i', "instance-name")]

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -276,7 +276,7 @@ namespace slskd
                     using var runtimeMetrics = DotNetRuntimeStatsBuilder.Default().StartCollecting();
                 }
 
-                WebHost.CreateDefaultBuilder(args)
+                var webHost = WebHost.CreateDefaultBuilder(args)
                     .SuppressStatusMessages(true)
                     .ConfigureAppConfiguration((hostingContext, builder) =>
                     {
@@ -308,8 +308,15 @@ namespace slskd
                         });
                     })
                     .UseStartup<Startup>()
-                    .Build()
-                    .Run();
+                    .Build();
+
+                if (Options.NoStart)
+                {
+                    logger.Information("Qutting because 'no-start' option is enabled");
+                    return;
+                }
+
+                webHost.Run();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Sometimes I want to run the application to test out initialization code.  Currently I have to kill the app manually, and usually after it has connected to the server and begun the process of finding a distributed parent.

This PR adds command-line and environment variable options to force the application to quit after initialization logic has been executed, and before startup.