### PR TITLE
Fix bug causing html to be injected in prometheus metrics

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -648,7 +648,7 @@ namespace slskd
             // prepend the url base.
             app.UsePathBase(urlBase);
             app.UseHTMLRewrite("((\\.)?\\/static)", $"{(urlBase == "/" ? string.Empty : urlBase)}/static");
-            app.UseHTMLInjection($"<script>window.urlBase=\"{urlBase}\"</script>");
+            app.UseHTMLInjection($"<script>window.urlBase=\"{urlBase}\"</script>", excludedRoutes: new[] { "/api", "/swagger" });
             Log.Information("Using base url {UrlBase}", urlBase);
 
             // serve static content from the configured path


### PR DESCRIPTION
Now checks the response content type in addition to the request, in case a controller returns a type other than what was requested (as was the case for Prometheus).

Adds the ability to explicitly exclude routes by path, and excludes `/api` and `/swagger`.

Closes #614 