### PR TITLE
Add the ability to automatically join rooms on login

### DIFF
--- a/src/slskd/Application/Application.cs
+++ b/src/slskd/Application/Application.cs
@@ -1,4 +1,4 @@
-// <copyright file="Application.cs" company="slskd Team">
+﻿// <copyright file="Application.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -439,7 +439,11 @@ namespace slskd
         {
             Logger.Information("Joining rooms {Rooms}", string.Join(", ", OptionsMonitor.CurrentValue.Rooms));
 
-            var tasks = rooms.Select(room => SoulseekClient.JoinRoomAsync(room)
+            // don't try to join rooms that we've already joined.  the server returns no response in this case
+            // and the client believes the request has timed out.
+            var unjoined = rooms.Where(room => !RoomTracker.Rooms.ContainsKey(room));
+
+            var tasks = unjoined.Select(room => SoulseekClient.JoinRoomAsync(room)
                     .ContinueWith(task => Logger.Warning("Failed to join room {Room}: {Message}", room, task.Exception.InnerExceptions.First().Message), TaskContinuationOptions.OnlyOnFaulted));
 
             return Task.WhenAll(tasks);

--- a/src/slskd/Application/Application.cs
+++ b/src/slskd/Application/Application.cs
@@ -19,6 +19,7 @@ namespace slskd
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -252,7 +253,7 @@ namespace slskd
                     || newOptions.Rooms.Except(PreviousOptions.Rooms).Any())
                 {
                     Logger.Information("Room configuration changed.  Joining any newly added rooms.");
-                    _ = AutoJoinRooms(newOptions.Rooms);
+                    _ = AutoJoinRoomsAsync(newOptions.Rooms);
                 }
 
                 // determine whether any Soulseek options changed.  if so, we need to construct a patch
@@ -425,28 +426,62 @@ namespace slskd
             Logger.Information("Connected to the Soulseek server");
         }
 
-        private void Client_LoggedIn(object sender, EventArgs e)
+        private async void Client_LoggedIn(object sender, EventArgs e)
         {
             Logger.Information("Logged in to the Soulseek server as {Username}", Client.Username);
 
             // send whatever counts we have currently. we'll probably connect before the cache is primed,
             // so these will be zero initially, but we'll update them when the cache is filled.
             _ = SoulseekClient.SetSharedCountsAsync(State.SharedFileCache.Directories, State.SharedFileCache.Files);
-            _ = AutoJoinRooms(OptionsMonitor.CurrentValue.Rooms);
+
+            // rejoin any rooms that we might have been in during the previous session
+            await JoinRoomsAsync(RoomTracker.Rooms.Keys);
+
+            // join the rooms configured for autojoin.  always do this after rejoining has completed.
+            await AutoJoinRoomsAsync(OptionsMonitor.CurrentValue.Rooms);
         }
 
-        private Task AutoJoinRooms(string[] rooms)
+        private Task AutoJoinRoomsAsync(string[] rooms)
         {
-            Logger.Information("Joining rooms {Rooms}", string.Join(", ", OptionsMonitor.CurrentValue.Rooms));
-
             // don't try to join rooms that we've already joined.  the server returns no response in this case
             // and the client believes the request has timed out.
             var unjoined = rooms.Where(room => !RoomTracker.Rooms.ContainsKey(room));
+            return JoinRoomsAsync(unjoined);
+        }
 
