### PR TITLE
Track user privileges

### DIFF
--- a/src/slskd/Core/Extensions.cs
+++ b/src/slskd/Core/Extensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CoreExtensions.cs" company="slskd Team">
+﻿// <copyright file="Extensions.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -24,7 +24,7 @@ namespace slskd
     /// <summary>
     ///     Core extensions; extensions for types specific to Soulseek or slskd.
     /// </summary>
-    public static class CoreExtensions
+    public static class Extensions
     {
         /// <summary>
         ///     Redacts this instance of Options, replacing properties marked with <see cref="SecretAttribute"/> with '*****'.
@@ -71,5 +71,18 @@ namespace slskd
                 inactivityTimeout: inactivityTimeout ?? o.InactivityTimeout,
                 proxyOptions: proxyOptions ?? o.ProxyOptions,
                 configureSocket: configureSocketAction ?? o.ConfigureSocket);
+
+        /// <summary>
+        ///     Creates a new instance of <see cref="UserStatisticsState"/> from this instance of <see cref="UserStatistics"/>.
+        /// </summary>
+        /// <param name="stats">The UserStatistics instance from which to copy data</param>
+        /// <returns>The new instance.</returns>
+        public static UserStatisticsState ToUserStatisticsState(this UserStatistics stats) => new()
+        {
+            AverageSpeed = stats.AverageSpeed,
+            DirectoryCount = stats.DirectoryCount,
+            FileCount = stats.FileCount,
+            UploadCount = stats.UploadCount,
+        };
     }
 }

--- a/src/slskd/Core/State.cs
+++ b/src/slskd/Core/State.cs
@@ -34,6 +34,7 @@ namespace slskd
         public bool PendingReconnect { get; init; }
         public bool PendingRestart { get; init; }
         public ServerState Server { get; init; } = new ServerState();
+        public UserState User { get; init; } = new UserState();
         public DistributedNetworkState DistributedNetwork { get; init; } = new DistributedNetworkState();
         public ShareState Shares { get; init; } = new ShareState();
         public string[] Rooms { get; init; } = Array.Empty<string>();
@@ -57,11 +58,30 @@ namespace slskd
         [JsonConverter(typeof(IPEndPointConverter))]
         public IPEndPoint IPEndPoint { get; init; }
         public SoulseekClientStates State { get; init; }
-        public string Username { get; init; }
-        public UserStatistics Statistics { get; init; }
         public bool IsConnected => State.HasFlag(SoulseekClientStates.Connected);
         public bool IsLoggedIn => State.HasFlag(SoulseekClientStates.LoggedIn);
         public bool IsTransitioning => State.HasFlag(SoulseekClientStates.Connecting) || State.HasFlag(SoulseekClientStates.Disconnecting) || State.HasFlag(SoulseekClientStates.LoggingIn);
+    }
+
+    public record UserState
+    {
+        public string Username { get; init; }
+        public UserPrivilegeState Privileges { get; init; } = new UserPrivilegeState();
+        public UserStatisticsState Statistics { get; init; } = new UserStatisticsState();
+    }
+
+    public record UserPrivilegeState
+    {
+        public bool IsPrivileged { get; init; }
+        public int PrivilegesRemaining { get; init; }
+    }
+
+    public record UserStatisticsState
+    {
+        public int AverageSpeed { get; init; }
+        public int DirectoryCount { get; init; }
+        public int FileCount { get; init; }
+        public long UploadCount { get; init; }
     }
 
     public record DistributedNetworkState

--- a/src/slskd/Messaging/API/Controllers/ConversationsController.cs
+++ b/src/slskd/Messaging/API/Controllers/ConversationsController.cs
@@ -152,7 +152,7 @@ namespace slskd.Messaging.API
             var response = Tracker.Conversations.ToDictionary(
                 entry => entry.Key,
                 entry => entry.Value
-                    .Select(pm => PrivateMessageResponse.FromPrivateMessage(pm, self: pm.Username == ApplicationStateMonitor.CurrentValue.Server.Username))
+                    .Select(pm => PrivateMessageResponse.FromPrivateMessage(pm, self: pm.Username == ApplicationStateMonitor.CurrentValue.User.Username))
                     .OrderBy(m => m.Timestamp));
 
             return Ok(response);
