### PR TITLE
Make share scanning log more verbosely in debug mode, and a little easier on memory

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -965,10 +965,10 @@ namespace slskd
                 var lastProgress = Math.Round(previous.ScanProgress * 100);
                 var currentProgress = Math.Round(current.ScanProgress * 100);
 
-                if (lastProgress != currentProgress && Math.Round(currentProgress, 0) % 10d == 0)
+                if (lastProgress != currentProgress && Math.Round(currentProgress, 0) % 5d == 0)
                 {
                     State.SetValue(s => s with { Shares = current });
-                    Log.Information("Scanned {Percent}% () of shared directories.  Found {Files} files so far.", currentProgress, current.Files);
+                    Log.Information("Scanned {Percent}% of shared directories. Found {Files} files so far.", currentProgress, current.Files);
                 }
             }
         }

--- a/src/slskd/Core/State.cs
+++ b/src/slskd/Core/State.cs
@@ -21,7 +21,6 @@ namespace slskd
     using System.Collections.Generic;
     using System.Net;
     using System.Text.Json.Serialization;
-    using slskd.Shares;
     using slskd.Users;
     using Soulseek;
 
@@ -145,10 +144,5 @@ namespace slskd
         ///     Gets the number of directories excluded by filters.
         /// </summary>
         public int ExcludedDirectories { get; init; }
-
-        /// <summary>
-        ///     Gets the list of shares stored in the cache.
-        /// </summary>
-        public IReadOnlyCollection<Share> Shares { get; init; } = new List<Share>().AsReadOnly();
     }
 }

--- a/src/slskd/Shares/API/Controllers/SharesController.cs
+++ b/src/slskd/Shares/API/Controllers/SharesController.cs
@@ -59,7 +59,7 @@ namespace slskd.Shares.API
         {
             var browse = await Shares.BrowseAsync();
 
-            var summary = Shares.CachedShares.Select(share =>
+            var summary = Shares.Shares.Select(share =>
             {
                 var directories = browse.Where(directory => directory.Name.StartsWith(share.RemotePath));
                 var fileCount = directories.Aggregate(seed: 0, (sum, directory) =>

--- a/src/slskd/Shares/IShareService.cs
+++ b/src/slskd/Shares/IShareService.cs
@@ -27,11 +27,6 @@ namespace slskd.Shares
     public interface IShareService
     {
         /// <summary>
-        ///     Gets the list of shares stored in the cache.
-        /// </summary>
-        IReadOnlyList<Share> CachedShares { get; }
-
-        /// <summary>
         ///     Gets the list of configured shares.
         /// </summary>
         IReadOnlyList<Share> Shares { get; }

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -55,11 +55,6 @@ namespace slskd.Shares
                     Directories = current.Directories,
                     Files = current.Files,
                 });
-
-                if (previous.Filling && !current.Filling)
-                {
-                    CachedShares = current.Shares.ToList().AsReadOnly();
-                }
             });
 
             OptionsMonitor = optionsMonitor;
@@ -72,11 +67,6 @@ namespace slskd.Shares
         ///     Gets the list of configured shares.
         /// </summary>
         public IReadOnlyList<Share> Shares => SharesList.AsReadOnly();
-
-        /// <summary>
-        ///     Gets the list of shares stored in the cache.
-        /// </summary>
-        public IReadOnlyList<Share> CachedShares { get; private set; } = new List<Share>().AsReadOnly();
 
         /// <summary>
         ///     Gets the state monitor for the service.


### PR DESCRIPTION
Related to #610 