### PR TITLE
Normalize file path separators to backslashes

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -417,8 +417,7 @@ namespace slskd
                 var sw = new Stopwatch();
                 sw.Start();
 
-                var directories = (await Shares.BrowseAsync())
-                    .Select(d => new Soulseek.Directory(d.Name.Replace('/', '\\'), d.Files)); // Soulseek NS requires backslashes
+                var directories = await Shares.BrowseAsync();
 
                 sw.Stop();
 

--- a/src/slskd/Common/CommonExtensions.cs
+++ b/src/slskd/Common/CommonExtensions.cs
@@ -239,6 +239,16 @@ namespace slskd
             .Build()
             .Deserialize<T>(str);
 
+        public static string NormalizePath(this string filename)
+        {
+            if (Path.DirectorySeparatorChar == '\\')
+            {
+                return filename;
+            }
+
+            return filename.Replace(Path.DirectorySeparatorChar, '\\');
+        }
+
         /// <summary>
         ///     Converts a fully qualified remote filename to a local filename based in the provided
         ///     <paramref name="baseDirectory"/>, swapping directory characters for those specific to the local OS, removing any

--- a/src/slskd/Common/CommonExtensions.cs
+++ b/src/slskd/Common/CommonExtensions.cs
@@ -254,7 +254,7 @@ namespace slskd
         }
 
         /// <summary>
-        ///     Converts the given path to the normalized format (normalizes path separators to backslashes)
+        ///     Converts the given path to the normalized format (normalizes path separators to backslashes).
         /// </summary>
         /// <param name="path">The path to convert.</param>
         /// <returns>The converted path.</returns>
@@ -262,7 +262,6 @@ namespace slskd
         {
             return path.Replace('/', '\\');
         }
-
 
         /// <summary>
         ///     Converts the given path to the local format (normalizes path separators to Path.DirectorySeparatorChar).

--- a/src/slskd/Common/CommonExtensions.cs
+++ b/src/slskd/Common/CommonExtensions.cs
@@ -239,16 +239,6 @@ namespace slskd
             .Build()
             .Deserialize<T>(str);
 
-        public static string NormalizePath(this string filename)
-        {
-            if (Path.DirectorySeparatorChar == '\\')
-            {
-                return filename;
-            }
-
-            return filename.Replace(Path.DirectorySeparatorChar, '\\');
-        }
-
         /// <summary>
         ///     Converts a fully qualified remote filename to a local filename based in the provided
         ///     <paramref name="baseDirectory"/>, swapping directory characters for those specific to the local OS, removing any
@@ -264,11 +254,22 @@ namespace slskd
         }
 
         /// <summary>
-        ///     Converts the given path to the local format (normalizes path separators).
+        ///     Converts the given path to the normalized format (normalizes path separators to backslashes)
         /// </summary>
         /// <param name="path">The path to convert.</param>
         /// <returns>The converted path.</returns>
-        public static string ToLocalOSPath(this string path)
+        public static string NormalizePath(this string path)
+        {
+            return path.Replace('/', '\\');
+        }
+
+
+        /// <summary>
+        ///     Converts the given path to the local format (normalizes path separators to Path.DirectorySeparatorChar).
+        /// </summary>
+        /// <param name="path">The path to convert.</param>
+        /// <returns>The converted path.</returns>
+        public static string LocalizePath(this string path)
         {
             return path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
         }
@@ -288,7 +289,7 @@ namespace slskd
             }
 
             // normalize path separators
