### PR TITLE
Don't escape single quotes when scanning shares

### DIFF
--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -193,7 +193,8 @@ namespace slskd.Shares
 
                 foreach (var share in Shares)
                 {
-                    Log.Information($"Share: Alias: {share.Alias} Mask: {share.Mask} Local Path: {share.LocalPath} Remote Path: {share.RemotePath} Raw: {share.Raw}");
+                    Log.Information($"Sharing {share.LocalPath} as {share.RemotePath}");
+                    Log.Debug($"Raw: {share.Raw}, Alias: {share.Alias}, Mask: {share.Mask}, Remote: {share.RemotePath})");
                 }
 
                 Log.Debug("Enumerating shared directories");
@@ -416,20 +417,6 @@ namespace slskd.Shares
             catch (Exception ex)
             {
                 Log.Warning(ex, "Failed to map shared file result: {Message}", ex.Message);
-
-                // temporarily log the share state when we hit this error, to help debug
-                foreach (var share in Shares)
-                {
-                    Log.Information($"Share: Alias: {share.Alias} Mask: {share.Mask} Local Path: {share.LocalPath} Remote Path: {share.RemotePath} Raw: {share.Raw}");
-                }
-
-                Log.Information("Sample shared file keys:");
-
-                foreach (var key in MaskedFiles.Keys.Take(10))
-                {
-                    Log.Information(key);
-                }
-
                 return Enumerable.Empty<File>();
             }
         }

--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -411,7 +411,7 @@ namespace slskd.Shares
 
             try
             {
-                return results.Select(r => MaskedFiles[r.Replace("''", "'")]).ToList();
+                return results.Select(r => MaskedFiles[r]).ToList();
             }
             catch (Exception ex)
             {
@@ -450,7 +450,8 @@ namespace slskd.Shares
 
         private void InsertFilename(string filename)
         {
-            using var cmd = new SqliteCommand($"INSERT INTO cache(filename) VALUES('{filename.Replace("'", "''")}')", SQLite);
+            using var cmd = new SqliteCommand($"INSERT INTO cache(filename) VALUES(@filename)", SQLite);
+            cmd.Parameters.AddWithValue("filename", filename);
             cmd.ExecuteNonQuery();
         }
 


### PR DESCRIPTION
The code previously replaced single quotes with two single quotes to escape them prior to inserting them into the SQLite cache, which worked but caused strings with two single quotes (e.g. 12'') to be erroneously substituted on the way out, causing errors matching results to `File` records.

This PR changes the insert to use a parameter, so no escaping is needed.

For posterity, I did try to use parameters with the query used to find matching, and it appears as though the `MATCH` clause doesn't accept them so escaping will remain there.

Closes #269 