### PR TITLE
Improve search matching

### DIFF
--- a/src/slskd/Application/SharedFileCache.cs
+++ b/src/slskd/Application/SharedFileCache.cs
@@ -275,17 +275,16 @@ namespace slskd
         /// <returns>The matching files.</returns>
         public async Task<IEnumerable<File>> SearchAsync(SearchQuery query)
         {
-            // sanitize the query string. there's probably more to it than this.
-            var text = query.Query
-                .Replace("/", " ")
+            string Clean(string str) => str.Replace("/", " ")
                 .Replace("\\", " ")
                 .Replace(":", " ")
                 .Replace("\"", " ")
                 .Replace("'", "''");
 
-            var tokens = text.Split(' ').Select(token => $"\"{token}\"");
+            var match = string.Join(" AND ", query.Terms.Select(token => $"\"{Clean(token)}\""));
+            var exclusions = string.Join(" OR ", query.Exclusions.Select(exclusion => $"\"{Clean(exclusion)}\""));
 
-            var sql = $"SELECT * FROM cache WHERE cache MATCH '{string.Join(" AND ", tokens)}'";
+            var sql = $"SELECT * FROM cache WHERE cache MATCH '({match}) {(query.Exclusions.Any() ? $"NOT ({exclusions})" : string.Empty)}'";
 
             try
             {

--- a/src/slskd/Application/SharedFileCache.cs
+++ b/src/slskd/Application/SharedFileCache.cs
@@ -286,7 +286,7 @@ namespace slskd
                 .Replace("\"", " ")
                 .Replace("'", "''");
 
-            var tokens = text.Split(' ');
+            var tokens = text.Split(' ').Select(token => $"\"{token}\"");
 
             var sql = $"SELECT * FROM cache WHERE cache MATCH '{string.Join(" AND ", tokens)}'";
 

--- a/src/slskd/Application/SharedFileCache.cs
+++ b/src/slskd/Application/SharedFileCache.cs
@@ -283,9 +283,12 @@ namespace slskd
                 .Replace("/", " ")
                 .Replace("\\", " ")
                 .Replace(":", " ")
-                .Replace("\"", " ");
+                .Replace("\"", " ")
+                .Replace("'", "''");
 
-            var sql = $"SELECT * FROM cache WHERE cache MATCH '\"{text.Replace("'", "''")}\"'";
+            var tokens = text.Split(' ');
+
+            var sql = $"SELECT * FROM cache WHERE cache MATCH '{string.Join(" AND ", tokens)}'";
 
             try
             {
@@ -297,6 +300,8 @@ namespace slskd
                 {
                     results.Add(reader.GetString(0));
                 }
+
+                Log.Debug($"Query {sql} returned {results.Count} results");
 
                 return results.Select(r => Files[r.Replace("''", "'")]);
             }
@@ -318,7 +323,7 @@ namespace slskd
             SQLite = new SqliteConnection("Data Source=:memory:");
             SQLite.Open();
 
-            using var cmd = new SqliteCommand("CREATE VIRTUAL TABLE cache USING fts5(filename)", SQLite);
+            using var cmd = new SqliteCommand("CREATE VIRTUAL TABLE cache USING fts5(filename, tokenize=\"porter\")", SQLite);
             cmd.ExecuteNonQuery();
         }
 

--- a/src/slskd/Application/SharedFileCache.cs
+++ b/src/slskd/Application/SharedFileCache.cs
@@ -319,7 +319,7 @@ namespace slskd
             SQLite = new SqliteConnection("Data Source=:memory:");
             SQLite.Open();
 
-            using var cmd = new SqliteCommand("CREATE VIRTUAL TABLE cache USING fts5(filename, tokenize=\"porter\")", SQLite);
+            using var cmd = new SqliteCommand("CREATE VIRTUAL TABLE cache USING fts5(filename)", SQLite);
             cmd.ExecuteNonQuery();
         }
 


### PR DESCRIPTION
The shared file cache uses the SQLite FTS5 extension for full-text searching, but when I implemented it I didn't spend a lot of time reading through the docs to see how to get the best matching.

This PR improves matching by allowing search tokens to be located anywhere in a string, rather than strictly ordered according to the query, and includes any terms specified in the query as exclusions (prefixed with -)

Partially addresses #158 