### PR TITLE
Add option to set a limit for total number of upload slots

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -11,16 +11,9 @@
 #   downloads: ~
 #   shared:
 #     - ~
-# queues:
-#   default:
-#     strategy: roundrobin
-#     slots: 10
-#     priority: true
-#   custom:
-#     my_custom_fifo_queue:
-#       strategy: firstinfirstout
-#       slots: 5
-#       priority: true
+# limits:
+#   queue:
+#     slots: 20
 # filters:
 #   share:
 #     - \.ini$

--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -11,6 +11,16 @@
 #   downloads: ~
 #   shared:
 #     - ~
+# queues:
+#   default:
+#     strategy: roundrobin
+#     slots: 10
+#     priority: true
+#   custom:
+#     my_custom_fifo_queue:
+#       strategy: firstinfirstout
+#       slots: 5
+#       priority: true
 # filters:
 #   share:
 #     - \.ini$

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -601,13 +601,6 @@ namespace slskd
                     Log.Information("Shared directory configuration changed.  Shares must be re-scanned for changes to take effect.");
                 }
 
-                var removedQueues = PreviousOptions.Queues.Custom.Keys.Where(key => !newOptions.Queues.Custom.ContainsKey(key));
-                if (removedQueues.Any())
-                {
-                    Log.Information("Custom queue(s) {Queues} removed or renamed. Restart required to take effect.", string.Join(", ", removedQueues));
-                    pendingRestart = true;
-                }
-
                 if (PreviousOptions.Filters.Share.Except(newOptions.Filters.Share).Any()
                     || newOptions.Filters.Share.Except(PreviousOptions.Filters.Share).Any())
                 {

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -615,6 +615,8 @@ namespace slskd
                     _ = RoomService.TryJoinAsync(newOptions.Rooms);
                 }
 
+                // todo: determine if any custom queues were deleted, and require a restart if so
+
                 // determine whether any Soulseek options changed. if so, we need to construct a patch and invoke ReconfigureOptionsAsync().
                 var slskDiff = PreviousOptions.Soulseek.DiffWith(newOptions.Soulseek);
 

