### PR TITLE
Default shares to an empty array.  Warn if no shares are configured

### DIFF
--- a/src/slskd/Application/SharedFileCache.cs
+++ b/src/slskd/Application/SharedFileCache.cs
@@ -137,6 +137,11 @@ namespace slskd
                     .OrderByDescending(share => share.LocalPath.Length) // process subdirectories first.  this allows them to be aliased separately from their parent
                     .ToList();
 
+                if (!Shares.Any())
+                {
+                    Log.Warning("Aborting shared file scan; no shares configured.");
+                }
+
                 Log.Debug("Enumerating shared directories");
                 swSnapshot = sw.ElapsedMilliseconds;
 

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -260,7 +260,7 @@ namespace slskd
             [Argument('s', "shared")]
             [EnvironmentVariable("SHARED_DIR")]
             [Description("path to shared files")]
-            public string[] Shared { get; private set; } = new[] { Program.DefaultSharedDirectory };
+            public string[] Shared { get; private set; } = Array.Empty<string>();
 
             /// <summary>
             ///     Extended validation.

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -74,11 +74,6 @@ namespace slskd
         public static readonly string DefaultDownloadsDirectory = Path.Combine(DefaultAppDirectory, "downloads");
 
         /// <summary>
-        ///     The default shared directory.
-        /// </summary>
-        public static readonly string DefaultSharedDirectory = Path.Combine(DefaultAppDirectory, "shared");
-
-        /// <summary>
         ///     The global prefix for environment variables.
         /// </summary>
         public static readonly string EnvironmentVariablePrefix = $"{AppName.ToUpperInvariant()}_";
@@ -241,7 +236,6 @@ namespace slskd
                 VerifyDirectory(OptionsAtStartup.Directories.App, createIfMissing: true, verifyWriteable: true);
                 VerifyDirectory(OptionsAtStartup.Directories.Incomplete, createIfMissing: true, verifyWriteable: true);
                 VerifyDirectory(OptionsAtStartup.Directories.Downloads, createIfMissing: true, verifyWriteable: true);
-                VerifyDirectory(DefaultSharedDirectory, createIfMissing: true, verifyWriteable: false);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The inability to override the default share is causing users issues and the use case is hypothetical.  This PR removes it.