### PR TITLE
Switch back to runtime-deps base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN bash ./bin/build --dotnet-only --version $VERSION
 RUN bash ./bin/publish --no-prebuild --platform $TARGETPLATFORM --version $VERSION --output ../../dist/${TARGETPLATFORM}
 
 # application
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS slskd
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-bullseye-slim AS slskd
 ARG TARGETPLATFORM
 ARG TAG=0.0.1
 ARG VERSION=0.0.1.65534-local


### PR DESCRIPTION
The runtime memory dump idea fell flat; dependencies are missing and I'd have to use the SDK image moving forward (and it still didn't work).

This can still work, but not within this Docker image.