### PR TITLE
Add transfer buffer option

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -10,7 +10,7 @@
 #   incomplete: ~
 #   downloads: ~
 #   shared:
-#	  - ~
+#     - ~
 # filters:
 #   share:
 #     - \.ini$
@@ -28,7 +28,7 @@
 #   content_path: wwwroot
 #   logging: false
 #   authentication:
-#     disable: false
+#     disabled: false
 #     username: slskd
 #     password: slskd
 #     jwt:
@@ -54,8 +54,9 @@
 #     buffer:
 #       read: 16384
 #       write: 16384
+#       transfer: 262144
 #     proxy:
-#		enabled: false
+#       enabled: false
 #       address: ~
 #       port: ~
 #       username: ~

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -201,6 +201,13 @@ namespace slskd
                 inactivityTimeout: OptionsAtStartup.Soulseek.Connection.Timeout.Inactivity,
                 proxyOptions: proxyOptions);
 
+            var transferOptions = new ConnectionOptions(
+                readBufferSize: OptionsAtStartup.Soulseek.Connection.Buffer.Transfer,
+                writeBufferSize: OptionsAtStartup.Soulseek.Connection.Buffer.Transfer,
+                connectTimeout: OptionsAtStartup.Soulseek.Connection.Timeout.Connect,
+                inactivityTimeout: -1,
+                proxyOptions: proxyOptions);
+
             var patch = new SoulseekClientOptionsPatch(
                 listenPort: OptionsAtStartup.Soulseek.ListenPort,
                 enableListener: true,
@@ -211,7 +218,7 @@ namespace slskd
                 acceptPrivateRoomInvitations: true,
                 serverConnectionOptions: connectionOptions,
                 peerConnectionOptions: connectionOptions,
-                transferConnectionOptions: connectionOptions,
+                transferConnectionOptions: transferOptions,
                 distributedConnectionOptions: connectionOptions,
                 userInfoResponseResolver: UserInfoResponseResolver,
                 browseResponseResolver: BrowseResponseResolver,

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -534,6 +534,15 @@ namespace slskd
                     [Description("write buffer size for connections")]
                     [Range(1024, int.MaxValue)]
                     public int Write { get; private set; } = 16384;
+
+                    /// <summary>
+                    ///     Gets the read/write buffer size for transfers.
+                    /// </summary>
+                    [Argument(default, "slsk-transfer-buffer")]
+                    [EnvironmentVariable("SLSK_TRANSFER_BUFFER")]
+                    [Description("read/write buffer size for transfers")]
+                    [Range(81920, int.MaxValue)]
+                    public int Transfer { get; private set; } = 262144;
                 }
 
                 /// <summary>


### PR DESCRIPTION
Transfer speeds are sensitive to the buffer size used, which ends up being much larger than the buffer needed for other types of communication.  This PR separates the two.

Specify the transfer buffer option with:

* `--slsk-transfer-buffer` on the command line
* The `SLSKD_SLSK_TRANSFER_BUFFER` environment variable
* The `transfer` property in the yaml, under `soulseek.connection.buffer`.

The value defaults to `262144` (256 kib) and can't be set any lower than `81920` (80 kib).  

Rationale for the lower limit can be found here: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs#L122-L127 (internally, transfers are a copy of data from stream to stream.  I could be convinced that this isn't the same thing since there's a socket in between, but I don't think it is important at the moment).