### PR TITLE
Bump dependencies, including Soulseek.NET to 4.0.0

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -259,10 +259,10 @@ namespace slskd
                 peerConnectionOptions: connectionOptions,
                 transferConnectionOptions: transferOptions,
                 distributedConnectionOptions: distributedOptions,
-                userInfoResponseResolver: UserInfoResponseResolver,
+                userInfoResolver: UserInfoResolver,
                 browseResponseResolver: BrowseResponseResolver,
-                directoryContentsResponseResolver: DirectoryContentsResponseResolver,
-                enqueueDownloadAction: (username, endpoint, filename) => EnqueueDownloadAction(username, endpoint, filename, TransferTracker),
+                directoryContentsResolver: DirectoryContentsResponseResolver,
+                enqueueDownload: (username, endpoint, filename) => EnqueueDownloadAction(username, endpoint, filename, TransferTracker),
                 searchResponseCache: new SearchResponseCache(),
                 searchResponseResolver: SearchResponseResolver);
 
@@ -550,7 +550,7 @@ namespace slskd
             Task.Run(async () =>
             {
                 using var stream = new FileStream(fileInfo.FullName, FileMode.Open, FileAccess.Read);
-                await Client.UploadAsync(username, filename, fileInfo.Length, stream, options: topts, cancellationToken: cts.Token);
+                await Client.UploadAsync(username, filename, fileInfo.FullName, options: topts, cancellationToken: cts.Token);
             }).ContinueWith(t =>
             {
                 Console.WriteLine($"[UPLOAD FAILED] {t.Exception}");
@@ -815,7 +815,7 @@ namespace slskd
         /// <param name="username">The username of the requesting user.</param>
         /// <param name="endpoint">The IP endpoint of the requesting user.</param>
         /// <returns>A Task resolving the UserInfo instance.</returns>
-        private Task<UserInfo> UserInfoResponseResolver(string username, IPEndPoint endpoint)
+        private Task<UserInfo> UserInfoResolver(string username, IPEndPoint endpoint)
         {
             var info = new UserInfo(
                 description: $"Soulseek.NET Web Example! also, your username is {username}, and IP endpoint is {endpoint}",

--- a/src/slskd/Common/Extensions.cs
+++ b/src/slskd/Common/Extensions.cs
@@ -350,7 +350,8 @@ namespace slskd
                 writeQueueSize: writeQueueSize ?? o.WriteQueueSize,
                 connectTimeout: connectTimeout ?? o.ConnectTimeout,
                 inactivityTimeout: inactivityTimeout ?? o.InactivityTimeout,
-                configureSocketAction: configureSocketAction ?? o.ConfigureSocketAction);
+                proxyOptions: proxyOptions ?? o.ProxyOptions,
+                configureSocket: configureSocketAction ?? o.ConfigureSocket);
 
         /// <summary>
         ///     Deserializes this string from json to an object of type <typeparamref name="T"/>.

--- a/src/slskd/Transfers/API/Controllers/TransfersController.cs
+++ b/src/slskd/Transfers/API/Controllers/TransfersController.cs
@@ -132,13 +132,11 @@ namespace slskd.Transfers.API
                     Log.Debug("Attempting to enqueue {Filename} from user {Username}", request.Filename, username);
 
                     var waitUntilEnqueue = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                    var stream = GetLocalFileStream(request.Filename, Options.Directories.Incomplete);
-
                     var cts = new CancellationTokenSource();
 
                     var downloadTask = Task.Run(async () =>
                     {
-                        await Client.DownloadAsync(username, request.Filename, stream, request.Size, 0, request.Token, new TransferOptions(disposeOutputStreamOnCompletion: true, stateChanged: (e) =>
+                        await Client.DownloadAsync(username, request.Filename, () => GetLocalFileStream(request.Filename, Options.Directories.Incomplete), request.Size, 0, request.Token, new TransferOptions(disposeOutputStreamOnCompletion: true, stateChanged: (e) =>
                         {
                             Tracker.AddOrUpdate(e, cts);
 

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -43,7 +43,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="FluentFTP" Version="35.2.2" />
+    <PackageReference Include="FluentFTP" Version="35.2.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
@@ -69,7 +69,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Soulseek" Version="3.4.1" />
+    <PackageReference Include="Soulseek" Version="4.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Note that there's a new option in Soulseek.NET, `MaximumConcurrentUploads`, which defaults to 10 and for which there is no option in slskd, so the canary that is built from this merge commit will be stuck at 10.

I'll have a fast-follow PR to add the option to slskd settings.