### PR TITLE
Use more secure strings for secrets

### DIFF
--- a/src/slskd/Common/Cryptography/Random.cs
+++ b/src/slskd/Common/Cryptography/Random.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="Random.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd.Cryptography
+{
+    using System.Security.Cryptography;
+
+    public static class Random
+    {
+        public static byte[] GetBytes(int size)
+        {
+            var key = new byte[size];
+            using (var generator = RandomNumberGenerator.Create())
+            {
+                generator.GetBytes(key);
+            }
+
+            return key;
+        }
+    }
+}

--- a/src/slskd/Common/Extensions.cs
+++ b/src/slskd/Common/Extensions.cs
@@ -22,7 +22,9 @@ namespace slskd
     using System.IO;
     using System.Linq;
     using System.Net.Sockets;
+    using System.Numerics;
     using System.Reflection;
+    using System.Text;
     using System.Text.Json;
     using System.Text.Json.Serialization;
     using System.Text.RegularExpressions;
@@ -282,6 +284,27 @@ namespace slskd
             }
 
             return Path.Combine(path, sanitizedFilename).TrimStart('\\').TrimStart('/');
+        }
+
+        /// <summary>
+        ///     Converts the byte array into a base 62 encoded string.
+        /// </summary>
+        /// <param name="bytes">The bytes to convert.</param>
+        /// <returns>The converted bytes as a base 62 string.</returns>
+        public static string ToBase62String(this byte[] bytes)
+        {
+            const string alphabet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+            BigInteger dividend = new BigInteger(bytes);
+            var builder = new StringBuilder();
+
+            while (dividend != 0)
+            {
+                dividend = BigInteger.DivRem(dividend, alphabet.Length, out BigInteger remainder);
+                builder.Insert(0, alphabet[Math.Abs((int)remainder)]);
+            }
+
+            return builder.ToString();
         }
 
         /// <summary>

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -801,7 +801,7 @@ namespace slskd
                     [Description("JWT signing key")]
                     [StringLength(255, MinimumLength = 16)]
                     [RequiresRestart]
-                    public string Key { get; private set; } = Guid.NewGuid().ToString();
+                    public string Key { get; private set; } = Cryptography.Random.GetBytes(16).ToBase62String();
 
                     /// <summary>
                     ///     Gets the TTL for JWTs, in milliseconds.

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -198,7 +198,7 @@ namespace slskd
 
             if (GenerateCertificate)
             {
-                GenerateX509Certificate(password: Guid.NewGuid().ToString(), filename: $"{AppName}.pfx");
+                GenerateX509Certificate(password: Cryptography.Random.GetBytes(16).ToBase62String(), filename: $"{AppName}.pfx");
                 return;
             }
 
@@ -548,7 +548,7 @@ namespace slskd
                █▄▄▄▄▄█▄▄█▄▄▄▄▄█▄▄█▄▄█▄▄▄▄▄█",
             };
 
-            var logo = logos[new Random().Next(0, logos.Length)];
+            var logo = logos[new System.Random().Next(0, logos.Length)];
 
             var banner = @$"
 {logo}


### PR DESCRIPTION
A couple of things were generating Guids to use as secrets, which are pretty random but also not very.  This PR generates an RNG byte array and then converts it to a base 62 string instead.

Closes #286 
Closes #289 