### PR TITLE
Rename 'File not found.' message to 'File not shared.'

### DIFF
--- a/src/slskd/Application/Service.cs
+++ b/src/slskd/Application/Service.cs
@@ -413,7 +413,7 @@ namespace slskd
             if (!fileInfo.Exists)
             {
                 Console.WriteLine($"[UPLOAD REJECTED] File {localFilename} not found.");
-                throw new DownloadEnqueueException($"File not found.");
+                throw new DownloadEnqueueException($"File not shared.");
             }
 
             if (tracker.TryGet(TransferDirection.Upload, username, filename, out _))


### PR DESCRIPTION
I believe the `File not found.` transfer status message is an oversight, since the Soulseek.NET library and official clients deal with `File not shared.` messages.