### PR TITLE
Accept option lists via command line and environment variables

### DIFF
--- a/src/slskd/Application/Service.cs
+++ b/src/slskd/Application/Service.cs
@@ -214,7 +214,7 @@ namespace slskd
                     var requiresRestart = HasAttribute<RequiresRestartAttribute>(property);
                     var requiresReconnect = HasAttribute<RequiresReconnectAttribute>(property);
 
-                    Logger.Debug($"{fqn} changed from '{left ?? "<null>"}' to '{right ?? "<null>"}'{(requiresRestart ? "; Restart required to take effect." : string.Empty)}{(requiresReconnect ? "; Reconnect required to take effect." : string.Empty)}");
+                    Logger.Debug($"{fqn} changed from '{left.ToJson() ?? "<null>"}' to '{right.ToJson() ?? "<null>"}'{(requiresRestart ? "; Restart required to take effect." : string.Empty)}{(requiresReconnect ? "; Reconnect required to take effect." : string.Empty)}");
 
                     pendingRestart |= requiresRestart;
                     pendingReconnect |= requiresReconnect;

--- a/src/slskd/Common/Configuration/CommandLineConfigurationSource.cs
+++ b/src/slskd/Common/Configuration/CommandLineConfigurationSource.cs
@@ -33,9 +33,10 @@ namespace slskd.Configuration
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to which to add.</param>
         /// <param name="targetType">The type from which to map properties.</param>
+        /// <param name="multiValuedArguments">An array of argument names which can be specified with multiple values.</param>
         /// <param name="commandLine">The command line string from which to parse arguments.</param>
         /// <returns>The updated <see cref="IConfigurationBuilder"/>.</returns>
-        public static IConfigurationBuilder AddCommandLine(this IConfigurationBuilder builder, Type targetType, string commandLine = null)
+        public static IConfigurationBuilder AddCommandLine(this IConfigurationBuilder builder, Type targetType, string[] multiValuedArguments = null, string commandLine = null)
         {
             if (builder == null)
             {
@@ -51,6 +52,7 @@ namespace slskd.Configuration
             {
                 s.TargetType = targetType;
                 s.CommandLine = commandLine ?? Environment.CommandLine;
+                s.MultiValuedArguments = multiValuedArguments;
             });
         }
 
@@ -78,11 +80,13 @@ namespace slskd.Configuration
             TargetType = source.TargetType;
             Namespace = TargetType.Namespace.Split('.').First();
             CommandLine = source.CommandLine;
+            MultiValuedArguments = source.MultiValuedArguments;
         }
 
         private string CommandLine { get; set; }
         private string Namespace { get; set; }
         private Type TargetType { get; set; }
+        private string[] MultiValuedArguments { get; set; }
 
         /// <summary>
         ///     Parses command line arguments from the specified string and maps them to the corresponding keys.
