### PR TITLE
Synchronously update transfer database records

### DIFF
--- a/src/slskd/Transfers/Downloads/DownloadService.cs
+++ b/src/slskd/Transfers/Downloads/DownloadService.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DownloadService.cs" company="slskd Team">
+// <copyright file="DownloadService.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -170,7 +170,7 @@ namespace slskd.Transfers.Downloads
 
                                         transfer = transfer.WithSoulseekTransfer(args.Transfer);
 
-                                        if (args.Transfer.State.HasFlag(TransferStates.Queued) || args.Transfer.State == TransferStates.Initializing)
+                                        if ((args.Transfer.State.HasFlag(TransferStates.Queued) && args.Transfer.State.HasFlag(TransferStates.Remotely)) || args.Transfer.State == TransferStates.Initializing)
                                         {
                                             transfer.EnqueuedAt = DateTime.UtcNow;
                                             waitUntilEnqueue.TrySetResult(true);

--- a/src/slskd/Transfers/Downloads/DownloadService.cs
+++ b/src/slskd/Transfers/Downloads/DownloadService.cs
@@ -1,4 +1,4 @@
-// <copyright file="DownloadService.cs" company="slskd Team">
+﻿// <copyright file="DownloadService.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -176,14 +176,13 @@ namespace slskd.Transfers.Downloads
                                             waitUntilEnqueue.TrySetResult(true);
                                         }
 
-                                        // todo: broadcast
-                                        _ = UpdateAsync(transfer);
+                                        UpdateSync(transfer);
                                     },
                                     progressUpdated: (args) => rateLimiter.Invoke(() =>
                                     {
                                         transfer = transfer.WithSoulseekTransfer(args.Transfer);
                                         // todo: broadcast
-                                        _ = UpdateAsync(transfer);
+                                        UpdateSync(transfer);
                                     }));
 
                                 var completedTransfer = await Client.DownloadAsync(
@@ -198,7 +197,7 @@ namespace slskd.Transfers.Downloads
 
                                 transfer = transfer.WithSoulseekTransfer(completedTransfer);
                                 // todo: broadcast
-                                await UpdateAsync(transfer);
+                                UpdateSync(transfer);
 
                                 // this would be the ideal place to hook in a generic post-download task processor for now, we'll
                                 // just carry out hard coded behavior. these carry the risk of failing the transfer, and i could
@@ -230,7 +229,7 @@ namespace slskd.Transfers.Downloads
                             {
                                 transfer.EndedAt = DateTime.UtcNow;
                                 // todo: broadcast
-                                await UpdateAsync(transfer);
+                                UpdateSync(transfer);
 
                                 CancellationTokens.TryRemove(id, out _);
                             }
@@ -415,15 +414,14 @@ namespace slskd.Transfers.Downloads
         }
 
         /// <summary>
-        ///     Updates the specified <paramref name="transfer"/>.
+        ///     Synchronously updates the specified <paramref name="transfer"/>.
         /// </summary>
         /// <param name="transfer">The transfer to update.</param>
-        /// <returns>The operation context.</returns>
-        public async Task UpdateAsync(Transfer transfer)
+        public void UpdateSync(Transfer transfer)
         {
-            using var context = await ContextFactory.CreateDbContextAsync();
+            using var context = ContextFactory.CreateDbContext();
             context.Update(transfer);
-            await context.SaveChangesAsync();
+            context.SaveChanges();
         }
 
         private static FileStream GetLocalFileStream(string remoteFilename, string saveDirectory)

--- a/src/slskd/Transfers/Downloads/DownloadService.cs
+++ b/src/slskd/Transfers/Downloads/DownloadService.cs
@@ -264,11 +264,6 @@ namespace slskd.Transfers.Downloads
                         {
                             Log.Debug("Successfully enqueued {Filename} from user {Username}", file.Filename, username);
                         }
