### PR TITLE
Use a new SQLite connection for each search request

### DIFF
--- a/src/slskd/Application/SharedFileCache.cs
+++ b/src/slskd/Application/SharedFileCache.cs
@@ -107,19 +107,17 @@ namespace slskd
         /// <returns>The operation context.</returns>
         public async Task FillAsync()
         {
-            if (SyncRoot.CurrentCount == 0)
+            // obtain the semaphore, or fail if it can't be obtained immediately, indicating that a scan is running.
+            if (!await SyncRoot.WaitAsync(millisecondsTimeout: 0))
             {
                 Log.Warning("Shared file scan rejected; scan is already in progress.");
                 throw new ShareScanInProgressException("Shared files are already being scanned.");
             }
 
-            await Task.Yield();
-
-            await SyncRoot.WaitAsync();
-
             try
             {
-                // todo: don't do this, but rather build a new cache and then swap it in
+                await Task.Yield();
+
                 ResetCache();
 
                 State.SetValue(state => state with { Filling = true, FillProgress = 0 });

--- a/src/slskd/Application/SharedFileCache.cs
+++ b/src/slskd/Application/SharedFileCache.cs
@@ -1,4 +1,4 @@
-// <copyright file="SharedFileCache.cs" company="slskd Team">
+﻿// <copyright file="SharedFileCache.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -319,8 +319,13 @@ namespace slskd
 
             try
             {
-                using var cmd = new SqliteCommand(sql, SQLite);
                 var results = new List<string>();
+
+                using var sqlite = new SqliteConnection("Data Source=file:shares?mode=memory&cache=shared");
+                using var cmd = new SqliteCommand(sql, sqlite);
+
+                sqlite.Open();
+
                 var reader = await cmd.ExecuteReaderAsync();
 
                 while (reader.Read())

--- a/src/slskd/Application/SharedFileCache.cs
+++ b/src/slskd/Application/SharedFileCache.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SharedFileCache.cs" company="slskd Team">
+// <copyright file="SharedFileCache.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -344,7 +344,7 @@ namespace slskd
                 SQLite.Dispose();
             }
 
-            SQLite = new SqliteConnection("Data Source=:memory:");
+            SQLite = new SqliteConnection("Data Source=file:shares?mode=memory&cache=shared");
             SQLite.Open();
 
             using var cmd = new SqliteCommand("CREATE VIRTUAL TABLE cache USING fts5(filename)", SQLite);

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -61,8 +61,7 @@ namespace slskd
         /// <summary>
         ///     The default configuration filename.
         /// </summary>
-        //public static readonly string DefaultConfigurationFile = Path.Combine(AppContext.BaseDirectory, "config", $"{AppName}.yml");
-        public static readonly string DefaultConfigurationFile = @"C:\Users\JP.WHATNET\slskd.yml";
+        public static readonly string DefaultConfigurationFile = Path.Combine(AppContext.BaseDirectory, "config", $"{AppName}.yml");
 
         /// <summary>
         ///     The default incomplete download directory.

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -61,7 +61,8 @@ namespace slskd
         /// <summary>
         ///     The default configuration filename.
         /// </summary>
-        public static readonly string DefaultConfigurationFile = Path.Combine(AppContext.BaseDirectory, "config", $"{AppName}.yml");
+        //public static readonly string DefaultConfigurationFile = Path.Combine(AppContext.BaseDirectory, "config", $"{AppName}.yml");
+        public static readonly string DefaultConfigurationFile = @"C:\Users\JP.WHATNET\slskd.yml";
 
         /// <summary>
         ///     The default incomplete download directory.


### PR DESCRIPTION
The general guidance is to avoid cross-thread access of SQLite connections, and the best way to do that, without getting into some esoteric connection pooling scheme, is to create a new one for each query.

I profiled the memory usage with this change for ~12 hours and confirmed that it doesn't cause any leaks or undue GC pressure, and queries themselves generally come back in 0-2ms either way, so I don't anticipate any performance issues.

Closes #178
Closes #179 