### PR TITLE
Fix bug preventing SignalR hubs from connecting behind a reverse proxy

### DIFF
--- a/src/web/src/config.js
+++ b/src/web/src/config.js
@@ -1,4 +1,4 @@
-const rootUrl = process.env.NODE_ENV === 'production' ? window.location.href.split('/')[1] : 'http://localhost:5000/';
+const rootUrl = process.env.NODE_ENV === 'production' ? '' : 'http://localhost:5000/';
 const baseUrl = `${rootUrl}api/v0`;
 const tokenKey = 'slskd-token';
 const tokenPassthroughValue = 'n/a';

--- a/src/web/src/lib/hubFactory.js
+++ b/src/web/src/lib/hubFactory.js
@@ -17,6 +17,6 @@ export const createHubConnection = ({ url }) =>
     .configureLogging(LogLevel.Warning)
     .build();
 
-export const createApplicationHubConnection = () => createHubConnection({ url: `${rootUrl}/hub/application` });
+export const createApplicationHubConnection = () => createHubConnection({ url: `${rootUrl}hub/application` });
 
-export const createLogsHubConnection = () => createHubConnection({ url: `${rootUrl}/hub/logs` });
+export const createLogsHubConnection = () => createHubConnection({ url: `${rootUrl}hub/logs` });


### PR DESCRIPTION
Misplaced slashes were causing urls to be treated as absolute, rather than relative as intended.

Closes #231 