-
-                        // this may be redundant, as the record would have been updated inside of the
-                        // state handler, just before the task completion source was signalled. do it anyway.
-                        // todo: broadcast
-                        await UpdateAsync(transfer);
                     }
 
                     if (thrownExceptions.Any())

--- a/src/slskd/Transfers/Downloads/IDownloadService.cs
+++ b/src/slskd/Transfers/Downloads/IDownloadService.cs
@@ -88,10 +88,9 @@ namespace slskd.Transfers.Downloads
         bool TryCancel(Guid id);
 
         /// <summary>
-        ///     Updates the specified <paramref name="transfer"/>.
+        ///     Synchronously updates the specified <paramref name="transfer"/>.
         /// </summary>
         /// <param name="transfer">The transfer to update.</param>
-        /// <returns>The operation context.</returns>
-        Task UpdateAsync(Transfer transfer);
+        void UpdateSync(Transfer transfer);
     }
 }

--- a/src/slskd/Transfers/Uploads/IUploadService.cs
+++ b/src/slskd/Transfers/Uploads/IUploadService.cs
@@ -84,10 +84,9 @@ namespace slskd.Transfers.Uploads
         bool TryCancel(Guid id);
 
         /// <summary>
-        ///     Updates the specified <paramref name="transfer"/>.
+        ///     Synchronously updates the specified <paramref name="transfer"/>.
         /// </summary>
         /// <param name="transfer">The transfer to update.</param>
-        /// <returns>The operation context.</returns>
-        Task UpdateAsync(Transfer transfer);
+        void UpdateSync(Transfer transfer);
     }
 }

--- a/src/slskd/Transfers/Uploads/UploadService.cs
+++ b/src/slskd/Transfers/Uploads/UploadService.cs
@@ -193,13 +193,13 @@ namespace slskd.Transfers.Uploads
                             }
 
                             // todo: broadcast
-                            _ = UpdateAsync(transfer);
+                            UpdateSync(transfer);
                         },
                         progressUpdated: (args) => rateLimiter.Invoke(() =>
                         {
                             transfer = transfer.WithSoulseekTransfer(args.Transfer);
                             // todo: broadcast
-                            _ = UpdateAsync(transfer);
+                            UpdateSync(transfer);
                         }),
                         governor: (tx, req, ct) => Governor.GetBytesAsync(tx.Username, req, ct),
                         reporter: (tx, att, grant, act) => Governor.ReturnBytes(tx.Username, att, grant, act),
@@ -216,7 +216,7 @@ namespace slskd.Transfers.Uploads
 
                     transfer = transfer.WithSoulseekTransfer(completedTransfer);
                     //todo: broadcast
-                    await UpdateAsync(transfer);
+                    UpdateSync(transfer);
                 }
                 catch (TaskCanceledException ex)
                 {
@@ -238,7 +238,7 @@ namespace slskd.Transfers.Uploads
                 {
                     transfer.EndedAt = DateTime.UtcNow;
                     // todo: broadcast
-                    await UpdateAsync(transfer);
+                    UpdateSync(transfer);
 
                     CancellationTokens.TryRemove(id, out _);
                 }
@@ -348,15 +348,14 @@ namespace slskd.Transfers.Uploads
         }
 
         /// <summary>
-        ///     Updates the specified <paramref name="transfer"/>.
+        ///     Synchronously updates the specified <paramref name="transfer"/>.
         /// </summary>
         /// <param name="transfer">The transfer to update.</param>
-        /// <returns>The operation context.</returns>
-        public async Task UpdateAsync(Transfer transfer)
+        public void UpdateSync(Transfer transfer)
         {
-            using var context = await ContextFactory.CreateDbContextAsync();
+            using var context = ContextFactory.CreateDbContext();
             context.Update(transfer);
-            await context.SaveChangesAsync();
+            context.SaveChanges();
         }
     }
 }


### PR DESCRIPTION
Previously these records were being updated with 'fire and forget' async method calls, which _I believe_ were causing out-of-order updates and potentially leaving records in a state other than what should have been the terminal state in the database.

Potentially related to #598 