### PR TITLE
Move reconnect logic to ConnectionWatchdog

### DIFF
--- a/src/slskd/Core/ConnectionWatchdog.cs
+++ b/src/slskd/Core/ConnectionWatchdog.cs
@@ -166,8 +166,6 @@ namespace slskd
                             // options that were captured at startup. if a user has updated these values prior to the disconnect,
                             // the changes will take effect now.
                             await Client.ConnectAsync(Options.CurrentValue.Soulseek.Username, Options.CurrentValue.Soulseek.Password);
-
-                            Log.Information("Successfully reconnected after #{Attempts}", attempts);
                             break;
                         }
                         catch (Exception ex)

--- a/src/slskd/Core/ConnectionWatchdog.cs
+++ b/src/slskd/Core/ConnectionWatchdog.cs
@@ -1,0 +1,113 @@
+﻿// <copyright file="ConnectionWatchdog.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+using Microsoft.Extensions.Options;
+
+namespace slskd
+{
+    using System;
+    using System.Threading.Tasks;
+    using Serilog;
+    using Soulseek;
+
+    public interface IConnectionWatchdog : IDisposable
+    {
+    }
+
+    public class ConnectionWatchdog : IConnectionWatchdog
+    {
+        private static readonly int ReconnectMaxDelayMilliseconds = 300000; // 5 minutes
+
+        public ConnectionWatchdog(
+            ISoulseekClient soulseekClient,
+            IOptionsMonitor<Options> optionsMonitor,
+            IStateMonitor<State> state)
+        {
+            Client = soulseekClient;
+            Options = optionsMonitor;
+            State = state;
+
+            WatchDogTimer = new System.Timers.Timer()
+            {
+                Interval = 250,
+                AutoReset = true,
+                Enabled = true,
+            };
+
+            WatchDogTimer.Elapsed += (sender, args) => _ = AttemptReconnect();
+        }
+
+        private int Attempts { get; set; }
+        private ISoulseekClient Client { get; }
+        private bool Disposed { get; set; }
+        private ILogger Log { get; } = Serilog.Log.ForContext<Application>();
+        private IOptionsMonitor<Options> Options { get; set; }
+        private IStateMonitor<State> State { get; }
+        private System.Timers.Timer WatchDogTimer { get; }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!Disposed)
+            {
+                if (disposing)
+                {
+                    WatchDogTimer?.Dispose();
+                }
+
+                Disposed = true;
+            }
+        }
+
+        private async Task AttemptReconnect()
+        {
+            if (State.CurrentValue.Server.IsConnected || !State.CurrentValue.Server.AttemptingReconnect)
+            {
+                return;
+            }
+
+            var (delay, jitter) = Compute.ExponentialBackoffDelay(
+                iteration: Attempts,
+                maxDelayInMilliseconds: ReconnectMaxDelayMilliseconds);
+
+            var approximateDelay = (int)Math.Ceiling((double)(delay + jitter) / 1000);
+            Log.Information($"Waiting about {(approximateDelay == 1 ? "a second" : $"{approximateDelay} seconds")} before reconnecting");
+
+            await Task.Delay(delay + jitter);
+
+            Log.Information("Attempting to reconnect (#{Attempts})...", Attempts);
+
+            try
+            {
+                // reconnect with the latest configuration values we have for username and password, instead of the options that
+                // were captured at startup. if a user has updated these values prior to the disconnect, the changes will take
+                // effect now.
+                await Client.ConnectAsync(Options.CurrentValue.Soulseek.Username, Options.CurrentValue.Soulseek.Password);
+            }
+            catch (Exception ex)
+            {
+                Attempts++;
+                Log.Error("Failed to reconnect: {Message}", ex.Message);
+            }
+        }
+    }
+}

--- a/src/slskd/Core/ConnectionWatchdog.cs
+++ b/src/slskd/Core/ConnectionWatchdog.cs
@@ -20,18 +20,47 @@ using Microsoft.Extensions.Options;
 namespace slskd
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Serilog;
     using Soulseek;
 
