### PR TITLE
Substitute share paths with a hash

### DIFF
--- a/src/slskd/Application/Application.cs
+++ b/src/slskd/Application/Application.cs
@@ -21,6 +21,7 @@ namespace slskd
     using System.Collections.Concurrent;
     using System.IO;
     using System.Linq;
+    //using System.Linq;
     using System.Net;
     using System.Reflection;
     using System.Threading;
@@ -592,7 +593,9 @@ namespace slskd
         private Task EnqueueDownloadAction(string username, IPEndPoint endpoint, string filename, ITransferTracker tracker)
         {
             _ = endpoint;
-            var localFilename = filename.ToLocalOSPath();
+            var localFilename = SharedFileCache.Resolve(filename).ToLocalOSPath();
+            Console.WriteLine($"Local: {localFilename}");
+
             var fileInfo = new FileInfo(localFilename);
 
             if (!fileInfo.Exists)

--- a/src/slskd/Application/Application.cs
+++ b/src/slskd/Application/Application.cs
@@ -594,7 +594,6 @@ namespace slskd
         {
             _ = endpoint;
             var localFilename = SharedFileCache.Resolve(filename).ToLocalOSPath();
-            Console.WriteLine($"Local: {localFilename}");
 
             var fileInfo = new FileInfo(localFilename);
 

--- a/src/slskd/Application/Application.cs
+++ b/src/slskd/Application/Application.cs
@@ -21,7 +21,6 @@ namespace slskd
     using System.Collections.Concurrent;
     using System.IO;
     using System.Linq;
-    //using System.Linq;
     using System.Net;
     using System.Reflection;
     using System.Threading;

--- a/src/slskd/Application/ApplicationState.cs
+++ b/src/slskd/Application/ApplicationState.cs
@@ -25,6 +25,6 @@ namespace slskd
         public bool PendingReconnect { get; init; }
         public bool PendingRestart { get; init; }
         public bool PendingShareRescan { get; init; }
-        public SharedFileCacheState SharedFileCache { get; init; }
+        public SharedFileCacheState SharedFileCache { get; init; } = new SharedFileCacheState();
     }
 }

--- a/src/slskd/Application/ISharedFileCache.cs
+++ b/src/slskd/Application/ISharedFileCache.cs
@@ -44,6 +44,14 @@ namespace slskd
         Task FillAsync();
 
         /// <summary>
+        ///     Substitutes the mask in the specified <paramref name="filename"/> with the original path, if the mask is tracked
+        ///     by the cache.
+        /// </summary>
+        /// <param name="filename">The fully qualified filename to unmask.</param>
+        /// <returns>The unmasked filename.</returns>
+        public string Resolve(string filename);
+
+        /// <summary>
         ///     Searches the cache for the specified <paramref name="query"/> and returns the matching files.
         /// </summary>
         /// <param name="query">The query for which to search.</param>

