### PR TITLE
Use workstation garbage collection

### DIFF
--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -12,8 +12,7 @@
     <LangVersion>9.0</LangVersion>
     <CodeAnalysisRuleSet>Properties\analysis.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <ServerGarbageCollection>true</ServerGarbageCollection>
-    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
     <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
   </PropertyGroup>
 


### PR DESCRIPTION
The server garbage collection mode seems to perform poorly and use more overhead than the workstation mode.  I must have tested and concluded this a while ago, but it's good to test again since the framework has changed quite a bit since then.

I'm guessing the tendency of the application to create massive amounts of new objects during searches and then immediately discard them is the root of the problem, that's more consistent with a workstation type of workload than a server (I guess?).

It may be worthwhile revisiting this once things are migrated to .NET 6.