### PR TITLE
Don't trim while publishing

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -98,7 +98,7 @@ dotnet publish \
     --configuration Release \
     -p:PublishSingleFile=true \
     -p:ReadyToRun=true \
-    -p:PublishTrimmed=true \
+    -p:PublishTrimmed=false \
     -p:IncludeNativeLibrariesForSelfExtract=true \
     -p:CopyOutputSymbolsToPublishDirectory=false \
     -p:Version=$version \


### PR DESCRIPTION
There are a bunch of problems with trimmed libraries and .NET 6 that are causing runtime errors.  This PR disables trimming.

Unless there's a clear performance benefit to staying on .NET 6, I'll revert to .NET 5.