### PR TITLE
Rename DirectoryResponse Name prop to Directory

### DIFF
--- a/src/slskd/Transfers/API/Controllers/TransfersController.cs
+++ b/src/slskd/Transfers/API/Controllers/TransfersController.cs
@@ -165,7 +165,7 @@ namespace slskd.Transfers.API
                 Username = grouping.Key,
                 Directories = grouping.GroupBy(g => g.Filename.DirectoryName()).Select(d => new DirectoryResponse()
                 {
-                    Name = d.Key,
+                    Directory = d.Key,
                     FileCount = d.Count(),
                     Files = d.ToList(),
                 }),
@@ -197,7 +197,7 @@ namespace slskd.Transfers.API
                 Username = username,
                 Directories = downloads.GroupBy(g => g.Filename.DirectoryName()).Select(d => new DirectoryResponse()
                 {
-                    Name = d.Key,
+                    Directory = d.Key,
                     FileCount = d.Count(),
                     Files = d.ToList(),
                 }),
@@ -279,7 +279,7 @@ namespace slskd.Transfers.API
                 Username = grouping.Key,
                 Directories = grouping.GroupBy(g => g.Filename.DirectoryName()).Select(d => new DirectoryResponse()
                 {
-                    Name = d.Key,
+                    Directory = d.Key,
                     FileCount = d.Count(),
                     Files = d.ToList(),
                 }),
@@ -311,7 +311,7 @@ namespace slskd.Transfers.API
                 Username = username,
                 Directories = uploads.GroupBy(g => g.Filename.DirectoryName()).Select(d => new DirectoryResponse()
                 {
-                    Name = d.Key,
+                    Directory = d.Key,
                     FileCount = d.Count(),
                     Files = d.ToList(),
                 }),

--- a/src/slskd/Transfers/API/DTO/DirectoryResponse.cs
+++ b/src/slskd/Transfers/API/DTO/DirectoryResponse.cs
@@ -21,7 +21,7 @@ namespace slskd.Transfers.API
 
     public record DirectoryResponse
     {
-        public string Name { get; init; }
+        public string Directory { get; init; }
         public int FileCount { get; init; }
         public IEnumerable<Transfers.Transfer> Files { get; init; }
     }


### PR DESCRIPTION
I inadvertently broke a bunch of stuff on the UI by renaming this property from `Directory` to just `Name`.  This PR changes it back.

Fixes:

* Missing directory name on groups of files
* File selection and actions not working