### PR TITLE
Fix share path issues when the parent directory is a root

### DIFF
--- a/src/slskd/Application/SharedFileCache.cs
+++ b/src/slskd/Application/SharedFileCache.cs
@@ -406,11 +406,13 @@ namespace slskd
                     LocalPath = share;
                 }
 
-                Mask = Compute.MaskHash(System.IO.Directory.GetParent(LocalPath).FullName);
+                var parent = System.IO.Directory.GetParent(LocalPath).FullName.TrimEnd('/', '\\');
 
-                var maskedPath = LocalPath.ReplaceFirst(System.IO.Directory.GetParent(LocalPath).FullName, Mask);
+                Mask = Compute.MaskHash(parent);
 
-                var aliasedSegment = LocalPath[(System.IO.Directory.GetParent(LocalPath).FullName.Length + 1)..];
+                var maskedPath = LocalPath.ReplaceFirst(parent, Mask);
+
+                var aliasedSegment = LocalPath[(parent.Length + 1)..];
                 RemotePath = maskedPath.ReplaceFirst(aliasedSegment, Alias);
             }
 


### PR DESCRIPTION
Built in functions for working with paths hide a lot of ambiguous behavior and are a general pain to work with.  In this case, when using `GetParent()` to get the parent of a given directory, a string _not_ ending with a trailing slash is returned, _except_ when that path is a root:

```c#
Console.WriteLine(Directory.GetParent(@"C:\foo\bar"));
Console.WriteLine(Directory.GetParent(@"C:\foo"));
```

```
C:\foo
C:\
```

This PR adds some additional code to remove the trailing slash after using `GetParent()`.

There's also some very strange behavior when working with root paths, so those are explicitly forbidden when validating the configuration.

Addresses #200 