### PR TITLE
Fix bug downloading files from the root of a share

### DIFF
--- a/tests/slskd.Tests.Unit/Common/Extensions/ToLocalRelativeFilenameTests.cs
+++ b/tests/slskd.Tests.Unit/Common/Extensions/ToLocalRelativeFilenameTests.cs
@@ -46,7 +46,7 @@
             }
             else
             {
-                Assert.Equal(@"path/fi_le.ext", "C:\\path\\fi\0le.ext");
+                Assert.Equal(@"_", $"{'\0'}".ToLocalRelativeFilename());
             }
         }
     }

--- a/tests/slskd.Tests.Unit/Common/Extensions/ToLocalRelativeFilenameTests.cs
+++ b/tests/slskd.Tests.Unit/Common/Extensions/ToLocalRelativeFilenameTests.cs
@@ -1,0 +1,53 @@
+﻿namespace slskd.Tests.Unit.Common.Extensions
+{
+    using System;
+    using Xunit; 
+
+    public class ToLocalRelativeFilenameTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("\t")]
+        public void Throws_ArgumentException_Given_Bad_Remote_Filename(string filename)
+        {
+            var ex = Record.Exception(() => filename.ToLocalRelativeFilename());
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentException>(ex);
+        }
+
+        [Fact]
+        public void Returns_Localized_Filename_And_Parent_Directory()
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                Assert.Equal(@"path\file.ext", "deeply/nested/path/file.ext".ToLocalRelativeFilename());
+            }
+            else
+            {
+                Assert.Equal(@"path/file.ext", @"C:\deeply\nested\path\file.ext".ToLocalRelativeFilename());
+            }
+
+        }
+        
+        [Fact]
+        public void Returns_Just_File_If_Only_File_Given()
+        {
+            Assert.Equal("file.ext", "file.ext".ToLocalRelativeFilename());
+        }
+
+        [Fact]
+        public void Removes_Invalid_Characters_From_Path_And_Filename()
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                Assert.Equal(@"p_a_t_h\fi_le.ext", @"p?a|t<h/fi>le.ext".ToLocalRelativeFilename());
+            }
+            else
+            {
+                Assert.Equal(@"path/fi_le.ext", "C:\\path\\fi\0le.ext");
+            }
+        }
+    }
+}


### PR DESCRIPTION
The existing code is expecting remote filenames to contain at least two parent directories (e.g. `@share\foo\bar.ext`); this isn't always the case.  

This PR refactors the logic to convert remote filenames to local filenames so that it returns only the file and the immediate parent.  If there is no parent, only the file is returned.

Closes #325 