### PR TITLE
Tweak options related to garbage collection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ VOLUME /app
 HEALTHCHECK --interval=60s --timeout=3s --start-period=5s --retries=3 CMD wget -q -O - http://localhost:${SLSKD_HTTP_PORT}/health
 
 ENV DOTNET_BUNDLE_EXTRACT_BASE_DIR=/var/tmp/.net \
+  DOTNET_gcServer=0 \
   DOTNET_GCConserveMemory=9 \
   SLSKD_HTTP_PORT=5000 \
   SLSKD_HTTPS_PORT=5001 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,8 @@ HEALTHCHECK --interval=60s --timeout=3s --start-period=5s --retries=3 CMD wget -
 
 ENV DOTNET_BUNDLE_EXTRACT_BASE_DIR=/var/tmp/.net \
   DOTNET_gcServer=0 \
+  DOTNET_gcConcurrent=1 \
+  DOTNET_GCHeapHardLimit=1F400000	\
   DOTNET_GCConserveMemory=9 \
   SLSKD_HTTP_PORT=5000 \
   SLSKD_HTTPS_PORT=5001 \

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -180,7 +180,7 @@ namespace slskd
 
             GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
 #pragma warning disable S1215 // "GC.Collect" should not be called
-            GC.Collect(2, GCCollectionMode.Forced, blocking: false, compacting: true);
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
 #pragma warning restore S1215 // "GC.Collect" should not be called
 
             sw.Stop();

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -12,7 +12,6 @@
     <LangVersion>9.0</LangVersion>
     <CodeAnalysisRuleSet>Properties\analysis.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <ServerGarbageCollection>false</ServerGarbageCollection>
     <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
   </PropertyGroup>
 


### PR DESCRIPTION
I'm still trying to figure out how much of the memory usage reported in #553 is just idiomatic .NET garbage collection, and how much of it is an application memory leak.

This PR implements the most relevant GC settings as environment variables in the Dockerfile, which should give users a better idea of default behavior if they want to tweak things for their environment.

This change also implements a hard memory limit of 500mib.  The rationale is that if the application has a legitimate memory leak, it will eventually crash when it hits this limit (as opposed to GC increasing pressure).

I have still been unsuccessful in retrieving a memory dump for an inexplicably long list of reasons.