@@ -174,7 +174,7 @@ namespace slskd.Messaging.API
             if (Tracker.TryGet(username, out var conversation))
             {
                 var response = conversation
-                    .Select(pm => PrivateMessageResponse.FromPrivateMessage(pm, self: pm.Username == ApplicationStateMonitor.CurrentValue.Server.Username))
+                    .Select(pm => PrivateMessageResponse.FromPrivateMessage(pm, self: pm.Username == ApplicationStateMonitor.CurrentValue.User.Username))
                     .OrderBy(m => m.Timestamp);
 
                 return Ok(response);
@@ -207,7 +207,7 @@ namespace slskd.Messaging.API
             // append the outgoing message to the tracker
             Tracker.AddOrUpdate(username, new PrivateMessage()
             {
-                Username = ApplicationStateMonitor.CurrentValue.Server.Username,
+                Username = ApplicationStateMonitor.CurrentValue.User.Username,
                 Timestamp = DateTime.UtcNow,
                 Message = message,
                 Acknowledged = true,

--- a/src/slskd/Messaging/API/Controllers/RoomsController.cs
+++ b/src/slskd/Messaging/API/Controllers/RoomsController.cs
@@ -172,7 +172,7 @@ namespace slskd.Messaging.API
             if (Tracker.TryGet(roomName, out var room))
             {
                 var response = room.Users
-                    .Select(user => UserDataResponse.FromUserData(user, self: user.Username == ApplicationStateMonitor.CurrentValue.Server.Username));
+                    .Select(user => UserDataResponse.FromUserData(user, self: user.Username == ApplicationStateMonitor.CurrentValue.User.Username));
 
                 return Ok(response);
             }
@@ -196,7 +196,7 @@ namespace slskd.Messaging.API
             if (Tracker.TryGet(roomName, out var room))
             {
                 var response = room.Messages
-                    .Select(message => RoomMessageResponse.FromRoomMessage(message, self: message.Username == ApplicationStateMonitor.CurrentValue.Server.Username));
+                    .Select(message => RoomMessageResponse.FromRoomMessage(message, self: message.Username == ApplicationStateMonitor.CurrentValue.User.Username));
 
                 return Ok(response);
             }
@@ -293,7 +293,7 @@ namespace slskd.Messaging.API
         {
             bool IsSelf(string username)
             {
-                return username == ApplicationStateMonitor.CurrentValue.Server.Username;
+                return username == ApplicationStateMonitor.CurrentValue.User.Username;
             }
 
             var response = RoomResponse.FromRoom(room);

--- a/src/web/src/components/App.js
+++ b/src/web/src/components/App.js
@@ -116,7 +116,7 @@ class App extends Component {
 
   render = () => {
     const { login, applicationState = {}, applicationOptions = {}, error, initialized, retriesExhausted } = this.state;
-    const { version = {}, server, pendingReconnect, pendingRestart, shares = {} } = applicationState;
+    const { version = {}, server, pendingReconnect, pendingRestart, shares = {}, user } = applicationState;
     const { isUpdateAvailable, current, latest } = version;
     const { scanPending: pendingShareRescan } = shares;
 
@@ -203,7 +203,11 @@ class App extends Component {
               {server?.isConnected && <Menu.Item
                 onClick={() => disconnect()}
               >
-                <Icon name='plug' color={pendingReconnect ? 'yellow' : 'green'}/>Connected
+                <Icon.Group className='menu-icon-group'>
+                  <Icon name='plug' color={pendingReconnect ? 'yellow' : 'green'}/>
+                  {user?.privileges?.isPrivileged &&
+                    <Icon name='star' color='yellow' corner className='menu-icon-no-shadow'/>}
+                </Icon.Group>Connected
               </Menu.Item>}
               {(!server?.isConnected) && <Menu.Item 
                 onClick={() => connect()}

--- a/src/web/src/components/System/Info/index.js
+++ b/src/web/src/components/System/Info/index.js
@@ -17,7 +17,7 @@ const Info = ({ state }) => {
 
   useEffect(() => {
     setTimeout(() => {
-      setContents(YAML.stringify(state, { simpleKeys: true, sortMapEntries: true }));
+      setContents(YAML.stringify(state, { simpleKeys: true, sortMapEntries: false }));
     }, 250);
   }, [state]);
 

--- a/src/web/src/components/System/Info/index.js
+++ b/src/web/src/components/System/Info/index.js
@@ -29,19 +29,29 @@ const Info = ({ state }) => {
         <div style={{float: 'left'}}>
           <ShrinkableButton
             icon='refresh'
-            mediaQuery='(max-width: 516px)'
+            mediaQuery='(max-width: 686px)'
             primary
             disabled={!contents}
             onClick={() => getVersion({ forceCheck: true })}
           >
             Check for Updates
           </ShrinkableButton>
+          <ShrinkableButton
+            icon='star'
+            mediaQuery='(max-width: 686px)'
+            color='yellow'
+            disabled={!contents}
+            onClick={() => 
+              window.open(`http://www.slsknet.org/qtlogin.php?username=${state?.user?.username}`, '_blank')}
+          >
+            Get Privileges
+          </ShrinkableButton>
         </div>
         <Modal
           trigger={
             <ShrinkableButton
               icon='shutdown'
-              mediaQuery='(max-width: 516px)'
+              mediaQuery='(max-width: 686px)'
               negative
               disabled={!contents}
             >
@@ -58,7 +68,7 @@ const Info = ({ state }) => {
           trigger={
             <ShrinkableButton
               icon='redo'
-              mediaQuery='(max-width: 516px)'
+              mediaQuery='(max-width: 686px)'
               negative={!pendingRestart}
               color={pendingRestart ? 'yellow' : undefined}
               disabled={!contents}

--- a/src/web/src/components/System/Options/index.js
+++ b/src/web/src/components/System/Options/index.js
@@ -19,7 +19,7 @@ const Index = ({ options }) => {
 
   useEffect(() => {
     setTimeout(() => {
-      setContents(YAML.stringify(options, { simpleKeys: true, sortMapEntries: true }));
+      setContents(YAML.stringify(options, { simpleKeys: true, sortMapEntries: false }));
     }, 250);
   }, [options]);
   


### PR DESCRIPTION
Adds tracking of the logged in user's privileges client-side.  Adds a button users can click to navigate to the Soulseek donation page:

![image](https://user-images.githubusercontent.com/17145758/176462392-43117972-d36d-4cd9-be35-99930f2090d4.png)

Adds a small star icon to indicate privileged status:

![image](https://user-images.githubusercontent.com/17145758/176462580-0632f585-5361-4b14-864a-60e02a8b26f0.png)


Closes #536 
Closes #535 

Also stops sorting info and options yaml.