### PR TITLE
Add the ability to filter incoming search requests

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -49,6 +49,9 @@
 #     - \.ini$
 #     - Thumbs.db$
 #     - \.DS_Store$
+#   search:
+#     request:
+#       - ^.{1,2}$
 # web:
 #   port: 5000
 #   https:

--- a/docs/config.md
+++ b/docs/config.md
@@ -542,11 +542,14 @@ web:
 
 A number of filters can be configured to control various aspects of how the application interacts with the Soulseek network.
 
-The share filters can be used to prevent certain types of files from being shared.  This option is an array that can take any number of filters.  Filters must be a valid regular expression; a few examples are included below and in the example configuration included with the application, but the list is empty by default.
+Share filters can be used to prevent certain types of files from being shared.  This option is an array that can take any number of filters.  Filters must be a valid regular expression; a few examples are included below and in the example configuration included with the application, but the list is empty by default.
 
-| Command Line     | Environment Variable | Description                                                    |
-| ---------------- | -------------------- | -------------------------------------------------------------- |
-| `--share-filter` | `SHARE_FILTER`       | A list of regular expressions used to filter files from shares |
+Search request filters can be used to discard incoming search requests that match one or more filters.  Like share filters, this option is an array of regular expressions, and it defaults to an empty array (no request filtering is applied).
+
+| Command Line              | Environment Variable    | Description                                                           |
+| ------------------------- | ----------------------- | --------------------------------------------------------------------- |
+| `--share-filter`          | `SHARE_FILTER`          | A list of regular expressions used to filter files from shares        |
+| `--search-request-filter` | `SEARCH_REQUEST_FILTER` | A list of regular expressions used to filter incoming search requests |
 
 #### **YAML**
 ```yaml
@@ -555,6 +558,9 @@ filters:
     - \.ini$
     - Thumbs.db$
     - \.DS_Store$
+  search:
+    request:
+      - ^.{1,2}$
 ```
 
 # Integrations

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -625,6 +625,12 @@ namespace slskd
             public string[] Share { get; init; } = Array.Empty<string>();
 
             /// <summary>
+            ///     Gets search filter options.
+            /// </summary>
+            [Validate]
+            public SearchOptions Search { get; init; } = new SearchOptions();
+
+            /// <summary>
             ///     Extended validation.
             /// </summary>
             /// <param name="validationContext"></param>
@@ -642,6 +648,40 @@ namespace slskd
                 }
 
                 return results;
+            }
+
+            /// <summary>
+            ///     Search filter options.
+            /// </summary>
+            public class SearchOptions : IValidatableObject
+            {
+                /// <summary>
+                ///     Gets the list of search request filters.
+                /// </summary>
+                [Argument(default, "search-request-filter")]
+                [EnvironmentVariable("SEARCH_REQUEST_FILTER")]
+                [Description("regular expressions to filter incoming search requests")]
+                public string[] Request { get; init; } = Array.Empty<string>();
+
+                /// <summary>
+                ///     Extended validation.
+                /// </summary>
+                /// <param name="validationContext"></param>
+                /// <returns></returns>
+                public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+                {
+                    var results = new List<ValidationResult>();
+
+                    foreach (var filter in Request)
+                    {
+                        if (!filter.IsValidRegex())
+                        {
+                            results.Add(new ValidationResult($"Search request filter '{filter}' is not a valid regular expression"));
+                        }
+                    }
+
+                    return results;
+                }
             }
         }
 


### PR DESCRIPTION
Previously any incoming search of less than 3 characters was discarded.  This was mostly a carry-over from when the application was being built as an example/testing platform for Soulseek.NET.

This PR adds the ability to configure a list of regular expressions that, when matched with an incoming search request, cause the request to be discarded.

By default there is no filtering.