### PR TITLE
Refactor Prometheus implementation and add basic authentication for the /metrics endpoint

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -76,8 +76,14 @@
 #       ttl: 604800000
 # logger:
 #   loki: ~
+# metrics:
+#   enabled: false
+#   url: /metrics
+#   authentication:
+#     disabled: false
+#     username: slskd
+#     password: slskd
 # feature:
-#   prometheus: false
 #   swagger: false
 # soulseek:
 #   username: ~

--- a/docs/config.md
+++ b/docs/config.md
@@ -666,23 +666,48 @@ logger:
   loki: ~
 ```
 
+## Metrics
+
+The application captures metrics internally and can optionally expose these metrics to be consumed by an instance of Prometheus.  This is a good option for those wanting to tune performance characterisics of the application.
+
+Metrics are disabled by default, and enabling them will make them available at `/metrics`.  Authentication is enabled by default, and the credentials are the same defaults as the web UI (`slskd`:`slskd`).
+
+If the application will be exposed to the internet, it's a good idea to leave this disabled or to set credentials other than the defaults.  Elements of the system configuration, like operating system, architecture, and drive configuration are included and can this can make it easier for an attacker to exploit a vulnerability in your system.
+
+
+| Command Line         | Environment Variable | Description                                               |
+| -------------------- | -------------------- | --------------------------------------------------------- |
+| `--metrics`          | `METRICS`            | Determines whether the metrics endpoint should be enabled |
+| `--metrics-url`      | `METRICS_URL`        | The URL of the metrics endpoint                           |
+| `--metrics-no-auth`  | `METRICS_NO_AUTH`    | Disables authentication for the metrics endpoint          |
+| `--metrics-username` | `METRICS_USERNAME`   | The username for the metrics endpoint                     |
+| `--metrics-password` | `METRICS_PASSWORD`   | The password for the metrics endpoint                     |
+
+#### **YAML**
+
+```yaml
+metrics:
+  enabled: false
+  url: /metrics
+  authentication:
+    disabled: false
+    username: slskd
+    password: slskd
+```
+
 ## Features
 
 Several features have been added that aid in the development, debugging and operation of the application, but are generally not of much use to most users.
-
-The application can publish Prometheus metrics to `/metrics` using [prometheus-net](https://github.com/prometheus-net/prometheus-net).  This is especially useful for anyone attempting to tune performance characteristics.
 
 The application can publish a Swagger (OpenAPI) definition and host SwaggerUI at `/swagger` using [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore).  This is useful for anyone developing against the application API and/or creating a new web interface.
 
 | Command Line   | Environment Variable | Description                                                                               |
 | -------------- | -------------------- | ----------------------------------------------------------------------------------------- |
-| `--prometheus` | `PROMETHEUS`         | Determines whether Prometheus metrics are published to `/metrics`                         |
 | `--swagger`    | `SWAGGER`            | Determines whether Swagger (OpenAPI) definitions and UI should be available at `/swagger` |
 
 #### **YAML**
 ```yaml
 feature:
