### PR TITLE
Bump Soulseek.NET to 4.4.2

### DIFF
--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -69,7 +69,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Soulseek" Version="4.4.0" />
+    <PackageReference Include="Soulseek" Version="4.4.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Fixes a critical bug limiting downloads to one at a time.