### PR TITLE
Add share aliases

### DIFF
--- a/src/slskd/Application/Exceptions/ShareAliasException.cs
+++ b/src/slskd/Application/Exceptions/ShareAliasException.cs
@@ -1,0 +1,72 @@
+﻿// <copyright file="ShareAliasException.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    ///     Represents an error that occurs when multiple share scans are attempted concurrently.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    [Serializable]
+    public class ShareAliasException : SlskdException
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ShareAliasException"/> class.
+        /// </summary>
+        public ShareAliasException()
+            : base()
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ShareAliasException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public ShareAliasException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ShareAliasException"/> class with a specified error message and a
+        ///     reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">
+        ///     The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no
+        ///     inner exception is specified.
+        /// </param>
+        public ShareAliasException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ShareAliasException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The SerializationInfo that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
+        protected ShareAliasException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/slskd/Application/SharedFileCache.cs
+++ b/src/slskd/Application/SharedFileCache.cs
@@ -56,10 +56,10 @@ namespace slskd
         private ILogger Log { get; } = Serilog.Log.ForContext<SharedFileCache>();
         private HashSet<string> MaskedDirectories { get; set; }
         private IOptionsMonitor<Options> OptionsMonitor { get; set; }
+        private List<Share> Shares { get; set; }
         private SqliteConnection SQLite { get; set; }
         private SemaphoreSlim SyncRoot { get; } = new SemaphoreSlim(1);
         private HashSet<string> UnmaskedDirectories { get; set; }
-        private List<Share> Shares { get; set; }
 
         /// <summary>
         ///     Returns the contents of the cache.
@@ -143,7 +143,7 @@ namespace slskd
                 {
                     foreach (var dupe in duplicates)
                     {
-                        Log.Warning($"Overlapping shares: {string.Join(", ", dupe.Select(s => s.Raw))}. Use different alias(es) to disambiguate; downloads from these shares will most likely fail.");
+                        Log.Warning($"Overlapping shares: {string.Join(", ", dupe.Select(s => s.Raw))}. Use different alias(es) to disambiguate; downloads from one of these shares will fail.");
                     }
                 }
 
@@ -236,8 +236,8 @@ namespace slskd
         {
             var resolved = filename;
 
-            // a well-formed path will consist of a mask, either an alias or a local directory, and a
-            // fully qualified path to a file.  split the requested filename so we can examine the first two segments
+            // a well-formed path will consist of a mask, either an alias or a local directory, and a fully qualified path to a
+            // file. split the requested filename so we can examine the first two segments
             var parts = filename.Split(new[] { '/', '\\' });
 
             if (parts.Length < 2)
@@ -375,12 +375,12 @@ namespace slskd
                 }
             }
 
-            public string Raw { get; init; }
             public string Alias { get; init; }
-            public string LocalPath { get; init; }
-            public string RemotePath { get; init; }
-            public string Mask { get; init; }
             public bool IsExcluded { get; init; }
+            public string LocalPath { get; init; }
+            public string Mask { get; init; }
+            public string Raw { get; init; }
+            public string RemotePath { get; init; }
         }
     }
 }

--- a/src/slskd/Application/SharedFileCache.cs
+++ b/src/slskd/Application/SharedFileCache.cs
@@ -115,17 +115,16 @@ namespace slskd
                 {
                     var alias = matches[0].Groups[1].Value;
                     var unaliasedShare = matches[0].Groups[2].Value;
-                    var parent = System.IO.Directory.GetParent(unaliasedShare).FullName;
 
                     cleanedShares.Add(unaliasedShare);
 
-                    if (aliases.ContainsKey(parent))
+                    if (aliases.ContainsKey(unaliasedShare))
                     {
-                        aliases[parent] = alias;
+                        aliases[alias] = unaliasedShare;
                     }
                     else
                     {
-                        aliases.Add(parent, alias);
+                        aliases.Add(alias, unaliasedShare);
                     }
                 }
                 else