-  prometheus: false
   swagger: false
 ```
 

--- a/src/slskd/Core/API/Controllers/MetricsController.cs
+++ b/src/slskd/Core/API/Controllers/MetricsController.cs
@@ -17,7 +17,6 @@
 
 namespace slskd.Core.API
 {
-    using System.IO;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
@@ -38,16 +37,9 @@ namespace slskd.Core.API
         /// <returns></returns>
         [HttpGet]
         [Authorize]
-        public async Task<IActionResult> Metrics()
+        public async Task<IActionResult> Get()
         {
-            using var stream = new MemoryStream();
-            using var reader = new StreamReader(stream);
-
-            await Prometheus.Metrics.DefaultRegistry.CollectAndExportAsTextAsync(stream);
-            stream.Position = 0;
-
-            var response = await reader.ReadToEndAsync();
-
+            var response = await Metrics.BuildAsync();
             return Content(response, "text/plain");
         }
     }

--- a/src/slskd/Core/Metrics.cs
+++ b/src/slskd/Core/Metrics.cs
@@ -17,10 +17,27 @@
 
 namespace slskd
 {
+    using System.IO;
+    using System.Threading.Tasks;
     using Prometheus;
 
     public static class Metrics
     {
+        /// <summary>
+        ///     Builds metrics into a Prometheus-formatted string.
+        /// </summary>
+        /// <returns>A Prometheus-formatted string.</returns>
+        public static async Task<string> BuildAsync()
+        {
+            using var stream = new MemoryStream();
+            using var reader = new StreamReader(stream);
+
+            await Prometheus.Metrics.DefaultRegistry.CollectAndExportAsTextAsync(stream);
+            stream.Position = 0;
+
+            return await reader.ReadToEndAsync();
+        }
+
         public static class Search
         {
             /// <summary>

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -236,6 +236,13 @@ namespace slskd
         public LoggerOptions Logger { get; init; } = new LoggerOptions();
 
         /// <summary>
+        ///     Gets metrics options.
+        /// </summary>
+        [Validate]
+        [RequiresRestart]
+        public MetricsOptions Metrics { get; init; } = new MetricsOptions();
+
+        /// <summary>
         ///     Gets feature options.
         /// </summary>
         [Validate]
@@ -623,15 +630,6 @@ namespace slskd
         public class FeatureOptions
         {
             /// <summary>
-            ///     Gets a value indicating whether prometheus metrics should be collected and published.
-            /// </summary>
-            [Argument(default, "prometheus")]
-            [EnvironmentVariable("PROMETHEUS")]
-            [Description("enable collection and publishing of prometheus metrics")]
-            [RequiresRestart]
-            public bool Prometheus { get; init; } = false;
-
-            /// <summary>
             ///     Gets a value indicating whether swagger documentation and UI should be enabled.
             /// </summary>
             [Argument(default, "swagger")]
@@ -728,6 +726,72 @@ namespace slskd
             [Description("optional; url to a Grafana Loki instance to which to log")]
             [RequiresRestart]
             public string Loki { get; init; } = null;
+        }
+
+        /// <summary>
+        ///     Metrics options.
+        /// </summary>
+        public class MetricsOptions
+        {
+            /// <summary>
+            ///     Gets a value indicating whether the metrics endpoint should be enabled.
+            /// </summary>
+            [Argument(default, "metrics")]
+            [EnvironmentVariable("METRICS")]
+            [Description("enable metrics")]
+            [RequiresRestart]
+            public bool Enabled { get; init; } = false;
+
+            /// <summary>
+            ///     Gets the url for the metrics endpoint.
+            /// </summary>
+            [Argument(default, "metrics-url")]
+            [EnvironmentVariable("METRICS_URL")]
+            [Description("url for metrics")]
+            [RequiresRestart]
+            public string Url { get; init; } = "/metrics";
+
+            /// <summary>
+            ///     Gets metrics endpoint authentication options.
+            /// </summary>
+            [Validate]
+            public AuthenticationOptions Authentication { get; init; } = new AuthenticationOptions();
+
+            /// <summary>
+            ///     Metrics endpoint authentication options.
+            /// </summary>
+            public class AuthenticationOptions
+            {
+                /// <summary>
+                ///     Gets a value indicating whether authentication should be disabled.
+                /// </summary>
+                [Argument(default, "metrics-no-auth")]
+                [EnvironmentVariable("METRICS_NO_AUTH")]
+                [Description("disable authentication for metrics requests")]
+                [RequiresRestart]
+                public bool Disabled { get; init; } = false;
+
+                /// <summary>
+                ///     Gets the username for the metrics endpoint.
+                /// </summary>
+                [Argument(default, "metrics-username")]
+                [EnvironmentVariable("METRICS_USERNAME")]
+                [Description("username for metrics")]
+                [StringLength(255, MinimumLength = 1)]
+                [RequiresRestart]
+                public string Username { get; init; } = Program.AppName;
+
+                /// <summary>
+                ///     Gets the password for the metrics endpoint.
+                /// </summary>
+                [Argument(default, "metrics-password")]
+                [EnvironmentVariable("METRICS_PASSWORD")]
+                [Description("password for metrics")]
+                [StringLength(255, MinimumLength = 1)]
+                [Secret]
+                [RequiresRestart]
+                public string Password { get; init; } = Program.AppName;
+            }
         }
 
         /// <summary>

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -681,11 +681,11 @@ namespace slskd
                     var options = OptionsAtStartup.Metrics;
                     var url = options.Url.StartsWith('/') ? options.Url : "/" + options.Url;
 
-                    Log.Information($"Publishing Prometheus metrics to {url}");
+                    Log.Information("Publishing Prometheus metrics to {URL}", url);
 
                     if (options.Authentication.Disabled)
                     {
-                        Log.Warning("Authentication of metrics endpoint is DISABLED");
+                        Log.Warning("Authentication for the metrics endpoint is DISABLED");
                     }
 
                     endpoints.MapGet(url, async context =>
@@ -729,7 +729,7 @@ namespace slskd
                 app.UseSwaggerUI(options => app.Services.GetRequiredService<IApiVersionDescriptionProvider>().ApiVersionDescriptions.ToList()
                     .ForEach(description => options.SwaggerEndpoint($"{(urlBase == "/" ? string.Empty : urlBase)}/swagger/{description.GroupName}/swagger.json", description.GroupName)));
 
-                Log.Information("Publishing Swagger documentation to /swagger");
+                Log.Information("Publishing Swagger documentation to {URL}", "/swagger");
             }
 
             // if we made it this far, the caller is either looking for a route that was synthesized with a SPA router, or is genuinely confused.

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -665,9 +665,7 @@ namespace slskd
             }
 
             app.UseAuthentication();
-
             app.UseRouting();
-            app.UseHttpMetrics();
             app.UseAuthorization();
             app.UseEndpoints(endpoints =>
             {


### PR DESCRIPTION
Previously, the `/metrics` endpoint publishing Prometheus metrics wasn't able to be authenticated.  I didn't think this was a big deal at first, but somewhere along the way I enabled collection of system metrics and with these came things like OS, architecture, and most concerningly, drive mount points.  These aren't exactly secret, but it does give an attacker a lot of information about my system that could be used to exploit vulnerabilities.

This PR reworks the metrics implementation to add basic authentication (the type used by Prometheus) and allows users to set the endpoint.

Note that this is a breaking change for people using Prometheus today; the `features.prometheus` setting has been removed in favor of `metrics.enabled`.  Because metrics are disabled by default, metrics collection will stop when the app is updated.

Closes #616 