### PR TITLE
Persist search status to the database as the search is running

### DIFF
--- a/src/slskd/Search/API/Controllers/SearchesController.cs
+++ b/src/slskd/Search/API/Controllers/SearchesController.cs
@@ -68,7 +68,7 @@ namespace slskd.Search.API
 
             try
             {
-                search = await Searches.CreateAsync(id, SearchQuery.FromText(request.SearchText), SearchScope.Network, request.ToSearchOptions());
+                search = await Searches.StartAsync(id, SearchQuery.FromText(request.SearchText), SearchScope.Network, request.ToSearchOptions());
             }
             catch (Exception ex) when (ex is ArgumentException || ex is Soulseek.DuplicateTokenException)
             {

--- a/src/slskd/Search/ISearchService.cs
+++ b/src/slskd/Search/ISearchService.cs
@@ -38,7 +38,7 @@ namespace slskd.Search
         /// <param name="scope">The search scope.</param>
         /// <param name="options">Search options.</param>
         /// <returns>The completed search.</returns>
-        Task<Search> CreateAsync(Guid id, SearchQuery query, SearchScope scope, SearchOptions options = null);
+        Task<Search> StartAsync(Guid id, SearchQuery query, SearchScope scope, SearchOptions options = null);
 
         /// <summary>
         ///     Deletes the specified ssearch.

--- a/src/slskd/Search/SearchService.cs
+++ b/src/slskd/Search/SearchService.cs
@@ -77,7 +77,7 @@ namespace slskd.Search
         /// <param name="scope">The search scope.</param>
         /// <param name="options">Search options.</param>
         /// <returns>The completed search.</returns>
-        public async Task<Search> CreateAsync(Guid id, SearchQuery query, SearchScope scope, SearchOptions options = null)
+        public async Task<Search> StartAsync(Guid id, SearchQuery query, SearchScope scope, SearchOptions options = null)
         {
             var token = Client.GetNextToken();
 

--- a/src/slskd/Search/SearchService.cs
+++ b/src/slskd/Search/SearchService.cs
@@ -117,22 +117,16 @@ namespace slskd.Search
                 },
                 responseReceived: (args) => rateLimiter.Invoke(() =>
                 {
-                    // due to the rate limiter, this has the potential to be executed after the search is complete.
-                    // ensure that doesn't happen. this causes the update to be dropped, but we broadcast again when
-                    // the search is complete with the final stats, so it has no negative impact.
-                    if (search.State.HasFlag(SearchStates.InProgress))
-                    {
-                        // note: this is rate limited, but has the potential to update
-                        // the database every 250ms (or whatever the interval is set to)
-                        // for the duration of the search. any issues with disk/io or performance
-                        // while searches are running should investigate this as a cause
-                        search.ResponseCount = args.Search.ResponseCount;
-                        search.FileCount = args.Search.FileCount;
-                        search.LockedFileCount = args.Search.LockedFileCount;
+                    // note: this is rate limited, but has the potential to update
+                    // the database every 250ms (or whatever the interval is set to)
+                    // for the duration of the search. any issues with disk i/o or performance
+                    // while searches are running should investigate this as a cause
+                    search.ResponseCount = args.Search.ResponseCount;
+                    search.FileCount = args.Search.FileCount;
+                    search.LockedFileCount = args.Search.LockedFileCount;
 
-                        SearchHub.BroadcastUpdateAsync(search);
-                        _ = UpdateAndSaveChangesAsync(search);
-                    }
+                    SearchHub.BroadcastUpdateAsync(search);
+                    _ = UpdateAndSaveChangesAsync(search);
                 }));
 
             var soulseekSearchTask = Client.SearchAsync(


### PR DESCRIPTION
Currently, the search state is only persisted at the start and end of the search; updates are streamed to the browser via SignalR only.

If a user starts a search and then refreshes their browser, it will appear as though the search was started but had not received any updates because this is the only information the database has, and data is sent to the browser on first load straight from the db.

With this update, the database is updated when status changes are broadcast, so if a browser is refreshed (or if someone is monitoring the search over the REST API) the data should be in sync.

This was identified as a shortcoming of the search API as I was working on persisting transfer data, and the same applies there.