-            var localizedRemoteFilename = remoteFilename.ToLocalOSPath();
+            var localizedRemoteFilename = remoteFilename.LocalizePath();
 
             var parts = localizedRemoteFilename.Split(Path.DirectorySeparatorChar);
 

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -363,16 +363,16 @@ namespace slskd
             {
                 var results = new List<ValidationResult>();
 
-                bool IsBlankPath(string share) => Regex.IsMatch(share.ToLocalOSPath(), @"^(!|-){0,1}(\[.*\])$");
+                bool IsBlankPath(string share) => Regex.IsMatch(share.LocalizePath(), @"^(!|-){0,1}(\[.*\])$");
                 Shared.Where(share => IsBlankPath(share)).ToList()
                     .ForEach(blank => results.Add(new ValidationResult($"Share {blank} doees not specify a path")));
 
-                bool IsRootMount(string share) => Regex.IsMatch(share.ToLocalOSPath(), @"^(!|-){0,1}(\[.*\])/$");
+                bool IsRootMount(string share) => Regex.IsMatch(share.LocalizePath(), @"^(!|-){0,1}(\[.*\])/$");
                 Shared.Where(share => IsRootMount(share)).ToList()
                     .ForEach(blank => results.Add(new ValidationResult($"Share {blank} specifies a root mount, which is not supported.")));
 
                 // starts with '/', 'X:', or '\\'
-                bool IsAbsolutePath(string share) => Regex.IsMatch(share.ToLocalOSPath(), @"^(!|-){0,1}(\[.*\])?(\/|[a-zA-Z]:|\\\\).*$");
+                bool IsAbsolutePath(string share) => Regex.IsMatch(share.LocalizePath(), @"^(!|-){0,1}(\[.*\])?(\/|[a-zA-Z]:|\\\\).*$");
                 Shared.Where(share => !IsAbsolutePath(share)).ToList()
                     .ForEach(relativePath => results.Add(new ValidationResult($"Share {relativePath} contains a relative path; only absolute paths are supported.")));
 

--- a/src/slskd/Shares/IShareService.cs
+++ b/src/slskd/Shares/IShareService.cs
@@ -15,6 +15,8 @@
 //     along with this program.  If not, see https://www.gnu.org/licenses/.
 // </copyright>
 
+using System.IO;
+
 namespace slskd.Shares
 {
     using System.Collections.Generic;
@@ -58,7 +60,7 @@ namespace slskd.Shares
         /// <exception cref="NotFoundException">
         ///     Thrown when the specified remote filename can not be associated with a configured share.
         /// </exception>
-        Task<string> ResolveFilenameAsync(string remoteFilename);
+        Task<FileInfo> ResolveFileAsync(string remoteFilename);
 
         /// <summary>
         ///     Searches the cache for the specified <paramref name="query"/> and returns the matching files.

--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -137,7 +137,7 @@ namespace slskd.Shares
 
             var groups = MaskedFiles
                 .GroupBy(f => Path.GetDirectoryName(f.Key))
-                .Select(g => new Directory(g.Key.NormalizePath(), g.Select(g =>
+                .Select(g => new Directory(g.Key, g.Select(g =>
                 {
                     var f = g.Value;
                     return new File(
@@ -272,9 +272,7 @@ namespace slskd.Shares
                             IgnoreInaccessible = true,
                             RecurseSubdirectories = false,
                         })
-                            .Select(filename => SoulseekFileFactory.Create(
-                                filename: filename,
-                                maskedFilename: filename.ReplaceFirst(share.LocalPath, share.RemotePath)))
+                            .Select(filename => SoulseekFileFactory.Create(filename, maskedFilename: filename.ReplaceFirst(share.LocalPath, share.RemotePath)))
                             .ToDictionary(file => file.Filename, file => file);
 
                         addedFiles = newFiles.Count;
@@ -364,8 +362,6 @@ namespace slskd.Shares
         /// <returns>The contents of the directory.</returns>
         public Directory List(string directory)
         {
-            directory = directory.LocalizePath();
-
             if (!State.CurrentValue.Filled)
             {
                 if (State.CurrentValue.Filling)
@@ -387,7 +383,7 @@ namespace slskd.Shares
                     f.Attributes);
             });
 
-            return new Directory(directory.NormalizePath(), files);
+            return new Directory(directory, files);
         }
 
         /// <summary>
@@ -398,8 +394,6 @@ namespace slskd.Shares
         /// <returns>The unmasked filename.</returns>
         public string Resolve(string filename)
         {
-            filename = filename.LocalizePath();
-
             // ensure this is a tracked file
             if (!MaskedFiles.TryGetValue(filename, out _))
             {
@@ -480,12 +474,6 @@ namespace slskd.Shares
             {
                 return results
                     .Select(r => MaskedFiles[r])
-                    .Select(f => new File(
-                        f.Code,
-                        f.Filename.NormalizePath(),
-                        f.Size,
-                        f.Extension,
-                        f.Attributes))
                     .ToList();
             }
             catch (Exception ex)

--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -273,8 +273,8 @@ namespace slskd.Shares
                             RecurseSubdirectories = false,
                         })
                             .Select(filename => SoulseekFileFactory.Create(
-                                filename: filename.NormalizePath(),
-                                maskedFilename: filename.ReplaceFirst(share.LocalPath, share.RemotePath).NormalizePath()))
+                                filename: filename,
+                                maskedFilename: filename.ReplaceFirst(share.LocalPath, share.RemotePath)))
                             .ToDictionary(file => file.Filename, file => file);
 
                         addedFiles = newFiles.Count;

--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -272,7 +272,9 @@ namespace slskd.Shares
                             IgnoreInaccessible = true,
                             RecurseSubdirectories = false,
                         })
-                            .Select(filename => SoulseekFileFactory.Create(filename, maskedFilename: filename.ReplaceFirst(share.LocalPath, share.RemotePath)))
+                            .Select(filename => SoulseekFileFactory.Create(
+                                filename: filename.NormalizePath(),
+                                maskedFilename: filename.ReplaceFirst(share.LocalPath, share.RemotePath).NormalizePath()))
                             .ToDictionary(file => file.Filename, file => file);
 
                         addedFiles = newFiles.Count;

--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -387,7 +387,7 @@ namespace slskd.Shares
                     f.Attributes);
             });
 
