### PR TITLE
Disambiguate transfer size when less than 1 MB has been transferred

### DIFF
--- a/src/web/src/components/Transfers/TransferList.js
+++ b/src/web/src/components/Transfers/TransferList.js
@@ -40,9 +40,20 @@ const formatBytesTransferred = ({ transferred, size }) => {
     const [t, tExt] = formatBytes(transferred).split(' ')
     const [s, sExt] = formatBytes(size).split(' ')
 
-    // include the size label for transferred if it differs from size
-    // e.g. 12 KB/3 MB => 2.9/3 MB
-    return `${t}${tExt === sExt ? '' : ' ' + tExt}/${s} ${sExt}`
+    const fmt = (n) => parseFloat(n).toFixed(2);
+
+    // if less than 1 MB has been transferred, don't include decimals
+    if (tExt === 'KB') {
+        return `${t} KB/${fmt(s)} ${sExt}`
+    }
+
+    // if the suffix for size and transferred doesn't match, include
+    // the suffix for each
+    if (tExt !== sExt) {
+        return `${fmt(t)} ${tExt}/${fmt(s)} ${sExt}`
+    }
+
+    return `${fmt(t)}/${fmt(s)} ${sExt}`
 }
 
 class TransferList extends Component {

--- a/src/web/src/components/Transfers/TransferList.js
+++ b/src/web/src/components/Transfers/TransferList.js
@@ -36,6 +36,15 @@ const getColor = (state) => {
 const isRetryableState = (state) => getColor(state).color === 'red';
 const isQueuedState = (state) => state.includes('Queued');
 
+const formatBytesTransferred = ({ transferred, size }) => {
+    const [t, tExt] = formatBytes(transferred).split(' ')
+    const [s, sExt] = formatBytes(size).split(' ')
+
+    // include the size label for transferred if it differs from size
+    // e.g. 12 KB/3 MB => 2.9/3 MB
+    return `${t}${tExt === sExt ? '' : ' ' + tExt}/${s} ${sExt}`
+}
+
 class TransferList extends Component {
     handleClick = (file) => {
         const { state, direction } = file;
@@ -111,7 +120,7 @@ class TransferList extends Component {
                                         </Button>}
                                     </Table.Cell>
                                     <Table.Cell className='transferlist-size'>
-                                        {f.bytesTransferred > 0 ? formatBytes(f.bytesTransferred).split(' ', 1) + '/' + formatBytes(f.size) : ''}
+                                        {f.bytesTransferred > 0 ? formatBytesTransferred({ transferred: f.bytesTransferred, size: f.size }) : ''}
                                     </Table.Cell>
                                 </Table.Row>
                             )}

--- a/src/web/src/lib/util.js
+++ b/src/web/src/lib/util.js
@@ -42,10 +42,10 @@ export const formatAttributes = ({ bitRate, isVariableBitRate, bitDepth, sampleR
     }
 
     if (isVariableBitRate) {
-        return `${bitRate}kbps, VBR`
+        return `${bitRate} Kbps, VBR`
     }
 
-    return bitRate ? `${bitRate}kbps` : ''
+    return bitRate ? `${bitRate} Kbps` : ''
 }
 
 /* https://www.npmjs.com/package/js-file-download


### PR DESCRIPTION
Also changes `kbps` to `Kbps` to make size and bitrate labels consistent.

Closes #421 