### PR TITLE
Fix canary version detection

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -122,7 +122,7 @@ namespace slskd
         /// <summary>
         ///     Gets a value indicating whether the current version is a Canary build.
         /// </summary>
-        public static bool IsCanary { get; } = InformationalVersion.EndsWith("65534");
+        public static bool IsCanary { get; } = AssemblyVersion.Build == 65534;
 
         /// <summary>
         ///     Gets a buffer containing the last few log events.


### PR DESCRIPTION
For canary builds, the version looks like...

```
0.13.6.65534 (0.13.6.65534-9bba921)
```

The existing code is checking the informational version, `0.13.6.65534-9bba921` to see if it ends in `65534`, but it never will because of the git SHA tacked on to the end.  This PR looks instead at the final/fourth tuple of the assembly version.