@@ -90,7 +94,7 @@ namespace slskd.Configuration
         public override void Load()
         {
             Console.WriteLine(CommandLine);
-            var dictionary = Arguments.Parse(CommandLine, TargetType).ArgumentDictionary;
+            var dictionary = Arguments.Parse(CommandLine, options => options.CombinableArguments = MultiValuedArguments).ArgumentDictionary;
             Console.WriteLine(dictionary.ToJson());
 
             void Map(Type type, string path)
@@ -148,6 +152,11 @@ namespace slskd.Configuration
         ///     Gets or sets the type from which to map properties.
         /// </summary>
         public Type TargetType { get; set; }
+
+        /// <summary>
+        ///     Gets or sets an array of argument names which can be specified with multiple values.
+        /// </summary>
+        public string[] MultiValuedArguments { get; set; } = Array.Empty<string>();
 
         /// <summary>
         ///     Builds the <see cref="CommandLineConfigurationProvider"/> for this source.

--- a/src/slskd/Common/Configuration/CommandLineConfigurationSource.cs
+++ b/src/slskd/Common/Configuration/CommandLineConfigurationSource.cs
@@ -89,7 +89,9 @@ namespace slskd.Configuration
         /// </summary>
         public override void Load()
         {
-            var dictionary = Arguments.Parse(CommandLine).ArgumentDictionary;
+            Console.WriteLine(CommandLine);
+            var dictionary = Arguments.Parse(CommandLine, TargetType).ArgumentDictionary;
+            Console.WriteLine(dictionary.ToJson());
 
             void Map(Type type, string path)
             {

--- a/src/slskd/Common/Configuration/CommandLineConfigurationSource.cs
+++ b/src/slskd/Common/Configuration/CommandLineConfigurationSource.cs
@@ -94,9 +94,7 @@ namespace slskd.Configuration
         /// </summary>
         public override void Load()
         {
-            Console.WriteLine(CommandLine);
             var dictionary = Arguments.Parse(CommandLine, options => options.CombinableArguments = MultiValuedArguments).ArgumentDictionary;
-            Console.WriteLine(dictionary.ToJson());
 
             void Map(Type type, string path)
             {
@@ -125,7 +123,7 @@ namespace slskd.Configuration
                                     // Parse() will stuff multiple values into a List<T> if the argument name is
                                     // in the list of those supporting multiple values, and more than one value was supplied.
                                     // detect this, and add the values to the target.
-                                    if (value.GetType().IsGenericType)
+                                    if (value.GetType().IsGenericType && value.GetType().GetGenericTypeDefinition() == typeof(List<>))
                                     {
                                         var elements = (List<object>)dictionary[argument];
 

--- a/src/slskd/Common/Configuration/DefaultValueConfigurationSource.cs
+++ b/src/slskd/Common/Configuration/DefaultValueConfigurationSource.cs
@@ -99,6 +99,8 @@ namespace slskd.Configuration
                     }
                     else
                     {
+                        // don't add array values to the configuration; these are additive across providers
+                        // and the default value from the class is "stuck", so adding them again results in duplicates.
                         if (!property.PropertyType.IsArray)
                         {
                             var value = property.GetValue(defaults);

--- a/src/slskd/Common/Configuration/EnvironmentVariableConfigurationSource.cs
+++ b/src/slskd/Common/Configuration/EnvironmentVariableConfigurationSource.cs
@@ -100,15 +100,32 @@ namespace slskd.Configuration
 
                     if (attribute != default)
                     {
+                        // retrieve the envar name from the attribute
                         var name = (string)attribute.ConstructorArguments[0].Value;
 
                         if (!string.IsNullOrEmpty(name))
                         {
+                            // retrieve the corresponding value from environment variables
                             var value = Environment.GetEnvironmentVariable(Prefix + name);
 
                             if (value != null)
                             {
-                                Data[key] = value.ToString();
+                                // if the type of the backing property is an array,
+                                // split the retrieved value by semicolon and add the parts to
+                                // config as zero-based children of the prop
+                                if (property.PropertyType.IsArray)
+                                {
+                                    var elements = value.Split(';');
+
+                                    for (int i = 0; i < elements.Length; i++)
+                                    {
+                                        Data[ConfigurationPath.Combine(key, i.ToString())] = elements[i];
+                                    }
+                                }
+                                else
+                                {
+                                    Data[key] = value.ToString();
+                                }
                             }
                         }
                     }

--- a/src/slskd/Common/Extensions.cs
+++ b/src/slskd/Common/Extensions.cs
@@ -91,7 +91,14 @@ namespace slskd
                 var propType = prop.PropertyType;
                 var fqn = string.IsNullOrEmpty(parentFqn) ? prop.Name : string.Join(".", parentFqn, prop.Name);
 
-                if (propType.IsPrimitive || Nullable.GetUnderlyingType(propType) != null || new[] { typeof(string), typeof(decimal) }.Contains(propType))
+                if (propType.IsArray)
+                {
+                    if (leftVal.ToJson() != rightVal.ToJson())
+                    {
+                        differences.Add((prop, fqn, leftVal, rightVal));
+                    }
+                }
+                else if (propType.IsPrimitive || Nullable.GetUnderlyingType(propType) != null || new[] { typeof(string), typeof(decimal) }.Contains(propType))
                 {
                     if (!Equals(leftVal, rightVal))
                     {

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -159,14 +159,6 @@ namespace slskd
         [RequiresRestart]
         public string InstanceName { get; private set; } = "default";
 
-        [Argument('y', "list")]
-        [EnvironmentVariable("LIST")]
-        public string[] List { get; private set; } = Array.Empty<string>();
-
-        [Argument('b', "list-of-ints")]
-        [EnvironmentVariable("LIST_OF_INTS")]
-        public int[] ListOfInts { get; private set; } = Array.Empty<int>();
-
         /// <summary>
         ///     Gets directory options.
         /// </summary>

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -159,6 +159,14 @@ namespace slskd
         [RequiresRestart]
         public string InstanceName { get; private set; } = "default";
 
+        [Argument(default, "list")]
+        [EnvironmentVariable("LIST")]
+        public string[] List { get; private set; } = Array.Empty<string>();
+
+        [Argument(default, "list-of-ints")]
+        [EnvironmentVariable("LIST_OF_INTS")]
+        public int[] ListOfInts { get; private set; } = Array.Empty<int>();
+
         /// <summary>
         ///     Gets directory options.
         /// </summary>

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -212,6 +212,9 @@ namespace slskd
                 return;
             }
 
+            Console.WriteLine(OptionsAtStartup.List.ToJson());
+            Console.WriteLine(OptionsAtStartup.ListOfInts.ToJson());
+
             try
             {
                 VerifyOrCreateDirectory(OptionsAtStartup.Directories.App);

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -335,6 +335,8 @@ namespace slskd
         {
             configurationFile = Path.GetFullPath(configurationFile);
 
+            // todo: write some code here to fetch any properties in options marked with `Attribute` and backed by an array. stuff those arguments into a list for multiValuedArgumetns
+
             return builder
                 .AddDefaultValues(
                     targetType: typeof(Options))
@@ -349,6 +351,7 @@ namespace slskd
                     provider: new PhysicalFileProvider(Path.GetDirectoryName(configurationFile), ExclusionFilters.None)) // required for locations outside of the app directory
                 .AddCommandLine(
                     targetType: typeof(Options),
+                    multiValuedArguments: new[] { "t", "list", "list-of-ints" },
                     commandLine: Environment.CommandLine);
         }
 

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -212,9 +212,6 @@ namespace slskd
                 return;
             }
 
-            Console.WriteLine(OptionsAtStartup.List.ToJson());
-            Console.WriteLine(OptionsAtStartup.ListOfInts.ToJson());
-
             try
             {
                 VerifyOrCreateDirectory(OptionsAtStartup.Directories.App);

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -75,7 +75,7 @@
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.1" />
-    <PackageReference Include="Utility.CommandLine.Arguments" Version="5.0.0" />
+    <PackageReference Include="Utility.CommandLine.Arguments" Version="6.0.0" />
     <PackageReference Include="Utility.EnvironmentVariables" Version="1.0.5" />
     <PackageReference Include="YamlDotNet" Version="11.2.0" />
   </ItemGroup>


### PR DESCRIPTION
Allows types `string[]` and `int[]` to be used as backing types for `Option` properties.  When these types are used, environment variables can be specified as strings with multiple values delimited by semicolons (e.g. `"foo;bar;baz"` is expanded to `[ 'foo', 'bar', 'baz' ]`.  Command line arguments backed by array types can be specified multiple times (e.g. `--foo bar --foo baz` is expanded to `[ 'bar', 'baz' ]`.

Multiple values are represented in YAML in the standard way.

Closes #124 
Closes #129