### PR TITLE
Add sqlite pooling, set multithreading mode

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -455,6 +455,9 @@ namespace slskd
             services.AddDbContext<SearchDbContext>("search.db");
             services.AddDbContext<TransfersDbContext>("transfers.db");
 
+            // https://github.com/aspnet/EntityFrameworkCore/issues/9994#issuecomment-508588678
+            SQLitePCL.raw.sqlite3_config(2 /*SQLITE_CONFIG_MULTITHREAD*/);
+
             services.AddSingleton<IBrowseTracker, BrowseTracker>();
             services.AddSingleton<IConversationTracker, ConversationTracker>();
             services.AddSingleton<IRoomTracker, RoomTracker>(_ => new RoomTracker(messageLimit: 250));
@@ -798,7 +801,7 @@ namespace slskd
             {
                 services.AddDbContextFactory<T>(options =>
                 {
-                    options.UseSqlite($"Data Source={Path.Combine(AppDirectory, "data", filename)}");
+                    options.UseSqlite($"Data Source={Path.Combine(AppDirectory, "data", filename)};Pooling=True;");
 
                     if (OptionsAtStartup.Debug && OptionsAtStartup.Flags.LogSQL)
                     {

--- a/src/slskd/Transfers/TransfersDbContext.cs
+++ b/src/slskd/Transfers/TransfersDbContext.cs
@@ -29,7 +29,7 @@ namespace slskd.Transfers
             Database.EnsureCreated();
         }
 
-        public DbSet<Transfer> Transfers { get; set;}
+        public DbSet<Transfer> Transfers { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {


### PR DESCRIPTION
A user in Discord reported errors deleting transfers:

```
Microsoft.Data.Sqlite.SqliteException (0x80004005): SQLite Error 5: 'database is locked'
```

I believe this is due to the change to synchronous updates introduced in #599.  I did a bunch of research and came up with two things that might fix the issue, the first being to set the connection to use pooling via the connection string, and the second to set SQLite into multithreading mode, which I was surprised to discover is not the default.