### PR TITLE
Improve Docker caching in CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,14 +164,14 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        - name: Move cache
-          if: 
-          run: |
-            rm -rf /tmp/.buildx-cache
-            mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        if: 
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   release:
     name: Create Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
             ghcr.io/slskd/slskd:${{ env.VERSION }}
             ghcr.io/slskd/slskd:canary
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
       - name: Build and push Release
         if: startsWith(github.ref, 'refs/tags/')
@@ -162,7 +162,16 @@ jobs:
             ghcr.io/slskd/slskd:canary
             ghcr.io/slskd/slskd:latest
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        - name: Move cache
+          if: 
+          run: |
+            rm -rf /tmp/.buildx-cache
+            mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   release:
     name: Create Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,27 @@ ARG VERSION=0.0.1.65534-local
 ARG REVISION=0
 ARG BUILD_DATE
 
+RUN apt-get update && apt-get install -y \
+  wget \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN bash -c 'mkdir -p /app/{incomplete,downloads} \ 
+  && chmod -R 777 /app'
+
+VOLUME /app
+
+HEALTHCHECK --interval=60s --timeout=3s --start-period=5s --retries=3 CMD wget -q -O - http://localhost:${SLSKD_HTTP_PORT}/health
+
+ENV DOTNET_BUNDLE_EXTRACT_BASE_DIR=/var/tmp/.net \
+  SLSKD_HTTP_PORT=5000 \
+  SLSKD_HTTPS_PORT=5001 \
+  SLSKD_SLSK_LISTEN_PORT=50000 \
+  SLSKD_APP_DIR=/app \
+  SLSKD_DOCKER_TAG=$TAG \
+  SLSKD_DOCKER_VERSION=$VERSION \
+  SLSKD_DOCKER_REVISON=$REVISION \
+  SLSKD_DOCKER_BUILD_DATE=$BUILD_DATE
+
 LABEL org.opencontainers.image.title=slskd \
   org.opencontainers.image.description="A modern client-server application for the Soulseek file sharing network" \
   org.opencontainers.image.authors="slskd Team" \
@@ -50,28 +71,7 @@ LABEL org.opencontainers.image.title=slskd \
   org.opencontainers.image.revision=$REVISION \
   org.opencontainers.image.created=$BUILD_DATE
 
-RUN apt-get update && apt-get install -y \
-  wget \
-  && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /slskd
 COPY --from=publish /slskd/dist/${TARGETPLATFORM} .
-
-RUN bash -c 'mkdir -p /app/{incomplete,downloads} \ 
-  && chmod -R 777 /app'
-
-ENV DOTNET_BUNDLE_EXTRACT_BASE_DIR=/var/tmp/.net \
-  SLSKD_HTTP_PORT=5000 \
-  SLSKD_HTTPS_PORT=5001 \
-  SLSKD_SLSK_LISTEN_PORT=50000 \
-  SLSKD_APP_DIR=/app \
-  SLSKD_DOCKER_TAG=$TAG \
-  SLSKD_DOCKER_VERSION=$VERSION \
-  SLSKD_DOCKER_REVISON=$REVISION \
-  SLSKD_DOCKER_BUILD_DATE=$BUILD_DATE
-
-VOLUME /app
-
-HEALTHCHECK --interval=60s --timeout=3s --start-period=5s --retries=3 CMD wget -q -O - http://localhost:${SLSKD_HTTP_PORT}/health
 
 ENTRYPOINT ["./slskd"]


### PR DESCRIPTION
Reorders some directives in the Dockerfile to _maybe_ allow one or two additional layers to be cached (probably does nothing, but we'll see!)

Tweaks the buildx cache configuration to follow guidance from the build-push-action repo, here: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md