### PR TITLE
Replace headers on rewritten HTML responses

### DIFF
--- a/src/slskd/Common/Middleware/HTMLRewriteMiddleware.cs
+++ b/src/slskd/Common/Middleware/HTMLRewriteMiddleware.cs
@@ -74,15 +74,13 @@ namespace slskd
         {
             context.Request.Headers.TryGetValue("accept", out var accept);
             var requestedTypes = accept.ToString().Split(',');
-
-            var rewriteableType = new[] { "text/html", "application/xhtml + xml", "application/xml" };
+            var injectableTypes = new[] { "text/html", "application/xhtml + xml", "application/xml" };
+            var isRewriteableType = requestedTypes
+                .Intersect(injectableTypes, StringComparer.InvariantCultureIgnoreCase)
+                .Any();
 
             var isApiRoute = context.Request.Path.ToString().StartsWith("/api");
             var isGET = context.Request.Method == "GET";
-
-            var isRewriteableType = requestedTypes
-                .Intersect(rewriteableType, StringComparer.InvariantCultureIgnoreCase)
-                .Any();
 
             if (!isApiRoute && isGET && isRewriteableType)
             {
@@ -98,11 +96,20 @@ namespace slskd
                 if (context.Response.StatusCode == 200)
                 {
                     // something downstream responded with a 200, meaning there's data in the body
-                    // we need to read it, so we can reset then play it back with the appended HTML
+                    // we need to read it, so we can reset then play it back with the modified HTML
                     context.Response.Body.Seek(0, SeekOrigin.Begin);
                     var body = await new StreamReader(context.Response.Body).ReadToEndAsync();
 
+                    var headers = context.Response.Headers
+                        .ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
+                        .Where(kvp => !string.Equals(kvp.Key, "Content-Length", StringComparison.InvariantCultureIgnoreCase));
+
                     context.Response.Clear();
+
+                    foreach (var header in headers)
+                    {
+                        context.Response.Headers.Add(header);
+                    }
 
                     await context.Response.WriteAsync(Regex.Replace(body, Pattern, Replacement));
                 }


### PR DESCRIPTION
Recent work to fix some routing bugs with `urlBase` introduced a few middlewares to the ASP.NET pipeline; one to inject some javascript into static html files, and another to rewrite URLs in html links to include the base url.  Both of these middlewares rewrite the HTTP response, which includes resetting headers, status code, and body, and then re-writing.  

These middlewares worked, but I neglected to replace all of the response headers after rewriting the body, so `content-type` (among other things) was missing.  Lack of `content-type` caused the middleware to fight with one another, resulting in some static css and javascript files to have html appended, and causing upstream proxies to get confused about the response type.

This PR captures response headers and adds them back after rewriting the response (omitting `content-length`, which changes by design).

Closes #458 
Closes #459