-            return new Directory(directory, files);
+            return new Directory(directory.NormalizePath(), files);
         }
 
         /// <summary>

--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SharedFileCache.cs" company="slskd Team">
+// <copyright file="SharedFileCache.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -137,7 +137,7 @@ namespace slskd.Shares
 
             var groups = MaskedFiles
                 .GroupBy(f => Path.GetDirectoryName(f.Key))
-                .Select(g => new Directory(g.Key, g.Select(g =>
+                .Select(g => new Directory(g.Key.NormalizePath(), g.Select(g =>
                 {
                     var f = g.Value;
                     return new File(

--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -364,6 +364,8 @@ namespace slskd.Shares
         /// <returns>The contents of the directory.</returns>
         public Directory List(string directory)
         {
+            directory = directory.LocalizePath();
+
             if (!State.CurrentValue.Filled)
             {
                 if (State.CurrentValue.Filling)
@@ -396,7 +398,7 @@ namespace slskd.Shares
         /// <returns>The unmasked filename.</returns>
         public string Resolve(string filename)
         {
-            filename = filename.ToLocalOSPath();
+            filename = filename.LocalizePath();
 
             // ensure this is a tracked file
             if (!MaskedFiles.TryGetValue(filename, out _))

--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -1,4 +1,4 @@
-// <copyright file="SharedFileCache.cs" company="slskd Team">
+﻿// <copyright file="SharedFileCache.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -478,7 +478,15 @@ namespace slskd.Shares
 
             try
             {
-                return results.Select(r => MaskedFiles[r]).ToList();
+                return results
+                    .Select(r => MaskedFiles[r])
+                    .Select(f => new File(
+                        f.Code,
+                        f.Filename.NormalizePath(),
+                        f.Size,
+                        f.Extension,
+                        f.Attributes))
+                    .ToList();
             }
             catch (Exception ex)
             {

--- a/src/slskd/Transfers/Uploads/UploadService.cs
+++ b/src/slskd/Transfers/Uploads/UploadService.cs
@@ -58,7 +58,6 @@ namespace slskd.Transfers.Uploads
         /// <summary>
         ///     Gets the upload governor.
         /// </summary>
-        public IUploadGovernor Governor { get; init; }
 
         /// <summary>
         ///     Gets the upload queue.
@@ -114,7 +113,7 @@ namespace slskd.Transfers.Uploads
 
             try
             {
-                localFilename = (await Shares.ResolveFilenameAsync(filename)).ToLocalOSPath();
+                localFilename = await Shares.ResolveFilenameAsync(filename);
 
                 fileInfo = new FileInfo(localFilename);
 

--- a/src/slskd/Transfers/Uploads/UploadService.cs
+++ b/src/slskd/Transfers/Uploads/UploadService.cs
@@ -58,6 +58,7 @@ namespace slskd.Transfers.Uploads
         /// <summary>
         ///     Gets the upload governor.
         /// </summary>
+        public IUploadGovernor Governor { get; init; }
 
         /// <summary>
         ///     Gets the upload queue.


### PR DESCRIPTION
This has been a contentious issue, with compatibility all over the place across various clients.  This PR should solve this once and for all by standardizing on using backslashes for file paths everywhere.

Two new extension methods have been added: `NormalizePath()`, which accepts a file path and returns that path with backslashes, and `LocalizePath()`, which accepts a file path and returns that path with slashes localized to the local OS.  This is important because most of the functionality in the BCL living in `System.IO.Path` relies on the `System.IO.Path.DirectorySeparatorChar` value, meaning if you try to manipulate a path using backslashes on Linux, it's not going to work the way you expect because it assumes your characters are forward slashes.

`NormalizePath()` _must_ be used to normalize file paths before sending any response containing a file path; search results, browse results, and folder contents.  

`LocalizePath()` _must_ be used to localize file paths when handing requests; folder contents, file uploads, etc.

File paths are stored internally in the local format.

Tested browse, search, and folder contents results on both Windows and Linux.

Closes #621 