### PR TITLE
Skip tests in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /slskd
 COPY bin bin/.
 COPY src/web src/web/.
 
-RUN sh ./bin/build --web-only --version $VERSION
+RUN sh ./bin/build --web-only --skip-tests --version $VERSION
 
 # build, test, and publish application binaries
 # note: this needs to be pinned to an amd64 image in order to publish armv7 binaries
@@ -26,7 +26,7 @@ COPY tests tests/.
 
 COPY --from=web /slskd/src/web/build /slskd/src/slskd/wwwroot/.
 
-RUN bash ./bin/build --dotnet-only --version $VERSION
+#RUN bash ./bin/build --dotnet-only --version $VERSION
 
 RUN bash ./bin/publish --no-prebuild --platform $TARGETPLATFORM --version $VERSION --output ../../dist/${TARGETPLATFORM}
 


### PR DESCRIPTION
The Docker build takes forever, and I'd like to see how skipping testing impacts the speed.

Testing within the Docker build is somewhat redundant because the application is built and tested in a prior step during the build.  My original rationale was that if the container was built locally running the tests again would be a safety net.  I don't think I've ever done this, so if removing the tests can speed things up I may remove them permanently.