### PR TITLE
Changed path of logs from "exe path" to "application path"

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -225,7 +225,7 @@ namespace slskd
                     outputTemplate: (OptionsAtStartup.Debug ? "[{SourceContext}] [{SoulseekContext}] " : string.Empty) + "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
                 .WriteTo.Async(config =>
                     config.File(
-                        Path.Combine(AppContext.BaseDirectory, "logs", $"{AppName}-.log"),
+                        Path.Combine(OptionsAtStartup.Directories.App, "logs", $"{AppName}-.log"),
                         outputTemplate: (OptionsAtStartup.Debug ? "[{SourceContext}] " : string.Empty) + "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
                         rollingInterval: RollingInterval.Day))
                 .WriteTo.Conditional(


### PR DESCRIPTION
Made and tested change of path of logs. They are now placed under the application directory.

This is to very specifically fix issue #173, without changing when the directory is verified.

As written in #173: The `Program` class has a usable instance called `OptionsAtStartup`, but the directories get verified after where the logging is initiated. Should this be fixed in this same pull request?