### PR TITLE
Remove console logging in favor of logger abstraction

### DIFF
--- a/src/slskd/Common/Logging/ConsoleWriteLineLogger.cs
+++ b/src/slskd/Common/Logging/ConsoleWriteLineLogger.cs
@@ -28,7 +28,14 @@ namespace slskd
         /// <inheritdoc/>
         public void Write(LogEvent logEvent)
         {
-            Console.WriteLine(logEvent.RenderMessage());
+            try
+            {
+                Console.WriteLine(logEvent.RenderMessage());
+            }
+            catch
+            {
+                // noop. console may not be available in all cases.
+            }
         }
     }
 }

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -991,7 +991,14 @@ namespace slskd
 
             banner += "\n└────────────────────────────────────────────────────────┘";
 
-            Console.WriteLine(banner);
+            try
+            {
+                Console.WriteLine(banner);
+            }
+            catch
+            {
+                // noop. console may not be available in all cases.
+            }
         }
 
         private static void VerifyDirectory(string directory, bool createIfMissing = true, bool verifyWriteable = true)


### PR DESCRIPTION
In the few places where `Console.WriteLine` is needed, use a try/catch.  

Related to #556 (I think)