### PR TITLE
Pass credentials to signalr hub negotiation when auth is disabled

### DIFF
--- a/src/web/src/lib/api.js
+++ b/src/web/src/lib/api.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { baseUrl, tokenPassthroughValue } from '../config';
+import { baseUrl } from '../config';
 import * as session from './session';
 
 axios.defaults.baseURL = baseUrl;
@@ -13,7 +13,7 @@ api.interceptors.request.use(config => {
 
     config.headers['Content-Type'] = 'application/json';
 
-    if (token && token !== tokenPassthroughValue) {
+    if (!session.isPassthroughEnabled() && token) {
         config.headers.Authorization = 'Bearer ' + token;
     }
 

--- a/src/web/src/lib/hubFactory.js
+++ b/src/web/src/lib/hubFactory.js
@@ -10,7 +10,8 @@ import * as session from '../lib/session';
 export const createHubConnection = ({ url }) => 
   new HubConnectionBuilder()
     .withUrl(url, {
-        accessTokenFactory: session.getToken
+        withCredentials: true,
+        accessTokenFactory: session.isPassthroughEnabled() ? undefined : session.getToken
     })
     .withAutomaticReconnect([0, 500, 1000, 3000, 5000, 5000, 5000, 5000, 5000])
     .withHubProtocol(new JsonHubProtocol())


### PR DESCRIPTION
Enables operation behind a reverse proxy implementing basic auth.  It should work for other schemes like cookies also.

Closes #339 