--- a/src/slskd/Application/SharedFileCache.cs
+++ b/src/slskd/Application/SharedFileCache.cs
@@ -161,7 +161,7 @@ namespace slskd
                     // filename and with a value of a Soulseek.File object
                     var newFiles = System.IO.Directory.GetFiles(directory, "*", SearchOption.TopDirectoryOnly)
                         .Select(f => new File(1, f.Replace("/", @"\").ReplaceFirst(mask.Value, mask.Key), new FileInfo(f).Length, Path.GetExtension(f)))
-                        .ToDictionary(f => f.Filename, f => f);
+                        .ToDictionary(f => f.Filename.ReplaceFirst(mask.Value, mask.Key), f => f);
 
                     // merge the new dictionary with the rest this will overwrite any duplicate keys, but keys are the fully
                     // qualified name the only time this *should* cause problems is if one of the shares is a subdirectory of another.
@@ -172,7 +172,7 @@ namespace slskd
                             Log.Warning($"File {file.Key} shared in directory {directory} has already been cached.  This is probably a misconfiguration of the shared directories (is a subdirectory being re-shared?).");
                         }
 
-                        files[file.Key.ReplaceFirst(mask.Value, mask.Key)] = file.Value;
+                        files[file.Key] = file.Value;
                     }
 
                     current++;

--- a/src/slskd/Application/SharedFileCache.cs
+++ b/src/slskd/Application/SharedFileCache.cs
@@ -160,7 +160,7 @@ namespace slskd
                     // recursively find all files in the directory and stick a record in a dictionary, keyed on the sanitized
                     // filename and with a value of a Soulseek.File object
                     var newFiles = System.IO.Directory.GetFiles(directory, "*", SearchOption.TopDirectoryOnly)
-                        .Select(f => new File(1, f.Replace("/", @"\"), new FileInfo(f).Length, Path.GetExtension(f)))
+                        .Select(f => new File(1, f.Replace("/", @"\").ReplaceFirst(mask.Value, mask.Key), new FileInfo(f).Length, Path.GetExtension(f)))
                         .ToDictionary(f => f.Filename, f => f);
 
                     // merge the new dictionary with the rest this will overwrite any duplicate keys, but keys are the fully

--- a/src/slskd/Application/SharedFileCache.cs
+++ b/src/slskd/Application/SharedFileCache.cs
@@ -133,7 +133,7 @@ namespace slskd
 
                 var masks = new Dictionary<string, string>(shares
                     .Select(s => System.IO.Directory.GetParent(s).FullName)
-                    .Select(s => new KeyValuePair<string, string>(Compute.MaskHash(s), s)));
+                    .Select(s => new KeyValuePair<string, string>(Compute.MaskHash(s), s)).ToHashSet());
 
                 Log.Debug("Enumerating shared directories");
                 swSnapshot = sw.ElapsedMilliseconds;

--- a/src/slskd/Common/Compute.cs
+++ b/src/slskd/Common/Compute.cs
@@ -43,5 +43,13 @@ namespace slskd
             using var sha1 = new SHA1Managed();
             return BitConverter.ToString(sha1.ComputeHash(Encoding.UTF8.GetBytes(str))).Replace("-", string.Empty);
         }
+
+        public static string MaskHash(string str)
+        {
+            var hashCode = str.GetStableHashCode();
+            var bytes = BitConverter.GetBytes(hashCode);
+            var base64 = Convert.ToBase64String(bytes);
+            return $"@@{base64.ToLowerInvariant().Replace("=", string.Empty)}";
+        }
     }
 }

--- a/src/slskd/Common/Compute.cs
+++ b/src/slskd/Common/Compute.cs
@@ -20,6 +20,7 @@ namespace slskd
     using System;
     using System.Security.Cryptography;
     using System.Text;
+    using System.Text.RegularExpressions;
 
     /// <summary>
     ///     Computational functions.
@@ -46,10 +47,19 @@ namespace slskd
 
         public static string MaskHash(string str)
         {
-            var hashCode = str.GetStableHashCode();
-            var bytes = BitConverter.GetBytes(hashCode);
-            var base64 = Convert.ToBase64String(bytes);
-            return $"@@{base64.ToLowerInvariant().Replace("=", string.Empty)}";
+            var hash = Sha1Hash(str);
+            hash = Convert.ToBase64String(Encoding.UTF8.GetBytes(hash));
+            hash = Regex.Replace(hash, @"[\d=]", string.Empty).ToLowerInvariant();
+
+            // in some very unlucky circumstances, the sha1 might end up being all or mostly numbers.
+            // if this is the case the resulting hash could be fewer than the 5 characters we need,
+            // so copy it until we get to 5
+            while (hash.Length < 5)
+            {
+                hash += hash;
+            }
+
+            return $"@@{hash.Substring(0, 5)}";
         }
     }
 }

--- a/src/slskd/Common/Extensions.cs
+++ b/src/slskd/Common/Extensions.cs
@@ -69,6 +69,55 @@ namespace slskd
         }
 
         /// <summary>