+    /// <summary>
+    ///     Monitors the connection to the Soulseek server and reconnects with exponential backoff, if necessary.
+    /// </summary>
     public interface IConnectionWatchdog : IDisposable
     {
+        /// <summary>
+        ///     Gets a value indicating whether the watchdog is monitoring the server connection.
+        /// </summary>
+        bool IsEnabled { get; }
+
+        /// <summary>
+        ///     Starts monitoring the server connection.
+        /// </summary>
+        /// <remarks>This should be called when the connection is disconnected.</remarks>
+        void Start();
+
+        /// <summary>
+        ///     Stops monitoring the server connection.
+        /// </summary>
+        /// <remarks>This should be called when the application is reasonably certain that the connection is connected.</remarks>
+        void Stop();
     }
 
+    /// <summary>
+    ///     Monitors the connection to the Soulseek network and reconnects with exponential backoff, if necessary.
+    /// </summary>
     public class ConnectionWatchdog : IConnectionWatchdog
     {
         private static readonly int ReconnectMaxDelayMilliseconds = 300000; // 5 minutes
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ConnectionWatchdog"/> class.
+        /// </summary>
+        /// <param name="soulseekClient"></param>
+        /// <param name="optionsMonitor"></param>
+        /// <param name="state"></param>
         public ConnectionWatchdog(
             ISoulseekClient soulseekClient,
             IOptionsMonitor<Options> optionsMonitor,
@@ -41,37 +70,65 @@ namespace slskd
             Options = optionsMonitor;
             State = state;
 
-            WatchDogTimer = new System.Timers.Timer()
+            WatchdogTimer = new System.Timers.Timer()
             {
-                Interval = 250,
+                Interval = 100,
                 AutoReset = true,
-                Enabled = true,
+                Enabled = false,
             };
 
-            WatchDogTimer.Elapsed += (sender, args) => _ = AttemptReconnect();
+            WatchdogTimer.Elapsed += (sender, args) => _ = AttemptReconnect();
         }
 
-        private int Attempts { get; set; }
+        /// <summary>
+        ///     Gets a value indicating whether the watchdog is monitoring the server connection.
+        /// </summary>
+        public bool IsEnabled => WatchdogTimer.Enabled;
+
         private ISoulseekClient Client { get; }
         private bool Disposed { get; set; }
         private ILogger Log { get; } = Serilog.Log.ForContext<Application>();
         private IOptionsMonitor<Options> Options { get; set; }
         private IStateMonitor<State> State { get; }
-        private System.Timers.Timer WatchDogTimer { get; }
+        private SemaphoreSlim SyncRoot { get; } = new SemaphoreSlim(1, 1);
+        private System.Timers.Timer WatchdogTimer { get; }
 
+        /// <summary>
+        ///     Disposes this instance.
+        /// </summary>
         public void Dispose()
         {
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        ///     Starts monitoring the server connection.
+        /// </summary>
+        /// <remarks>This should be called when the connection is disconnected.</remarks>
+        public void Start()
+        {
+            WatchdogTimer.Enabled = true;
+            _ = AttemptReconnect();
+        }
+
+        /// <summary>
+        ///     Stops monitoring the server connection.
+        /// </summary>
+        /// <remarks>This should be called when the application is reasonably certain that the connection is connected.</remarks>
+        public void Stop() => WatchdogTimer.Enabled = false;
+
+        /// <summary>
+        ///     Disposes this instance.
+        /// </summary>
+        /// <param name="disposing"></param>
         protected virtual void Dispose(bool disposing)
         {
             if (!Disposed)
             {
                 if (disposing)
                 {
-                    WatchDogTimer?.Dispose();
+                    WatchdogTimer?.Dispose();
                 }
 
                 Disposed = true;
@@ -80,33 +137,50 @@ namespace slskd
 
         private async Task AttemptReconnect()
         {
-            if (State.CurrentValue.Server.IsConnected || !State.CurrentValue.Server.AttemptingReconnect)
+            if (await SyncRoot.WaitAsync(0))
             {
-                return;
-            }
+                try
+                {
+                    if (State.CurrentValue.Server.IsConnected)
+                    {
+                        return;
+                    }
 
-            var (delay, jitter) = Compute.ExponentialBackoffDelay(
-                iteration: Attempts,
-                maxDelayInMilliseconds: ReconnectMaxDelayMilliseconds);
+                    var attempts = 1;
 
-            var approximateDelay = (int)Math.Ceiling((double)(delay + jitter) / 1000);
-            Log.Information($"Waiting about {(approximateDelay == 1 ? "a second" : $"{approximateDelay} seconds")} before reconnecting");
+                    while (true)
+                    {
+                        var (delay, jitter) = Compute.ExponentialBackoffDelay(
+                            iteration: attempts,
+                            maxDelayInMilliseconds: ReconnectMaxDelayMilliseconds);
 
-            await Task.Delay(delay + jitter);
+                        var approximateDelay = (int)Math.Ceiling((double)(delay + jitter) / 1000);
+                        Log.Information($"Waiting about {(approximateDelay == 1 ? "a second" : $"{approximateDelay} seconds")} before reconnecting");
+                        await Task.Delay(delay + jitter);
 
-            Log.Information("Attempting to reconnect (#{Attempts})...", Attempts);
+                        Log.Information("Attempting to reconnect (#{Attempts})...", attempts);
 
-            try
-            {
-                // reconnect with the latest configuration values we have for username and password, instead of the options that
-                // were captured at startup. if a user has updated these values prior to the disconnect, the changes will take
-                // effect now.
-                await Client.ConnectAsync(Options.CurrentValue.Soulseek.Username, Options.CurrentValue.Soulseek.Password);
-            }
-            catch (Exception ex)
-            {
-                Attempts++;
-                Log.Error("Failed to reconnect: {Message}", ex.Message);
+                        try
+                        {
+                            // reconnect with the latest configuration values we have for username and password, instead of the
+                            // options that were captured at startup. if a user has updated these values prior to the disconnect,
+                            // the changes will take effect now.
+                            await Client.ConnectAsync(Options.CurrentValue.Soulseek.Username, Options.CurrentValue.Soulseek.Password);
+
+                            Log.Information("Successfully reconnected after #{Attempts}", attempts);
+                            break;
+                        }
+                        catch (Exception ex)
+                        {
+                            attempts++;
+                            Log.Error("Failed to reconnect: {Message}", ex.Message);
+                        }
+                    }
+                }
+                finally
+                {
+                    SyncRoot.Release();
+                }
             }
         }
     }

--- a/src/slskd/Core/State.cs
+++ b/src/slskd/Core/State.cs
@@ -61,6 +61,7 @@ namespace slskd
         public bool IsConnected => State.HasFlag(SoulseekClientStates.Connected);
         public bool IsLoggedIn => State.HasFlag(SoulseekClientStates.LoggedIn);
         public bool IsTransitioning => State.HasFlag(SoulseekClientStates.Connecting) || State.HasFlag(SoulseekClientStates.Disconnecting) || State.HasFlag(SoulseekClientStates.LoggingIn);
+        public bool AttemptingReconnect { get; init; }
     }
 
     public record UserState

--- a/src/slskd/Core/State.cs
+++ b/src/slskd/Core/State.cs
@@ -61,7 +61,6 @@ namespace slskd
         public bool IsConnected => State.HasFlag(SoulseekClientStates.Connected);
         public bool IsLoggedIn => State.HasFlag(SoulseekClientStates.LoggedIn);
         public bool IsTransitioning => State.HasFlag(SoulseekClientStates.Connecting) || State.HasFlag(SoulseekClientStates.Disconnecting) || State.HasFlag(SoulseekClientStates.LoggingIn);
-        public bool AttemptingReconnect { get; init; }
     }
 
     public record UserState

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -446,6 +446,8 @@ namespace slskd
             services.AddSingleton<IApplication, Application>();
             services.AddHostedService(p => p.GetRequiredService<IApplication>());
 
+            services.AddSingleton<IConnectionWatchdog, ConnectionWatchdog>();
+
             services.AddDbContext<SearchDbContext>("search.db");
 
             services.AddSingleton<ITransferTracker, TransferTracker>();


### PR DESCRIPTION
The existing reconnect logic executes when a `Disconnected` event fires, and this event can fire while the client is attempting a connection, which causes the reconnect logic to be executed again, and ultimately a ton of reconnect attempts are made concurrently.

I could have added a semaphore to prevent this re-entrance, but there was no good way to ensure that reconnect logic would continue to execute if a connection connected successfully, but disconnected before the semaphore was released.

This PR adds a `ConnectionWatchdog` class that uses a timer to check the status of the connection and if the client is disconnected, the reconnect logic is executed.  The watchdog starts when a qualifying disconnect event is fired, and stops when a connect event is fired.

There shouldn't be a way for the watchdog to remain disabled, but if so, the logic can be adjusted to run all the time (if the timer interval is increased to maybe 500ms)

Closes #331