### PR TITLE
Temporarily use runtime image to enable memory dumps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN bash ./bin/build --dotnet-only --version $VERSION
 RUN bash ./bin/publish --no-prebuild --platform $TARGETPLATFORM --version $VERSION --output ../../dist/${TARGETPLATFORM}
 
 # application
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-bullseye-slim AS slskd
+FROM mcr.microsoft.com/dotnet/runtime:6.0-bullseye-slim AS slskd
 ARG TARGETPLATFORM
 ARG TAG=0.0.1
 ARG VERSION=0.0.1.65534-local


### PR DESCRIPTION
`dotnet-dump` throws this error, because .NET framework is not installed in the container:

```
A fatal error occurred. The required library libhostfxr.so could not be found.

If this is a self-contained application, that library should exist in [/var/tmp/.net/p1tya53k.oek/S2drLjKvIRWJ8Ptc7UtAKpJNqfC5ivU=/].

If this is a framework-dependent application, install the runtime in the global location [/usr/share/dotnet] or use the DOTNET_ROOT environment variable to specify the runtime location or register the runtime location in [/etc/dotnet/install_location].

The .NET Core runtime can be found at:
  - https://aka.ms/dotnet-core-applaunch?missing_runtime=true&arch=x64&rid=debian.11-x64

[] [13:20:06 ERR] An unhandled exception has occurred while executing the request.
System.IO.FileNotFoundException: Could not find file '/tmp/slskd_lykxz3ev.hv1.dmp'.
File name: '/tmp/slskd_lykxz3ev.hv1.dmp'
```

There's also a logical issue with the `dump` logic that doesn't handle a crash of the executable launched by `ExecAsync` but I'll deal with that later.