### PR TITLE
Store data protection keys in slskd data dir

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -31,6 +31,7 @@ namespace slskd
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Authentication.JwtBearer;
     using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.DataProtection;
     using Microsoft.AspNetCore.Diagnostics;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
@@ -474,6 +475,9 @@ namespace slskd
                 .AllowAnyMethod()
                 .SetIsOriginAllowed((host) => true)
                 .AllowCredentials()));
+
+            services.AddDataProtection()
+                .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(AppDirectory, "data", ".DataProtection-Keys")));
 
             var jwtSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(OptionsAtStartup.Web.Authentication.Jwt.Key));
 


### PR DESCRIPTION
`DataProtection` is for various built-in cryptography stuff that I'm not using (Cookies, request forgery keys, etc) but I can't turn it off.  The subsystem drops keys in an xml file by default in `~/.aspnet`; this PR forces the files to drop in `~/.local/share/slskd/data` instead.  