### PR TITLE
Don't send empty picture in user info response

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -755,7 +755,6 @@ namespace slskd
         {
             var info = new UserInfo(
                 description: $"Soulseek.NET Web Example! also, your username is {username}, and IP endpoint is {endpoint}",
-                picture: Array.Empty<byte>(),
                 uploadSlots: 1,
                 queueLength: 0,
                 hasFreeUploadSlot: false);


### PR DESCRIPTION
Noticed this while viewing the user info of a slskd user. Since the picture is not null, the HasPicture parameter in the user info response message is set to true: https://github.com/jpdillingham/Soulseek.NET/blob/8f5e6582aee1dc17b473a11b5b9e056abdc9564e/src/UserInfo.cs#L36