-            var tasks = unjoined.Select(room => SoulseekClient.JoinRoomAsync(room)
-                    .ContinueWith(task => Logger.Warning("Failed to join room {Room}: {Message}", room, task.Exception.InnerExceptions.First().Message), TaskContinuationOptions.OnlyOnFaulted));
+        private async Task JoinRoomsAsync(IEnumerable<string> roomNames)
+        {
+            var tasks = new List<Task>();
 
-            return Task.WhenAll(tasks);
+            foreach (var room in roomNames)
+            {
+                tasks.Add(JoinRoomAsync(room));
+            }
+
+            try
+            {
+                await Task.WhenAll(tasks);
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "Caught Exception in JoinRoomsAsync");
+            }
+        }
+
+        private async Task JoinRoomAsync(string roomName)
+        {
+            Logger.Debug("Joining room {Room}", roomName);
+
+            try
+            {
+                var data = await SoulseekClient.JoinRoomAsync(roomName);
+                Logger.Information("Joined room {Room}", roomName);
+                Logger.Debug("Room data for {Room}: {Info}", roomName, data.ToJson());
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning("Failed to join room {Room}: {Message}", roomName, ex.Message);
+            }
         }
 
         private async void Client_Disconnected(object sender, SoulseekClientDisconnectedEventArgs args)

--- a/src/slskd/Application/Application.cs
+++ b/src/slskd/Application/Application.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Application.cs" company="slskd Team">
+// <copyright file="Application.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -246,6 +246,13 @@ namespace slskd
                 {
                     StateMonitor.SetValue(state => state with { PendingShareRescan = true });
                     Logger.Information("File filter configuration changed.  Shares must be re-scanned for changes to take effect.");
+                }
+
+                if (PreviousOptions.Rooms.Except(newOptions.Rooms).Any()
+                    || newOptions.Rooms.Except(PreviousOptions.Rooms).Any())
+                {
+                    Logger.Information("Room configuration changed.  Joining any newly added rooms.");
+                    _ = AutoJoinRooms(newOptions.Rooms);
                 }
 
                 // determine whether any Soulseek options changed.  if so, we need to construct a patch

--- a/src/slskd/Application/Application.cs
+++ b/src/slskd/Application/Application.cs
@@ -425,6 +425,17 @@ namespace slskd
             // send whatever counts we have currently. we'll probably connect before the cache is primed,
             // so these will be zero initially, but we'll update them when the cache is filled.
             _ = SoulseekClient.SetSharedCountsAsync(State.SharedFileCache.Directories, State.SharedFileCache.Files);
+            _ = AutoJoinRooms(OptionsMonitor.CurrentValue.Rooms);
+        }
+
+        private Task AutoJoinRooms(string[] rooms)
+        {
+            Logger.Information("Joining rooms {Rooms}", string.Join(", ", OptionsMonitor.CurrentValue.Rooms));
+
+            var tasks = rooms.Select(room => SoulseekClient.JoinRoomAsync(room)
+                    .ContinueWith(task => Logger.Warning("Failed to join room {Room}: {Message}", room, task.Exception.InnerExceptions.First().Message), TaskContinuationOptions.OnlyOnFaulted));
+
+            return Task.WhenAll(tasks);
         }
 
         private async void Client_Disconnected(object sender, SoulseekClientDisconnectedEventArgs args)

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -194,6 +194,14 @@ namespace slskd
         public FiltersOptions Filters { get; private set; } = new FiltersOptions();
 
         /// <summary>
+        ///     Gets a list of rooms to automatically join upon connection.
+        /// </summary>
+        [Argument(default, "rooms")]
+        [EnvironmentVariable("ROOMS")]
+        [Description("a list of rooms to automatically join")]
+        public string[] Rooms { get; private set; } = Array.Empty<string>();
+
+        /// <summary>
         ///     Gets options for the web UI.
         /// </summary>
         [Validate]

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -68,7 +68,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Soulseek" Version="3.0.0-pre-828211031" />
+    <PackageReference Include="Soulseek" Version="3.0.0-pre-905211220" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
A configured list of chat rooms will now be automatically joined on connect.

The list can be specified via command line (e.g. `--rooms <room1> --rooms <room2>`), with the `SLSKD_ROOMS` environment variable (rooms separated by a semicolon), or in the yaml file as follows:

```yaml
rooms:
  - <room 1>
  - <room 2>
```

Additionally, when the client is disconnected, any rooms that were joined at the time of the disconnect are rejoined upon reconnect, as long as the app hasn't been restarted in between.

Closes #92 