### PR TITLE
Adjust release trimming options

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -98,7 +98,6 @@ dotnet publish \
     --configuration Release \
     -p:PublishSingleFile=true \
     -p:ReadyToRun=true \
-    -p:PublishTrimmed=false \
     -p:IncludeNativeLibrariesForSelfExtract=true \
     -p:CopyOutputSymbolsToPublishDirectory=false \
     -p:Version=$version \

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -16,6 +16,19 @@
     <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
   </PropertyGroup>
 
+  <!-- https://docs.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options -->
+  <PropertyGroup>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>copyused</TrimMode>
+    <DebuggerSupport>false</DebuggerSupport>
+    <TrimmerRemoveSymbols>true</TrimmerRemoveSymbols>
+    <EnableUnsafeBinaryFormatterSerialization>false</EnableUnsafeBinaryFormatterSerialization>
+    <EnableUnsafeUTF7Encoding>false</EnableUnsafeUTF7Encoding>
+    <EventSourceSupport>false</EventSourceSupport>
+    <HttpActivityPropagationSupport>false</HttpActivityPropagationSupport>
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Changes in .NET 6 broke some aspects of trimming.  This should fix them.

I followed the guidance from: https://docs.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options