### PR TITLE
Remove EXPOSE instruction from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,6 @@ ENV DOTNET_BUNDLE_EXTRACT_BASE_DIR=/var/tmp/.net \
     SLSKD_DOCKER_REVISON=$REVISION \
     SLSKD_DOCKER_BUILD_DATE=$BUILD_DATE
 
-EXPOSE 5000 5001 50000
-
 VOLUME /app
 
 HEALTHCHECK --interval=60s --timeout=3s --start-period=5s --retries=3 CMD wget -q -O - http://localhost:5000/health


### PR DESCRIPTION
Testing whether removing this instruction makes any difference in Unraid.  Because ports are user-configurable, it maybe doesn't make sense to expose them, anyway, as the exposed ports won't change according to the configuration and can cause confusion.

Related to #365 