### PR TITLE
Add 'islossless' search filter, improve handling of 'isvbr' and 'iscbr'

### DIFF
--- a/src/web/src/components/Search/Search.js
+++ b/src/web/src/components/Search/Search.js
@@ -262,7 +262,7 @@ class Search extends Component {
                 </div>
                 <Input 
                   className='search-filter'
-                  placeholder='lackluster container -bothersome iscbr|isvbr minbitrate:320 minfilesize:10 minfilesinfolder:8 minlength:5000'
+                  placeholder='lackluster container -bothersome iscbr|isvbr islossless minbitrate:320 minfilesize:10 minfilesinfolder:8 minlength:5000'
                   label={{ icon: 'filter', content: 'Filter' }}
                   value={resultFilters}
                   onChange={this.onResultFilterChange}


### PR DESCRIPTION
Filtering search results with the `islossless` keyword will now hide any results lacking the sample rate or bit depth attributes, which are only included for lossless formats.  Filtering with `islossy` will hide these files and show all others.

Search results have a dedicated flag to determine whether a file is VBR, or not.  The logic behind `isvbr` and `iscbr` has been changed from guessing about this based on the file bitrate, to looking at this flag directly.  If a file says it is VBR, it is included when filtering with `isvbr`.  If a file says it is _not_ VBR (by setting the flag to 0/false), it is included when filtering with `iscbr`.  If the VBR flag is missing entirely, the file is not included when using either filter.  Soulseek Qt does not send this flag any longer, so these filters should probably be considered deprecated.

Closes #398