+        ///     Replaces the first occurance of <paramref name="phrase"/> in the string with <paramref name="replacement"/>.
+        /// </summary>
+        /// <param name="str">The string on which to perform the replacement.</param>
+        /// <param name="phrase">The phrase or substring to replace.</param>
+        /// <param name="replacement">The replacement string.</param>
+        /// <returns>The string, with the desired phrase replaced.</returns>
+        public static string ReplaceFirst(this string str, string phrase, string replacement)
+        {
+            int pos = str.IndexOf(phrase);
+
+            if (pos < 0)
+            {
+                return str;
+            }
+
+            return str.Substring(0, pos) + replacement + str.Substring(pos + phrase.Length);
+        }
+
+        /// <summary>
+        ///     Computes a stable/consistent hash code for strings.
+        /// </summary>
+        /// <remarks>
+        ///     https://stackoverflow.com/questions/5154970/how-do-i-create-a-hashcode-in-net-c-for-a-string-that-is-safe-to-store-in-a
+        /// </remarks>
+        /// <param name="str">The string for which the hash code is to be computed.</param>
+        /// <returns>The hash code</returns>
+        public static int GetStableHashCode(this string str)
+        {
+            unchecked
+            {
+                int hash1 = 5381;
+                int hash2 = hash1;
+
+                for (int i = 0; i < str.Length && str[i] != '\0'; i += 2)
+                {
+                    hash1 = ((hash1 << 5) + hash1) ^ str[i];
+                    if (i == str.Length - 1 || str[i + 1] == '\0')
+                    {
+                        break;
+                    }
+
+                    hash2 = ((hash2 << 5) + hash2) ^ str[i + 1];
+                }
+
+                return hash1 + (hash2 * 1566083941);
+            }
+        }
+
+        /// <summary>
         ///     Deeply compares this object with the specified object and returns a list of properties that are different.
         /// </summary>
         /// <param name="left">The left side of the comparison.</param>

--- a/src/slskd/Common/Extensions.cs
+++ b/src/slskd/Common/Extensions.cs
@@ -94,7 +94,7 @@ namespace slskd
         ///     https://stackoverflow.com/questions/5154970/how-do-i-create-a-hashcode-in-net-c-for-a-string-that-is-safe-to-store-in-a
         /// </remarks>
         /// <param name="str">The string for which the hash code is to be computed.</param>
-        /// <returns>The hash code</returns>
+        /// <returns>The hash code.</returns>
         public static int GetStableHashCode(this string str)
         {
             unchecked

--- a/src/slskd/Properties/analysis.ruleset
+++ b/src/slskd/Properties/analysis.ruleset
@@ -37,6 +37,7 @@
     <Rule Id="S2589" Action="None" />
     <Rule Id="S3011" Action="None" />
     <Rule Id="S3427" Action="Info" />
+    <Rule Id="S1643" Action="Info" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA1008" Action="None" />


### PR DESCRIPTION
This PR adds functionality to the shared file cache to mask all but the most immediate directory in shared directories.  

The path:

```/home/Foo/My Sensitive Filepath/Music/Shared```

Appears in browse and search results as:

```@@hash/Shared```

The hash is computed by first computing the SHA1 hash of the directory, then by converting the hash to base 64, removing numbers, converting all letters to lowercase, and then taking the first 5.

I'm pretty sure at this point that Soulseek (Qt at least) is expecting hashes that:

* Begin with `@@`
* Contain only lowercase letters (no numbers)
* Are exactly 7 characters in length (including `@@` and 5 additional characters)

Including numbers seems to only obscure the path up to the first number, and including uppercase characters seems to invalidate the hash entirely.  Including more than 5 characters results in characters 6 onwards being displayed.

Closes #53 

