### PR TITLE
Refactor resolution of remote filenames

### DIFF
--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -119,9 +119,9 @@ namespace slskd.Shares
         {
             var resolvedFilename = Cache.Resolve(remoteFilename);
 
-            if (resolvedFilename == remoteFilename)
+            if (string.IsNullOrEmpty(resolvedFilename))
             {
-                throw new NotFoundException($"The requested filename '{remoteFilename}' could not be resolved to a configured share.");
+                throw new NotFoundException($"The requested filename '{remoteFilename}' could not be resolved to a local file.");
             }
 
             return Task.FromResult(resolvedFilename);


### PR DESCRIPTION
The previous implementation attempted to substitute parts of the string, and considered a string that was not substituted to be a failed lookup.  With the inclusion of root directories, some files may have the same locally and remotely, so this check is no longer helpful.

Closes #522 