### PR TITLE
Use configured listen port for health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,6 @@ ENV DOTNET_BUNDLE_EXTRACT_BASE_DIR=/var/tmp/.net \
 
 VOLUME /app
 
-HEALTHCHECK --interval=60s --timeout=3s --start-period=5s --retries=3 CMD wget -q -O - http://localhost:5000/health
+HEALTHCHECK --interval=60s --timeout=3s --start-period=5s --retries=3 CMD wget -q -O - http://localhost:${SLSKD_HTTP_PORT}/health
 
 ENTRYPOINT ["./slskd"]


### PR DESCRIPTION
When running the container with a listen port other than 5000 (e.g. `-e SLSKD_HTTP_PORT=6000`), the health check fails:

```
docker inspect --format "{{json .State.Health }}" slskd | jq
{
  "Status": "unhealthy",
  "FailingStreak": 1,
  "Log": [
    {
      "Start": "2022-03-03T18:39:40.946050619-06:00",
      "End": "2022-03-03T18:39:43.948265446-06:00",
      "ExitCode": -1,
      "Output": "Health check exceeded timeout (3s)"
    }
  ]
}
```

This PR updates the health check to use the `SLSKD_HTTP_PORT` environment variable when making health checks.

```
docker inspect --format "{{json .State.Health }}" slskd | jq
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2022-03-03T18:43:50.040169257-06:00",
      "End": "2022-03-03T18:43:50.284567916-06:00",
      "ExitCode": 0,
      "Output": "Healthy"
    }
  ]
}
```

Closes #324