### PR TITLE
Retry button on failed downloads fails with a script error

### DIFF
--- a/src/web/src/components/Transfers/TransferGroup.js
+++ b/src/web/src/components/Transfers/TransferGroup.js
@@ -120,7 +120,7 @@ class TransferGroup extends Component {
                             icon='redo' 
                             color='green' 
                             content={`Retry${all}`} 
-                            onClick={() => this.retryAll(direction, user.username, selected)}
+                            onClick={() => this.retryAll(selected)}
                         />}
                         {allRetryable && anyCancellable && <Button.Or/>}
                         {anyCancellable && 


### PR DESCRIPTION
Clicking retry on failed download(s) does not seem to work at all for me. To reproduce:

1. Search for something to download.
2. Switch to downloads tab and watch it start.
3. Force it to fail somehow.
4. Progress says "Completed, Errored" and the progress bar is 100% red.
5. Select the failed download(s) using the checkbox and press the green retry button at bottom of the page.

This error is being logged in the browser console.

```
Uncaught (in promise) TypeError: e.map is not a function
    retryAll TransferGroup.js:54
    onClick TransferGroup.js:123
    Lodash 4
    handleClick Button.js:63
    React 12
    unstable_runWithPriority scheduler.production.min.js:19
    React 3
```

Looking at it TransferGroup->retryAll function is expecting 1 parameter but it is being called with 3. Only the 3rd parameter should be used (map of selected items).

This is untested as I am running slskd in a Docker container and can't work out how to edit the source inside it.