### PR TITLE
Fix bug causing failed option update

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -657,8 +657,6 @@ namespace slskd
                         incomingConnectionOptions: connectionPatch,
                         distributedConnectionOptions: distributedPatch);
 
-                    Logger.Debug("Patching Soulseek options with {Patch}", patch.ToJson());
-
                     soulseekRequiresReconnect = await Client.ReconfigureOptionsAsync(patch);
                 }
 

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -633,9 +633,9 @@ namespace slskd
                         var configureKeepAlive = new Action<Socket>(socket =>
                         {
                             socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
-                            socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.TcpKeepAliveTime, connection.Timeout.Inactivity / 1000);
-                            socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.TcpKeepAliveInterval, connection.Timeout.Inactivity / 1000);
-                            socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.TcpKeepAliveRetryCount, 3);
+                            socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, connection.Timeout.Inactivity / 1000);
+                            socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, connection.Timeout.Inactivity / 1000);
+                            socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount, 3);
                         });
 
                         serverPatch = connectionPatch.With(configureSocketAction: configureKeepAlive);

--- a/src/slskd/Common/Configuration/YamlConfigurationSource.cs
+++ b/src/slskd/Common/Configuration/YamlConfigurationSource.cs
@@ -132,11 +132,6 @@ namespace slskd.Configuration
 
             if (root is YamlScalarNode scalar)
             {
-                if (Data.ContainsKey(Normalize(path)))
-                {
-                    throw new FormatException($"A duplicate key '{Normalize(path)}' was found.");
-                }
-
                 var value = NullValues.Contains(scalar.Value.ToLower()) ? null : scalar.Value;
 
                 if (value != null)


### PR DESCRIPTION
The new .NET serializer is not very forgiving, and throws on some values that are being logged when patching configuration options.  This PR removes the logging of the serialized option patch.

Also fixes a bug in socket configuration and yaml processing.