### PR TITLE
Add metrics tracking search and browse activity and distributed network state

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -421,6 +421,7 @@ namespace slskd
                 sw.Stop();
 
                 Metrics.Browse.ResponseLatency.Observe(sw.ElapsedMilliseconds);
+                Metrics.Browse.CurrentResponseLatency.Update(sw.ElapsedMilliseconds);
                 Metrics.Browse.ResponsesSent.Inc(1);
 
                 return new BrowseResponse(directories);

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -410,10 +410,10 @@ namespace slskd
         {
             try
             {
-                var directories = (await Metrics.MeasureAsync(Metrics.BrowseResponseLatency, () => Shares.BrowseAsync()))
+                var directories = (await Metrics.MeasureAsync(Metrics.Browse.ResponseLatency, () => Shares.BrowseAsync()))
                     .Select(d => new Soulseek.Directory(d.Name.Replace('/', '\\'), d.Files)); // Soulseek NS requires backslashes
 
-                Metrics.BrowseResponsesSent.Inc(1);
+                Metrics.Browse.ResponsesSent.Inc(1);
 
                 return new BrowseResponse(directories);
             }
@@ -625,6 +625,11 @@ namespace slskd
                     Parent = e.Parent.Username,
                 },
             });
+
+            Metrics.DistributedNetwork.HasParent.Set(e.HasParent ? 1 : 0);
+            Metrics.DistributedNetwork.BranchLevel.Set(e.BranchLevel);
+            Metrics.DistributedNetwork.ChildLimit.Set(e.ChildLimit);
+            Metrics.DistributedNetwork.Children.Set(e.Children.Count);
         }
 
         private void Client_TransferProgressUpdated(object sender, TransferProgressUpdatedEventArgs args)
