### PR TITLE
Upload identity

### DIFF
--- a/src/web/src/components/Browse/Directory.js
+++ b/src/web/src/components/Browse/Directory.js
@@ -47,11 +47,6 @@ class Directory extends Component {
     }
   }
 
-  downloadOne = (username, file) => {
-    const { filename, size } = file;
-    return transfers.download({ username, filename, size });
-  }
-
   render = () => {
     let { username, name, locked, marginTop, onClose } = this.props;
     let { files, downloadRequest, downloadError } = this.state;

--- a/src/web/src/components/Transfers/TransferGroup.js
+++ b/src/web/src/components/Transfers/TransferGroup.js
@@ -68,7 +68,7 @@ class TransferGroup extends Component {
         const { username, filename, size } = file;
         
         try {
-            await transfers.download({username, filename, size });
+            await transfers.download({username, files: [{filename, size }] });
         } catch (error) {
             console.log(error);
         }

--- a/src/web/src/components/Transfers/TransferList.js
+++ b/src/web/src/components/Transfers/TransferList.js
@@ -31,19 +31,21 @@ const getColor = (state) => {
     }
 }
 
-const isRetryable = (state) => getColor(state).color === 'red';
+const isRetryableState = (state) => getColor(state).color === 'red';
 
 class TransferList extends Component {
     handleClick = (file) => {
-        const { state } = file;
-        
-        if (isRetryable(state)) {
-            return this.props.onRetryRequested(file);
-        }
+        const { state, direction } = file;
 
-        if (state === 'Queued') {
-            return this.props.onPlaceInQueueRequested(file);
-        }
+        if (direction === 'Download') {
+            if (isRetryableState(state)) {
+                return this.props.onRetryRequested(file);
+            }
+    
+            if (state === 'Queued') {
+                return this.props.onPlaceInQueueRequested(file);
+            }
+        }    
     }
 
     render = () => {
@@ -95,12 +97,13 @@ class TransferList extends Component {
                                         <Button 
                                             fluid 
                                             size='mini' 
-                                            style={{ margin: 0, padding: 7 }} 
+                                            style={{ margin: 0, padding: 7, cursor: f.direction === 'Upload' ? 'unset' : '' }} 
                                             {...getColor(f.state)} 
                                             onClick={() => this.handleClick(f)}
+                                            active={f.direction === 'Upload'}
                                         >
-                                            {f.state === 'Queued' && <Icon name='refresh'/>}
-                                            {isRetryable(f.state) && <Icon name='redo'/>}
+                                            {f.direction === 'Download' && f.state === 'Queued' && <Icon name='refresh'/>}
+                                            {f.direction === 'Download' && isRetryableState(f.state) && <Icon name='redo'/>}
                                             {f.state}{f.placeInQueue ? ` (#${f.placeInQueue})` : ''}
                                         </Button>}
                                     </Table.Cell>


### PR DESCRIPTION
Previously, buttons for uploads and downloads weren't treated differently, and they should have been.  Clicking the button of an upload would cause the code to attempt to download that file from the requesting user.

This PR prevents the buttons associated with uploads from doing anything when clicked (as there is nothing that can be done, other than cancel, and there's already a mechanism for that), and tweaks the UI to make them appear more like status indicators rather than buttons (removes cursor, removes mouseover effects)

Closes #260
Closes #306 