@@ -203,6 +202,17 @@ namespace slskd
                 foreach (var directory in unmaskedDirectories)
                 {
                     var mask = masks.First(m => directory.StartsWith(m.Value));
+                    var alias = aliases.FirstOrDefault(a => directory.StartsWith(a.Value));
+
+                    var masked = directory.ReplaceFirst(mask.Value, mask.Key);
+
+                    if (alias.Key != null)
+                    {
+                        var target = masked.Split(new[] { '\\', '/' }).Skip(1).First();
+                        Console.WriteLine($"Directory {target} is aliased to {alias.Key}");
+                        masked = masked.ReplaceFirst(target, alias.Key);
+                        Console.WriteLine(masked);
+                    }
 
                     maskedDirectories.Add(directory.ReplaceFirst(mask.Value, mask.Key));
 

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -24,6 +24,8 @@ namespace slskd
     using System.ComponentModel;
     using System.ComponentModel.DataAnnotations;
     using System.Diagnostics;
+    using System.Linq;
+    using System.Text.RegularExpressions;
     using FluentFTP;
     using slskd.Configuration;
     using slskd.Validation;
@@ -219,7 +221,7 @@ namespace slskd
         /// <summary>
         ///     Directory options.
         /// </summary>
-        public class DirectoriesOptions
+        public class DirectoriesOptions : IValidatableObject
         {
             /// <summary>
             ///     Gets the path where application data is saved.
@@ -258,6 +260,33 @@ namespace slskd
             [EnvironmentVariable("SHARED_DIR")]
             [Description("path to shared files")]
             public string[] Shared { get; private set; } = new[] { Program.DefaultSharedDirectory };
+
+            /// <summary>
+            ///     Extended validation.
+            /// </summary>
+            /// <param name="validationContext"></param>
+            /// <returns></returns>
+            public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+            {
+                var results = new List<ValidationResult>();
+
+                foreach (var share in Shared)
+                {
+                    var matches = Regex.Matches(share, @"^(-?)\[(.*)\](.*)$");
+
+                    if (matches.Any())
+                    {
+                        var alias = matches[0].Groups[2].Value;
+
+                        if (alias.Contains('\\') || alias.Contains('/'))
+                        {
+                            results.Add(new ValidationResult($"Share {share} is invalid; aliases may not contain path separators '/' or '\'"));
+                        }
+                    }
+                }
+
+                return results;
+            }
         }
 
         /// <summary>

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -278,7 +278,11 @@ namespace slskd
                     {
                         var alias = matches[0].Groups[2].Value;
 
-                        if (alias.Contains('\\') || alias.Contains('/'))
+                        if (string.IsNullOrWhiteSpace(alias))
+                        {
+                            results.Add(new ValidationResult($"Share {share} is invalid; alias may not be null, empty or consist of only whitespace"));
+                        }
+                        else if (alias.Contains('\\') || alias.Contains('/'))
                         {
                             results.Add(new ValidationResult($"Share {share} is invalid; aliases may not contain path separators '/' or '\'"));
                         }

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -241,14 +241,6 @@ namespace slskd
                 VerifyDirectory(OptionsAtStartup.Directories.App, createIfMissing: true, verifyWriteable: true);
                 VerifyDirectory(OptionsAtStartup.Directories.Incomplete, createIfMissing: true, verifyWriteable: true);
                 VerifyDirectory(OptionsAtStartup.Directories.Downloads, createIfMissing: true, verifyWriteable: true);
-
-                foreach (var share in OptionsAtStartup.Directories.Shared)
-                {
-                    if (!VerifyDirectory(share, createIfMissing: false, verifyWriteable: false))
-                    {
-                        logger.Warning("Shared directory {Directory} does not exist", share);
-                    }
-                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This PR adds the ability to alias shared directories, giving users greater control over how their files show up to other users without requiring the physical location of files to be changed.

## Testing

### Validation

* [x] Duplicate shares don't throw
* [x] Overlapping shares throw (alias matches last directory in un-aliased share)
* [x] Overlapping detection is case sensitive (overlaps that differ only in case are ok)
* [x] Different aliases that reference the same path throw
* [x] Empty aliases throw
* [x] Aliases containing / and \ throw

### Aliases

* [x] Replaces final directory with alias
* [x] Works with nested directories
* [x] Order doesn't matter for parent/subdirectory
* [x] Duplicated directories with different aliases show up once and with the last alias


Closes #150 