@@ -880,7 +885,7 @@ namespace slskd
         {
             try
             {
-                Metrics.SearchRequestsReceived.Inc(1);
+                Metrics.Search.RequestsReceived.Inc(1);
 
                 if (CompiledSearchResponseFilters.Any(filter => filter.IsMatch(query.SearchText)))
                 {
@@ -896,7 +901,7 @@ namespace slskd
 
                 try
                 {
-                    var results = await Metrics.MeasureAsync(Metrics.SearchResponseLatency, () => Shares.SearchAsync(query));
+                    var results = await Metrics.MeasureAsync(Metrics.Search.ResponseLatency, () => Shares.SearchAsync(query));
 
                     if (results.Any())
                     {
@@ -907,7 +912,7 @@ namespace slskd
 
                         Log.Information("[{Context}]: Sending {Count} records to {Username} for query '{Query}'", "SEARCH RESULT SENT", results.Count(), username, query.SearchText);
 
-                        Metrics.SearchResponsesSent.Inc(1);
+                        Metrics.Search.ResponsesSent.Inc(1);
 
                         return new SearchResponse(
                             Client.Username,

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -410,6 +410,8 @@ namespace slskd
         /// <returns>A Task resolving an IEnumerable of Soulseek.Directory.</returns>
         private async Task<BrowseResponse> BrowseResponseResolver(string username, IPEndPoint endpoint)
         {
+            Metrics.Browse.RequestsReceived.Inc(1);
+            
             try
             {
                 var sw = new Stopwatch();

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -410,8 +410,10 @@ namespace slskd
         {
             try
             {
-                var directories = (await Shares.BrowseAsync())
+                var directories = (await Metrics.MeasureAsync(Metrics.BrowseResponseLatency, () => Shares.BrowseAsync()))
                     .Select(d => new Soulseek.Directory(d.Name.Replace('/', '\\'), d.Files)); // Soulseek NS requires backslashes
+
+                Metrics.BrowseResponsesSent.Inc(1);
 
                 return new BrowseResponse(directories);
             }
@@ -894,13 +896,7 @@ namespace slskd
 
                 try
                 {
-                    var sw = new Stopwatch();
-                    sw.Start();
-
-                    var results = await Shares.SearchAsync(query);
-
-                    sw.Stop();
-                    Metrics.SearchResponseLatency.Observe(sw.ElapsedMilliseconds);
+                    var results = await Metrics.MeasureAsync(Metrics.SearchResponseLatency, () => Shares.SearchAsync(query));
 
                     if (results.Any())
                     {

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -876,47 +876,65 @@ namespace slskd
         /// <returns>A Task resolving a SearchResponse, or null.</returns>
         private async Task<SearchResponse> SearchResponseResolver(string username, int token, SearchQuery query)
         {
-            if (CompiledSearchResponseFilters.Any(filter => filter.IsMatch(query.SearchText)))
-            {
-                return null;
-            }
-
-            // sometimes clients send search queries consisting only of exclusions; drop them.
-            // no other clients send search results for these, even though it is technically possible.
-            if (!query.Terms.Any())
-            {
-                return null;
-            }
-
             try
             {
-                var results = await Shares.SearchAsync(query);
+                Metrics.SearchRequestsReceived.Inc(1);
 
-                if (results.Any())
+                if (CompiledSearchResponseFilters.Any(filter => filter.IsMatch(query.SearchText)))
                 {
-                    // make sure our average speed (as reported by the server) is reasonably up to date
-                    await RefreshUserStatistics();
-
-                    var forecastedPosition = Transfers.Uploads.Queue.ForecastPosition(username);
-
-                    Log.Information("[{Context}]: Sending {Count} records to {Username} for query '{Query}'", "SEARCH RESULT SENT", results.Count(), username, query.SearchText);
-
-                    return new SearchResponse(
-                        Client.Username,
-                        token,
-                        uploadSpeed: State.CurrentValue.User.Statistics.AverageSpeed,
-                        freeUploadSlots: forecastedPosition == 0 ? 1 : 0,
-                        queueLength: forecastedPosition,
-                        fileList: results);
+                    return null;
                 }
 
-                // if no results, either return null or an instance of SearchResponse with a fileList of length 0 in either case, no
-                // response will be sent to the requestor.
-                return null;
+                // sometimes clients send search queries consisting only of exclusions; drop them.
+                // no other clients send search results for these, even though it is technically possible.
+                if (!query.Terms.Any())
+                {
+                    return null;
+                }
+
+                try
+                {
+                    var sw = new Stopwatch();
+                    sw.Start();
+
+                    var results = await Shares.SearchAsync(query);
+
+                    sw.Stop();
+                    Metrics.SearchResponseLatency.Observe(sw.ElapsedMilliseconds);
+
+                    if (results.Any())
+                    {
+                        // make sure our average speed (as reported by the server) is reasonably up to date
+                        await RefreshUserStatistics();
+
+                        var forecastedPosition = Transfers.Uploads.Queue.ForecastPosition(username);
+
+                        Log.Information("[{Context}]: Sending {Count} records to {Username} for query '{Query}'", "SEARCH RESULT SENT", results.Count(), username, query.SearchText);
+
+                        Metrics.SearchResponsesSent.Inc(1);
+
+                        return new SearchResponse(
+                            Client.Username,
+                            token,
+                            uploadSpeed: State.CurrentValue.User.Statistics.AverageSpeed,
+                            freeUploadSlots: forecastedPosition == 0 ? 1 : 0,
+                            queueLength: forecastedPosition,
+                            fileList: results);
+                    }
+
+                    // if no results, either return null or an instance of SearchResponse with a fileList of length 0 in either case, no
+                    // response will be sent to the requestor.
+                    return null;
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "Failed to resolve search response: {Message}", ex.Message);
+                    throw;
+                }
             }
             catch (Exception ex)
             {
-                Log.Warning(ex, "Failed to resolve search response: {Message}", ex.Message);
+                Console.WriteLine(ex);
                 throw;
             }
         }

--- a/src/slskd/Common/ExponentialMovingAverage.cs
+++ b/src/slskd/Common/ExponentialMovingAverage.cs
@@ -1,0 +1,71 @@
+﻿// <copyright file="ExponentialMovingAverage.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+using System;
+
+namespace slskd
+{
+    /// <summary>
+    ///     An exponential moving average.
+    /// </summary>
+    public class ExponentialMovingAverage
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ExponentialMovingAverage"/> class.
+        /// </summary>
+        /// <param name="smoothingFactor"></param>
+        public ExponentialMovingAverage(double smoothingFactor)
+        {
+            SmoothingFactor = smoothingFactor;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ExponentialMovingAverage"/> class.
+        /// </summary>
+        /// <param name="smoothingFactor"></param>
+        /// <param name="onUpdate"></param>
+        public ExponentialMovingAverage(double smoothingFactor, Action<double> onUpdate = null)
+            : this(smoothingFactor)
+        {
+            OnUpdate = onUpdate;
+        }
+
+        /// <summary>
+        ///     Gets the current value.
+        /// </summary>
+        public double Value { get; private set; } = 0;
+
+        /// <summary>
+        ///     Gets a value indicating whether the average has been initialized.
+        /// </summary>
+        public bool Initialized { get; private set; } = false;
+
+        private double SmoothingFactor { get; }
+        private Action<double> OnUpdate { get; }
+
+        /// <summary>
+        ///     Updates the average with a new value.
+        /// </summary>
+        /// <param name="value"></param>
+        public void Update(double value)
+        {
+            Value = !Initialized ? value : ((value - Value) * SmoothingFactor) + Value;
+            Initialized = true;
+            OnUpdate?.Invoke(Value);
+        }
+    }
+}

--- a/src/slskd/Core/API/Controllers/MetricsController.cs
+++ b/src/slskd/Core/API/Controllers/MetricsController.cs
@@ -1,0 +1,54 @@
+﻿// <copyright file="MetricsController.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd.Core.API
+{
+    using System.IO;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Mvc;
+
+    /// <summary>
+    ///     Logs.
+    /// </summary>
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [ApiVersion("0")]
+    [ApiController]
+    [Produces("application/json")]
+    [Consumes("application/json")]
+    public class MetricsController : ControllerBase
+    {
+        /// <summary>
+        ///     Gets application metrics.
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet]
+        [Authorize]
+        public async Task<IActionResult> Metrics()
+        {
+            using var stream = new MemoryStream();
+            using var reader = new StreamReader(stream);
+
+            await Prometheus.Metrics.DefaultRegistry.CollectAndExportAsTextAsync(stream);
+            stream.Position = 0;
+
+            var response = await reader.ReadToEndAsync();
+
+            return Ok(response);
+        }
+    }
+}

--- a/src/slskd/Core/Clock.cs
+++ b/src/slskd/Core/Clock.cs
@@ -1,0 +1,40 @@
+﻿// <copyright file="Clock.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd
+{
+    using System;
+    using System.Timers;
+
+    /// <summary>
+    ///     The application clock, used for time based events.
+    /// </summary>
+    public static class Clock
+    {
+        static Clock()
+        {
+            EveryMinuteTimer.Elapsed += (_, _) => EveryMinute?.Invoke(null, EventArgs.Empty);
+        }
+
+        /// <summary>
+        ///     Fires every 60 seconds.
+        /// </summary>
+        public static event EventHandler EveryMinute;
+
+        private static Timer EveryMinuteTimer { get; } = new Timer() { AutoReset = true, Interval = 60000, Enabled = true };
+    }
+}

--- a/src/slskd/Core/Metrics.cs
+++ b/src/slskd/Core/Metrics.cs
@@ -1,29 +1,76 @@
-﻿using System;
-using System.Diagnostics;
-using System.Threading.Tasks;
-using Prometheus;
+﻿// <copyright file="Metrics.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
 
 namespace slskd
 {
+    using System;
+    using System.Diagnostics;
+    using System.Threading.Tasks;
+    using Prometheus;
+
+    /// <summary>
+    ///     Application metrics.
+    /// </summary>
     public static class Metrics
     {
-        public static Histogram SearchResponseLatency { get; } = Prometheus.Metrics
-            .CreateHistogram($"slskd_search_response_latency", "The time taken to resolve a response to an incoming search request, in milliseconds",
-                new HistogramConfiguration
-                {
-                    Buckets = Histogram.ExponentialBuckets(1, 2, 10),
-                });
-
-        public static Counter SearchRequestsReceived { get; } = Prometheus.Metrics.CreateCounter("slskd_search_requests_received", "Total number of search requests received");
-        public static Counter SearchResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_search_responses_sent", "Total number of search responses sent");
-
-        public static Counter BrowseResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_browse_responses_sent", "Total number of browse responses sent");
-        public static Histogram BrowseResponseLatency { get; } = Prometheus.Metrics.CreateHistogram("slskd_browse_response_latency", "The time taken to resolve a response to an incoming browse request, in milliseconds",
+        /// <summary>
+        ///     Gets a histogram representing the time taken to resolve a response to an incoming search request, in milliseconds.
+        /// </summary>
+        public static Histogram SearchResponseLatency { get; } = Prometheus.Metrics.CreateHistogram(
+            "slskd_search_response_latency",
+            "The time taken to resolve a response to an incoming search request, in milliseconds",
             new HistogramConfiguration
             {
                 Buckets = Histogram.ExponentialBuckets(1, 2, 10),
             });
 
+        /// <summary>
+        ///     Gets a counter representing the total number of search requests received.
+        /// </summary>
+        public static Counter SearchRequestsReceived { get; } = Prometheus.Metrics.CreateCounter("slskd_search_requests_received", "Total number of search requests received");
+
+        /// <summary>
+        ///     Gets a counter representing the total number of search responses sent.
+        /// </summary>
+        public static Counter SearchResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_search_responses_sent", "Total number of search responses sent");
+
+        /// <summary>
+        ///     Gets a counter representing the total number of browse responses sent.
+        /// </summary>
+        public static Counter BrowseResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_browse_responses_sent", "Total number of browse responses sent");
+
+        /// <summary>
+        ///     Gets a histogram representing the the time taken to resolve a response to an incoming browse request, in milliseconds.
+        /// </summary>
+        public static Histogram BrowseResponseLatency { get; } = Prometheus.Metrics.CreateHistogram(
+            "slskd_browse_response_latency",
+            "The time taken to resolve a response to an incoming browse request, in milliseconds",
+            new HistogramConfiguration
+            {
+                Buckets = Histogram.ExponentialBuckets(1, 2, 10),
+            });
+
+        /// <summary>
+        ///     Measure the duration of the provided <paramref name="action"/> with the specified <paramref name="histogram"/>.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="histogram"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
         public static T Measure<T>(Histogram histogram, Func<T> action)
         {
             var sw = new Stopwatch();
@@ -38,6 +85,13 @@ namespace slskd
             return result;
         }
 
+        /// <summary>
+        ///     Measure the duration of the provided <paramref name="action"/> with the specified <paramref name="histogram"/>.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="histogram"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
         public static async Task<T> MeasureAsync<T>(Histogram histogram, Func<Task<T>> action)
         {
             var sw = new Stopwatch();

--- a/src/slskd/Core/Metrics.cs
+++ b/src/slskd/Core/Metrics.cs
@@ -71,6 +71,11 @@ namespace slskd
             public static ExponentialMovingAverage CurrentResponseLatency { get; } = new ExponentialMovingAverage(smoothingFactor: 0.5, onUpdate: value => CurrentResponseLatencyGauge.Set(value));
 
             /// <summary>
+            ///     Gets a counter representing the total number of browse requests received.
+            /// </summary>
+            public static Counter RequestsReceived { get; } = Prometheus.Metrics.CreateCounter("slskd_browse_requests_received", "Total number of browse requests received");
+
+            /// <summary>
             ///     Gets a counter representing the total number of browse responses sent.
             /// </summary>
             public static Counter ResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_browse_responses_sent", "Total number of browse responses sent");

--- a/src/slskd/Core/Metrics.cs
+++ b/src/slskd/Core/Metrics.cs
@@ -22,47 +22,73 @@ namespace slskd
     using System.Threading.Tasks;
     using Prometheus;
 
-    /// <summary>
-    ///     Application metrics.
-    /// </summary>
     public static class Metrics
     {
-        /// <summary>
-        ///     Gets a histogram representing the time taken to resolve a response to an incoming search request, in milliseconds.
-        /// </summary>
-        public static Histogram SearchResponseLatency { get; } = Prometheus.Metrics.CreateHistogram(
-            "slskd_search_response_latency",
-            "The time taken to resolve a response to an incoming search request, in milliseconds",
-            new HistogramConfiguration
-            {
-                Buckets = Histogram.ExponentialBuckets(1, 2, 10),
-            });
+        public static class Search
+        {
+            /// <summary>
+            ///     Gets a histogram representing the time taken to resolve a response to an incoming search request, in milliseconds.
+            /// </summary>
+            public static Histogram ResponseLatency { get; } = Prometheus.Metrics.CreateHistogram(
+                "slskd_search_response_latency",
+                "The time taken to resolve a response to an incoming search request, in milliseconds",
+                new HistogramConfiguration
+                {
+                    Buckets = Histogram.ExponentialBuckets(1, 2, 10),
+                });
 
-        /// <summary>
-        ///     Gets a counter representing the total number of search requests received.
-        /// </summary>
-        public static Counter SearchRequestsReceived { get; } = Prometheus.Metrics.CreateCounter("slskd_search_requests_received", "Total number of search requests received");
+            /// <summary>
+            ///     Gets a counter representing the total number of search requests received.
+            /// </summary>
+            public static Counter RequestsReceived { get; } = Prometheus.Metrics.CreateCounter("slskd_search_requests_received", "Total number of search requests received");
 
-        /// <summary>
-        ///     Gets a counter representing the total number of search responses sent.
-        /// </summary>
-        public static Counter SearchResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_search_responses_sent", "Total number of search responses sent");
+            /// <summary>
+            ///     Gets a counter representing the total number of search responses sent.
+            /// </summary>
+            public static Counter ResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_search_responses_sent", "Total number of search responses sent");
+        }
 
-        /// <summary>
-        ///     Gets a counter representing the total number of browse responses sent.
-        /// </summary>
-        public static Counter BrowseResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_browse_responses_sent", "Total number of browse responses sent");
+        public static class Browse
+        {
+            /// <summary>
+            ///     Gets a counter representing the total number of browse responses sent.
+            /// </summary>
+            public static Counter ResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_browse_responses_sent", "Total number of browse responses sent");
 
-        /// <summary>
-        ///     Gets a histogram representing the the time taken to resolve a response to an incoming browse request, in milliseconds.
-        /// </summary>
-        public static Histogram BrowseResponseLatency { get; } = Prometheus.Metrics.CreateHistogram(
-            "slskd_browse_response_latency",
-            "The time taken to resolve a response to an incoming browse request, in milliseconds",
-            new HistogramConfiguration
-            {
-                Buckets = Histogram.ExponentialBuckets(1, 2, 10),
-            });
+            /// <summary>
+            ///     Gets a histogram representing the time taken to resolve a response to an incoming browse request, in milliseconds.
+            /// </summary>
+            public static Histogram ResponseLatency { get; } = Prometheus.Metrics.CreateHistogram(
+                "slskd_browse_response_latency",
+                "The time taken to resolve a response to an incoming browse request, in milliseconds",
+                new HistogramConfiguration
+                {
+                    Buckets = Histogram.ExponentialBuckets(1, 2, 10),
+                });
+        }
+
+        public static class DistributedNetwork
+        {
+            /// <summary>
+            ///     Gets a gauge representing the current number of connected distributed children.
+            /// </summary>
+            public static Gauge Children { get; } = Prometheus.Metrics.CreateGauge("slskd_dnet_children", "Current number of connected distributed children");
+
+            /// <summary>
+            ///     Gets a gauge representing the current distributed child limit.
+            /// </summary>
+            public static Gauge ChildLimit { get; } = Prometheus.Metrics.CreateGauge("slskd_dnet_child_limit", "Current distributed child limit");
+
+            /// <summary>
+            ///     Gets a gauge indicating whether a distributed parent connection is established.
+            /// </summary>
+            public static Gauge HasParent { get; } = Prometheus.Metrics.CreateGauge("slskd_dnet_has_parent", "A value indicating whether a distributed parent connection is established");
+
+            /// <summary>
+            ///     Gets a gauge representing the current distributed branch level.
+            /// </summary>
+            public static Gauge BranchLevel { get; } = Prometheus.Metrics.CreateGauge("slskd_dnet_branch_level", "Current distributed branch level");
+        }
 
         /// <summary>
         ///     Measure the duration of the provided <paramref name="action"/> with the specified <paramref name="histogram"/>.

--- a/src/slskd/Core/Metrics.cs
+++ b/src/slskd/Core/Metrics.cs
@@ -1,18 +1,55 @@
-﻿using Prometheus;
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Prometheus;
 
 namespace slskd
 {
     public static class Metrics
     {
         public static Histogram SearchResponseLatency { get; } = Prometheus.Metrics
-            .CreateHistogram("slskd_search_response_latency", "Histogram of received order values (in USD).",
+            .CreateHistogram($"slskd_search_response_latency", "The time taken to resolve a response to an incoming search request, in milliseconds",
                 new HistogramConfiguration
                 {
-                    // We divide measurements in 10 buckets of $100 each, up to $1000.
                     Buckets = Histogram.ExponentialBuckets(1, 2, 10),
                 });
 
-        public static Counter SearchRequestsReceived { get; } = Prometheus.Metrics.CreateCounter("slskd_search_requests_received", "total number of search requests");
-        public static Counter SearchResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_search_responses_sent", "total number of search responses sent");
+        public static Counter SearchRequestsReceived { get; } = Prometheus.Metrics.CreateCounter("slskd_search_requests_received", "Total number of search requests received");
+        public static Counter SearchResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_search_responses_sent", "Total number of search responses sent");
+
+        public static Counter BrowseResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_browse_responses_sent", "Total number of browse responses sent");
+        public static Histogram BrowseResponseLatency { get; } = Prometheus.Metrics.CreateHistogram("slskd_browse_response_latency", "The time taken to resolve a response to an incoming browse request, in milliseconds",
+            new HistogramConfiguration
+            {
+                Buckets = Histogram.ExponentialBuckets(1, 2, 10),
+            });
+
+        public static T Measure<T>(Histogram histogram, Func<T> action)
+        {
+            var sw = new Stopwatch();
+            sw.Start();
+
+            var result = action();
+
+            sw.Stop();
+
+            histogram.Observe(sw.ElapsedMilliseconds);
+
+            return result;
+        }
+
+        public static async Task<T> MeasureAsync<T>(Histogram histogram, Func<Task<T>> action)
+        {
+            var sw = new Stopwatch();
+            sw.Start();
+
+            var result = await action();
+
+            sw.Stop();
+
+            histogram.Observe(sw.ElapsedMilliseconds);
+
+            return result;
+        }
     }
 }

--- a/src/slskd/Core/Metrics.cs
+++ b/src/slskd/Core/Metrics.cs
@@ -1,0 +1,18 @@
+﻿using Prometheus;
+
+namespace slskd
+{
+    public static class Metrics
+    {
+        public static Histogram SearchResponseLatency { get; } = Prometheus.Metrics
+            .CreateHistogram("slskd_search_response_latency", "Histogram of received order values (in USD).",
+                new HistogramConfiguration
+                {
+                    // We divide measurements in 10 buckets of $100 each, up to $1000.
+                    Buckets = Histogram.ExponentialBuckets(1, 2, 10),
+                });
+
+        public static Counter SearchRequestsReceived { get; } = Prometheus.Metrics.CreateCounter("slskd_search_requests_received", "total number of search requests");
+        public static Counter SearchResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_search_responses_sent", "total number of search responses sent");
+    }
+}

--- a/src/slskd/Core/Metrics.cs
+++ b/src/slskd/Core/Metrics.cs
@@ -55,11 +55,6 @@ namespace slskd
         public static class Browse
         {
             /// <summary>
-            ///     Gets a counter representing the total number of browse responses sent.
-            /// </summary>
-            public static Counter ResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_browse_responses_sent", "Total number of browse responses sent");
-
-            /// <summary>
             ///     Gets a histogram representing the time taken to resolve a response to an incoming browse request, in milliseconds.
             /// </summary>
             public static Histogram ResponseLatency { get; } = Prometheus.Metrics.CreateHistogram(
@@ -69,6 +64,18 @@ namespace slskd
                 {
                     Buckets = Histogram.ExponentialBuckets(1, 2, 10),
                 });
+
+            /// <summary>
+            ///     Gets an EMA representing the average time taken to resolve a response to an incoming search request, in milliseconds.
+            /// </summary>
+            public static ExponentialMovingAverage CurrentResponseLatency { get; } = new ExponentialMovingAverage(smoothingFactor: 0.5, onUpdate: value => CurrentResponseLatencyGauge.Set(value));
+
+            /// <summary>
+            ///     Gets a counter representing the total number of browse responses sent.
+            /// </summary>
+            public static Counter ResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_browse_responses_sent", "Total number of browse responses sent");
+
+            private static Gauge CurrentResponseLatencyGauge { get; } = Prometheus.Metrics.CreateGauge("slskd_browse_response_latency_current", "The average time taken to resolve a response to an incoming browse request, in milliseconds");
         }
 
         public static class DistributedNetwork

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -68,7 +68,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Soulseek" Version="5.1.0" />
+    <PackageReference Include="Soulseek" Version="5.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Also exposes Prometheus metrics via `/api/v0/metrhcis` in addition to the existing `/metrics`

Closes #613 