--- a/src/slskd/Common/Configuration/YamlConfigurationSource.cs
+++ b/src/slskd/Common/Configuration/YamlConfigurationSource.cs
@@ -109,6 +109,11 @@ namespace slskd.Configuration
         {
             try
             {
+                // clear the data collection before we populate
+                // not doing this will cause array and dictionary keys
+                // to get "stuck"
+                Data.Clear();
+
                 using var reader = new StreamReader(stream);
 
                 var yaml = new YamlStream();

--- a/src/slskd/Common/Configuration/YamlConfigurationSource.cs
+++ b/src/slskd/Common/Configuration/YamlConfigurationSource.cs
@@ -111,7 +111,7 @@ namespace slskd.Configuration
             {
                 // clear the data collection before we populate
                 // not doing this will cause array and dictionary keys
-                // to get "stuck"
+                // to get "stuck" when the config is reloaded
                 Data.Clear();
 
                 using var reader = new StreamReader(stream);

--- a/src/slskd/Common/Extensions.cs
+++ b/src/slskd/Common/Extensions.cs
@@ -60,7 +60,7 @@ namespace slskd
                 var propType = prop.PropertyType;
                 var fqn = string.IsNullOrEmpty(parentFqn) ? prop.Name : string.Join(".", parentFqn, prop.Name);
 
-                if (propType.IsArray)
+                if (propType.IsArray || (propType.IsGenericType && propType.GetGenericTypeDefinition() == typeof(Dictionary<,>)))
                 {
                     if (leftVal.ToJson() != rightVal.ToJson())
                     {

--- a/src/slskd/Common/QueueStrategy.cs
+++ b/src/slskd/Common/QueueStrategy.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="QueueStrategy.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd
+{
+    /// <summary>
+    ///     Queue strategies.
+    /// </summary>
+    public enum QueueStrategy
+    {
+        /// <summary>
+        ///     Uploads are prioritized based on the time they became ready.
+        /// </summary>
+        RoundRobin = 0,
+
+        /// <summary>
+        ///     Uploads are prioritized based on the time they were enqueued.
+        /// </summary>
+        FirstInFirstOut = 1,
+    }
+}

--- a/src/slskd/Common/Validation/ValidateAttribute.cs
+++ b/src/slskd/Common/Validation/ValidateAttribute.cs
@@ -27,6 +27,11 @@ namespace slskd.Validation
     {
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
         {
+            if (value == null)
+            {
+                return ValidationResult.Success;
+            }
+
             var results = new List<ValidationResult>();
             var context = new ValidationContext(value, null, null);
 

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -408,7 +408,7 @@ namespace slskd
                 [Description("the limit for the total number of queue slots")]
                 [RequiresRestart]
                 [Range(1, int.MaxValue)]
-                public int Slots { get; init; } = 20;
+                public int Slots { get; init; } = 10;
             }
         }
 

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -387,11 +387,11 @@ namespace slskd
         public class QueuesOptions : IValidatableObject
         {
             [Validate]
-            public QueueOptions Default { get; init; } = new QueueOptions();
+            public DefaultQueueOptions Default { get; init; } = new DefaultQueueOptions();
 
             [Validate]
             [RequiresRestart]
-            public Dictionary<string, QueueOptions> Custom { get; init; } = new Dictionary<string, QueueOptions>();
+            public Dictionary<string, CustomQueueOptions> Custom { get; init; } = new Dictionary<string, CustomQueueOptions>();
 
             /// <summary>
             ///     Extended validation.
@@ -428,7 +428,22 @@ namespace slskd
                 return validationResults;
             }
 
-            public class QueueOptions
+            public class DefaultQueueOptions
+            {
+                [Argument(default, "queue-strategy")]
+                [Enum(typeof(QueueStrategy))]
+                public string Strategy { get; init; } = "roundrobin";
+
+                [Argument(default, "queue-slots")]
+                [RequiresRestart]
+                [Range(1, int.MaxValue)]
+                public int Slots { get; init; } = 10;
+
+                [Argument(default, "disable-queue-priorty")]
+                public bool DisablePriority { get; init; } = false;
+            }
+
+            public class CustomQueueOptions
             {
                 [Enum(typeof(QueueStrategy))]
                 public string Strategy { get; init; } = "roundrobin";
@@ -437,7 +452,7 @@ namespace slskd
                 [Range(1, int.MaxValue)]
                 public int Slots { get; init; } = 10;
 
-                public bool Priority { get; init; } = true;
+                public bool DisablePriority { get; init; } = false;
             }
         }
 

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -390,6 +390,7 @@ namespace slskd
             public QueueOptions Default { get; init; } = new QueueOptions();
 
             [Validate]
+            [RequiresRestart]
             public Dictionary<string, QueueOptions> Custom { get; init; } = new Dictionary<string, QueueOptions>();
 
             /// <summary>
@@ -432,6 +433,7 @@ namespace slskd
                 [Enum(typeof(QueueStrategy))]
                 public string Strategy { get; init; } = "roundrobin";
 
+                [RequiresRestart]
                 [Range(1, int.MaxValue)]
                 public int Slots { get; init; } = 10;
 

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -228,10 +228,10 @@ namespace slskd
         public DirectoriesOptions Directories { get; init; } = new DirectoriesOptions();
 
         /// <summary>
-        ///     Gets queue options.
+        ///     Gets limits.
         /// </summary>
         [Validate]
-        public QueuesOptions Queues { get; init; } = new QueuesOptions();
+        public LimitsOptions Limits { get; init; } = new LimitsOptions();
 
         /// <summary>
         ///     Gets filter options.
@@ -384,72 +384,31 @@ namespace slskd
             }
         }
 
-        public class QueuesOptions : IValidatableObject
+        /// <summary>
+        ///     Limits.
+        /// </summary>
+        public class LimitsOptions
         {
+            /// <summary>
+            ///     Gets queue limits.
+            /// </summary>
             [Validate]
-            public DefaultQueueOptions Default { get; init; } = new DefaultQueueOptions();
-
-            [Validate]
-            public Dictionary<string, CustomQueueOptions> Custom { get; init; } = new Dictionary<string, CustomQueueOptions>();
+            public LimitsQueueOptions Queue { get; init; } = new LimitsQueueOptions();
 
             /// <summary>
-            ///     Extended validation.
+            ///     Queue limits.
             /// </summary>
-            /// <param name="validationContext"></param>
-            /// <returns></returns>
-            public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+            public class LimitsQueueOptions
             {
-                var validationResults = new List<ValidationResult>();
-
-                var customResults = new CompositeValidationResult("Custom");
-
-                foreach (var (key, value) in Custom)
-                {
-                    var results = new List<ValidationResult>();
-                    var context = new ValidationContext(value, null, null);
-
-                    Validator.TryValidateObject(value, context, results, true);
-
-                    if (results.Count != 0)
-                    {
-                        var keyResults = new CompositeValidationResult(key);
-                        results.ForEach(keyResults.AddResult);
-
-                        customResults.AddResult(keyResults);
-                    }
-                }
-
-                if (customResults.Results.Any())
-                {
-                    validationResults.Add(customResults);
-                }
-
-                return validationResults;
-            }
-
-            public class DefaultQueueOptions
-            {
-                [Argument(default, "queue-strategy")]
-                [Enum(typeof(QueueStrategy))]
-                public string Strategy { get; init; } = "roundrobin";
-
-                [Argument(default, "queue-slots")]
+                /// <summary>
+                ///     Gets the limit for the total number of queue slots.
+                /// </summary>
+                [Argument(default, "queue-slot-limit")]
+                [EnvironmentVariable("QUEUE_SLOT_LIMIT")]
+                [Description("the limit for the total number of queue slots")]
+                [RequiresRestart]
                 [Range(1, int.MaxValue)]
-                public int Slots { get; init; } = 10;
-
-                [Argument(default, "disable-queue-priorty")]
-                public bool DisablePriority { get; init; } = false;
-            }
-
-            public class CustomQueueOptions
-            {
-                [Enum(typeof(QueueStrategy))]
-                public string Strategy { get; init; } = "roundrobin";
-
-                [Range(1, int.MaxValue)]
-                public int Slots { get; init; } = 10;
-
-                public bool DisablePriority { get; init; } = false;
+                public int Slots { get; init; } = 20;
             }
         }
 

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -390,7 +390,6 @@ namespace slskd
             public DefaultQueueOptions Default { get; init; } = new DefaultQueueOptions();
 
             [Validate]
-            [RequiresRestart]
             public Dictionary<string, CustomQueueOptions> Custom { get; init; } = new Dictionary<string, CustomQueueOptions>();
 
             /// <summary>

--- a/src/slskd/Options.cs
+++ b/src/slskd/Options.cs
@@ -435,7 +435,6 @@ namespace slskd
                 public string Strategy { get; init; } = "roundrobin";
 
                 [Argument(default, "queue-slots")]
-                [RequiresRestart]
                 [Range(1, int.MaxValue)]
                 public int Slots { get; init; } = 10;
 
@@ -448,7 +447,6 @@ namespace slskd
                 [Enum(typeof(QueueStrategy))]
                 public string Strategy { get; init; } = "roundrobin";
 
-                [RequiresRestart]
                 [Range(1, int.MaxValue)]
                 public int Slots { get; init; } = 10;
 

--- a/src/slskd/Startup.cs
+++ b/src/slskd/Startup.cs
@@ -234,7 +234,9 @@ namespace slskd
             // add a partially configured instance of SoulseekClient. the Application instance will
             // complete configuration at startup.
             services.AddSingleton<ISoulseekClient, SoulseekClient>(_ =>
-                new SoulseekClient(options: new SoulseekClientOptions(minimumDiagnosticLevel: OptionsAtStartup.Soulseek.DiagnosticLevel)));
+                new SoulseekClient(options: new SoulseekClientOptions(
+                    maximumConcurrentUploads: OptionsAtStartup.Limits.Queue.Slots,
+                    minimumDiagnosticLevel: OptionsAtStartup.Soulseek.DiagnosticLevel)));
 
             // add the core application service to DI as well as a hosted service so that other services can
             // access instance methods


### PR DESCRIPTION
Related to #127, but there's still a bunch of additional work to do.

I started to add individual queues and user lists in this PR but I need to spend more time on it, and this part was ready now.  I'm leaving some of the stuff that was added for queue config in, and will follow up soon.

I'm not going to update the configuration docs just yet because I'm not sure I am happy with where this is implemented, but for the time being it can be set in the yaml with:

```yaml
limits:
  queue:
    slots: 10
```

Via the command line with `--queue-slot-limit` or environment variable with `SLSKD_QUEUE_SLOT_LIMIT`