### PR TITLE
Fix bug preventing routes with more than one segment from working

### DIFF
--- a/src/slskd/Core/API/Controllers/ApplicationController.cs
+++ b/src/slskd/Core/API/Controllers/ApplicationController.cs
@@ -15,6 +15,8 @@
 //     along with this program.  If not, see https://www.gnu.org/licenses/.
 // </copyright>
 
+using Microsoft.Extensions.Options;
+
 namespace slskd.Core.API
 {
     using System;
@@ -37,15 +39,18 @@ namespace slskd.Core.API
         public ApplicationController(
             IHostApplicationLifetime lifetime,
             IApplication application,
+            IOptionsMonitor<Options> optionsMonitor,
             IStateMonitor<State> applicationStateMonitor)
         {
             Lifetime = lifetime;
             Application = application;
+            OptionsMonitor = optionsMonitor;
             ApplicationStateMonitor = applicationStateMonitor;
         }
 
         private IApplication Application { get; }
         private IStateMonitor<State> ApplicationStateMonitor { get; }
+        private IOptionsMonitor<Options> OptionsMonitor { get; }
         private IHostApplicationLifetime Lifetime { get; }
 
         /// <summary>
@@ -145,6 +150,12 @@ namespace slskd.Core.API
             _ = Application.RescanSharesAsync();
 
             return Ok();
+        }
+
+        [HttpGet("urlbase")]
+        public IActionResult GetUrlBase()
+        {
+            return Ok(OptionsMonitor.CurrentValue.Web.UrlBase);
         }
     }
 }

--- a/src/web/src/components/System/System.js
+++ b/src/web/src/components/System/System.js
@@ -1,24 +1,35 @@
-import React, { Component } from 'react';
+import React from 'react';
+import { useRouteMatch } from "react-router-dom";
+
 import { Segment, Tab } from 'semantic-ui-react';
+
 import './System.css';
+
 import Info from './Info';
 import Logs from './Logs';
 import Options from './Options';
 
-class System extends Component {
-  render = () => {
-    return (
-      <div className='system'>
-        <Segment raised>
-          <Tab panes={[
-            { menuItem: 'Info', render: () => <Tab.Pane><Info state={this.props.state}/></Tab.Pane> },
-            { menuItem: 'Options', render: () => <Tab.Pane className='full-height'><Options options={this.props.options}/></Tab.Pane> },
-            { menuItem: 'Logs', render: () => <Tab.Pane><Logs/></Tab.Pane> },
-          ]}/>
-        </Segment>
-      </div>
-    );
-  }
-}
+const System = ({ state = {}, options = {} }) => {
+  const { params: { tab }} = useRouteMatch();
+
+  const panes = [
+    { route: 'info', menuItem: 'Info', render: () => <Tab.Pane><Info state={state}/></Tab.Pane> },
+    { route: 'options', menuItem: 'Options', render: () => <Tab.Pane className='full-height'><Options options={options}/></Tab.Pane> },
+    { route: 'logs', menuItem: 'Logs', render: () => <Tab.Pane><Logs/></Tab.Pane> },
+  ]
+
+  const activeIndex = panes.findIndex(pane => pane.route === tab)
+
+  return (
+    <div className='system'>
+      <Segment raised>
+        <Tab
+          activeIndex={activeIndex > -1 ? activeIndex : 0} 
+          panes={panes}
+        />
+      </Segment>
+    </div>
+  );
+};
 
 export default System;

--- a/src/web/src/components/System/System.js
+++ b/src/web/src/components/System/System.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useRouteMatch } from "react-router-dom";
+import { useRouteMatch, useHistory, Redirect } from "react-router-dom";
 
 import { Segment, Tab } from 'semantic-ui-react';
 
@@ -10,7 +10,8 @@ import Logs from './Logs';
 import Options from './Options';
 
 const System = ({ state = {}, options = {} }) => {
-  const { params: { tab }} = useRouteMatch();
+  const { params: { tab }, ...route } = useRouteMatch();
+  const history = useHistory();
 
   const panes = [
     { route: 'info', menuItem: 'Info', render: () => <Tab.Pane><Info state={state}/></Tab.Pane> },
@@ -20,12 +21,21 @@ const System = ({ state = {}, options = {} }) => {
 
   const activeIndex = panes.findIndex(pane => pane.route === tab)
 
+  const onTabChange = (e, { activeIndex }) => {
+    history.push(panes[activeIndex].route)
+  }
+
+  if (tab === undefined) {
+    return <Redirect to={`${route.url}/${panes[0].route}`}/>
+  }
+
   return (
     <div className='system'>
       <Segment raised>
         <Tab
           activeIndex={activeIndex > -1 ? activeIndex : 0} 
           panes={panes}
+          onTabChange={onTabChange}
         />
       </Segment>
     </div>

--- a/src/web/src/lib/application.js
+++ b/src/web/src/lib/application.js
@@ -4,6 +4,10 @@ export const getState = async () => {
   return (await api.get('/application')).data;
 };
 
+export const getUrlBase = async () => {
+  return (await api.get('/application/urlbase')).data;
+}
+
 export const restart = async () => {
   return api.put('/application');
 };


### PR DESCRIPTION
I have been working on searches and fighting with this for the last two days.  The conclusion is that the UI can't operate properly behind a reverse proxy (when `url_base` is set) if it doesn't explicitly know which part of the current url is `url_base`.  There may be a clever way to deduce this that I'm missing, but for now I've added an unauthenticated endpoint `GET /urlbase` that allows the UI to explicitly fetch this when the `App` component is loading.  This allows it to explicitly prefix routes properly.

As a test I've implemented #441 and it works locally, but we'll see once I get it deployed.