### PR TITLE
Refactor shared file cache to store all data on disk

### DIFF
--- a/src/slskd/Common/SqliteConnectionExtensions.cs
+++ b/src/slskd/Common/SqliteConnectionExtensions.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="SqliteConnectionExtensions.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd
+{
+    using System;
+    using Microsoft.Data.Sqlite;
+
+    public static class SqliteConnectionExtensions
+    {
+        public static int ExecuteNonQuery(this SqliteConnection conn, string query, Action<SqliteCommand> action = null)
+        {
+            using var cmd = new SqliteCommand(query, conn);
+            action?.Invoke(cmd);
+            return cmd.ExecuteNonQuery();
+        }
+    }
+}

--- a/src/slskd/Core/ConnectionStrings.cs
+++ b/src/slskd/Core/ConnectionStrings.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="ConnectionStrings.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd
+{
+    /// <summary>
+    ///     Application connection strings.
+    /// </summary>
+    public record ConnectionStrings
+    {
+        public string Transfers { get; init; }
+        public string Shares { get; init; }
+        public string Search { get; init; }
+    }
+}

--- a/src/slskd/Core/Filenames.cs
+++ b/src/slskd/Core/Filenames.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="Filenames.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd
+{
+    /// <summary>
+    ///     Application files.
+    /// </summary>
+    public static class Filenames
+    {
+        public static readonly string TransfersDb = "transfers.db";
+        public static readonly string SharesDb = "shares.db";
+        public static readonly string SearchDb = "search.db";
+        public static readonly string BrowseCache = "browse.cache";
+    }
+}

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -755,12 +755,12 @@ namespace slskd
             ///     Gets metrics endpoint authentication options.
             /// </summary>
             [Validate]
-            public AuthenticationOptions Authentication { get; init; } = new AuthenticationOptions();
+            public MetricsAuthenticationOptions Authentication { get; init; } = new MetricsAuthenticationOptions();
 
             /// <summary>
             ///     Metrics endpoint authentication options.
             /// </summary>
-            public class AuthenticationOptions
+            public class MetricsAuthenticationOptions
             {
                 /// <summary>
                 ///     Gets a value indicating whether authentication should be disabled.
@@ -1114,12 +1114,12 @@ namespace slskd
             ///     Gets authentication options.
             /// </summary>
             [Validate]
-            public AuthenticationOptions Authentication { get; init; } = new AuthenticationOptions();
+            public WebAuthenticationOptions Authentication { get; init; } = new WebAuthenticationOptions();
 
             /// <summary>
             ///     Authentication options.
             /// </summary>
-            public class AuthenticationOptions
+            public class WebAuthenticationOptions
             {
                 /// <summary>
                 ///     Gets a value indicating whether authentication should be disabled.

--- a/src/slskd/Core/State.cs
+++ b/src/slskd/Core/State.cs
@@ -102,6 +102,7 @@ namespace slskd
     {
         public bool ScanPending { get; init; }
         public bool Scanning { get; init; }
+        public bool Ready { get; init; }
         public bool Faulted { get; init; }
         public double ScanProgress { get; init; }
         public int Directories { get; init; }

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -45,7 +45,6 @@ namespace slskd
     using Microsoft.Extensions.FileProviders.Physical;
     using Microsoft.IdentityModel.Tokens;
     using Microsoft.OpenApi.Models;
-    using Prometheus;
     using Prometheus.DotNetRuntime;
     using Prometheus.SystemMetrics;
     using Serilog;
@@ -161,6 +160,16 @@ namespace slskd
         public static string ConfigurationFile { get; private set; } = null;
 
         /// <summary>
+        ///     Gets the connection strings for application databases.
+        /// </summary>
+        public static ConnectionStrings ConnectionStrings { get; private set; } = null;
+
+        /// <summary>
+        ///     Gets the path where persistent data is saved.
+        /// </summary>
+        public static string DataDirectory { get; private set; } = null;
+
+        /// <summary>
         ///     Gets the default fully qualified path to the configuration file.
         /// </summary>
         public static string DefaultConfigurationFile { get; private set; }
@@ -247,6 +256,15 @@ namespace slskd
             // and defaults that are dependent upon it
             AppDirectory ??= DefaultAppDirectory;
 
+            DataDirectory = Path.Combine(AppDirectory, "data");
+
+            ConnectionStrings = new()
+            {
+                Search = $"Data Source={Path.Combine(DataDirectory, "search.db")};Cache=shared;Pooling=True;",
+                Transfers = $"Data Source={Path.Combine(DataDirectory, "transfers.db")};Cache=shared;Pooling=True;",
+                Shares = $"Data Source={Path.Combine(DataDirectory, "shares.db")};Cache=shared",
+            };
+
             DefaultConfigurationFile = Path.Combine(AppDirectory, $"{AppName}.yml");
             DefaultDownloadsDirectory = Path.Combine(AppDirectory, "downloads");
             DefaultIncompleteDirectory = Path.Combine(AppDirectory, "incomplete");
@@ -260,7 +278,7 @@ namespace slskd
             try
             {
                 VerifyDirectory(AppDirectory, createIfMissing: true, verifyWriteable: true);
-                VerifyDirectory(Path.Combine(AppDirectory, "data"), createIfMissing: true, verifyWriteable: true);
+                VerifyDirectory(DataDirectory, createIfMissing: true, verifyWriteable: true);
                 VerifyDirectory(DefaultDownloadsDirectory, createIfMissing: true, verifyWriteable: true);
                 VerifyDirectory(DefaultIncompleteDirectory, createIfMissing: true, verifyWriteable: true);
             }
@@ -449,8 +467,8 @@ namespace slskd
 
             ConfigureSQLite();
 
-            services.AddDbContext<SearchDbContext>("search.db");
-            services.AddDbContext<TransfersDbContext>("transfers.db");
+            services.AddDbContext<SearchDbContext>(ConnectionStrings.Search);
+            services.AddDbContext<TransfersDbContext>(ConnectionStrings.Transfers);
 
             services.AddSingleton<IBrowseTracker, BrowseTracker>();
             services.AddSingleton<IConversationTracker, ConversationTracker>();
@@ -512,7 +530,7 @@ namespace slskd
             using var runtimeMetrics = DotNetRuntimeStatsBuilder.Default().StartCollecting();
 
             services.AddDataProtection()
-                .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(AppDirectory, "data", ".DataProtection-Keys")));
+                .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(DataDirectory, ".DataProtection-Keys")));
 
             var jwtSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(OptionsAtStartup.Web.Authentication.Jwt.Key));
 
@@ -838,7 +856,7 @@ namespace slskd
                     commandLine: Environment.CommandLine);
         }
 
-        private static IServiceCollection AddDbContext<T>(this IServiceCollection services, string filename)
+        private static IServiceCollection AddDbContext<T>(this IServiceCollection services, string connectionString)
             where T : DbContext
         {
             Log.Debug("Initializing database context {Name}", typeof(T).Name);
@@ -847,7 +865,7 @@ namespace slskd
             {
                 services.AddDbContextFactory<T>(options =>
                 {
-                    options.UseSqlite($"Data Source={Path.Combine(AppDirectory, "data", filename)};Cache=shared;Pooling=True;");
+                    options.UseSqlite(connectionString);
 
                     if (OptionsAtStartup.Debug && OptionsAtStartup.Flags.LogSQL)
                     {

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -260,9 +260,9 @@ namespace slskd
 
             ConnectionStrings = new()
             {
-                Search = $"Data Source={Path.Combine(DataDirectory, "search.db")};Cache=shared;Pooling=True;",
-                Transfers = $"Data Source={Path.Combine(DataDirectory, "transfers.db")};Cache=shared;Pooling=True;",
-                Shares = $"Data Source={Path.Combine(DataDirectory, "shares.db")};Cache=shared",
+                Search = $"Data Source={Path.Combine(DataDirectory, Filenames.SearchDb)};Cache=shared;Pooling=True;",
+                Transfers = $"Data Source={Path.Combine(DataDirectory, Filenames.TransfersDb)};Cache=shared;Pooling=True;",
+                Shares = $"Data Source={Path.Combine(DataDirectory, Filenames.SharesDb)};Cache=shared",
             };
 
             DefaultConfigurationFile = Path.Combine(AppDirectory, $"{AppName}.yml");

--- a/src/slskd/Shares/IShareService.cs
+++ b/src/slskd/Shares/IShareService.cs
@@ -75,5 +75,7 @@ namespace slskd.Shares
         /// <returns>The operation context.</returns>
         /// <exception cref="ShareScanInProgressException">Thrown when a scan is already in progress.</exception>
         Task StartScanAsync();
+
+        void LoadFromDisk();
     }
 }

--- a/src/slskd/Shares/IShareService.cs
+++ b/src/slskd/Shares/IShareService.cs
@@ -76,6 +76,10 @@ namespace slskd.Shares
         /// <exception cref="ShareScanInProgressException">Thrown when a scan is already in progress.</exception>
         Task StartScanAsync();
 
-        void LoadFromDisk();
+        /// <summary>
+        ///     Attempt to load shares from disk.
+        /// </summary>
+        /// <returns>A value indicating whether shares were loaded.</returns>
+        Task<bool> TryLoadFromDiskAsync();
     }
 }

--- a/src/slskd/Shares/ISharedFileCache.cs
+++ b/src/slskd/Shares/ISharedFileCache.cs
@@ -1,0 +1,78 @@
+﻿// <copyright file="ISharedFileCache.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd.Shares
+{
+    using System.Collections.Generic;
+    using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
+    using Soulseek;
+
+    /// <summary>
+    ///     Shared file cache.
+    /// </summary>
+    public interface ISharedFileCache
+    {
+        /// <summary>
+        ///     Gets the cache state monitor.
+        /// </summary>
+        IStateMonitor<SharedFileCacheState> StateMonitor { get; }
+
+        /// <summary>
+        ///     Returns the contents of the cache.
+        /// </summary>
+        /// <returns>The contents of the cache.</returns>
+        IEnumerable<Directory> Browse();
+
+        /// <summary>
+        ///     Scans the configured shares and fills the cache.
+        /// </summary>
+        /// <remarks>Initiates the scan, then yields execution back to the caller; does not wait for the operation to complete.</remarks>
+        /// <param name="shares">The list of shares from which to fill the cache.</param>
+        /// <param name="filters">The list of regular expressions used to exclude files or paths from scanning.</param>
+        /// <returns>The operation context.</returns>
+        Task FillAsync(IEnumerable<Share> shares, IEnumerable<Regex> filters);
+
+        /// <summary>
+        ///     Returns the contents of the specified <paramref name="directory"/>.
+        /// </summary>
+        /// <param name="directory">The directory for which the contents are to be listed.</param>
+        /// <returns>The contents of the directory.</returns>
+        Directory List(string directory);
+
+        /// <summary>
+        ///     Substitutes the mask in the specified <paramref name="filename"/> with the original path, if the mask is tracked
+        ///     by the cache.
+        /// </summary>
+        /// <param name="filename">The fully qualified filename to unmask.</param>
+        /// <returns>The unmasked filename.</returns>
+        public string Resolve(string filename);
+
+        /// <summary>
+        ///     Searches the cache for the specified <paramref name="query"/> and returns the matching files.
+        /// </summary>
+        /// <param name="query">The query for which to search.</param>
+        /// <returns>The matching files.</returns>
+        IEnumerable<File> Search(SearchQuery query);
+
+        /// <summary>
+        ///     Attempts to load the cache from disk.
+        /// </summary>
+        /// <returns>A value indicating whether the load was successful.</returns>
+        bool TryLoad();
+    }
+}

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -154,11 +154,6 @@ namespace slskd.Shares
                 r.Attributes)));
         }
 
-        public void LoadFromDisk()
-        {
-            Cache.Load();
-        }
-
         /// <summary>
         ///     Starts a scan of the configured shares.
         /// </summary>
@@ -167,6 +162,15 @@ namespace slskd.Shares
         public Task StartScanAsync()
         {
             return Cache.FillAsync(Shares, FilterRegexes);
+        }
+
+        /// <summary>
+        ///     Attempt to load shares from disk.
+        /// </summary>
+        /// <returns>A value indicating whether shares were loaded.</returns>
+        public Task<bool> TryLoadFromDiskAsync()
+        {
+            return Task.FromResult(Cache.TryLoad());
         }
 
         private void Configure(Options options)

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -52,6 +52,7 @@ namespace slskd.Shares
                     ScanPending = current.Faulted || (!(previous.Filling && !current.Filling) && state.ScanPending),
                     Scanning = current.Filling,
                     Faulted = current.Faulted,
+                    Ready = current.Filled,
                     ScanProgress = current.FillProgress,
                     Directories = current.Directories,
                     Files = current.Files,

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -142,16 +142,21 @@ namespace slskd.Shares
         /// </summary>
         /// <param name="query">The query for which to search.</param>
         /// <returns>The matching files.</returns>
-        public async Task<IEnumerable<File>> SearchAsync(SearchQuery query)
+        public Task<IEnumerable<File>> SearchAsync(SearchQuery query)
         {
-            var results = await Cache.SearchAsync(query);
+            var results = Cache.Search(query);
 
-            return results.Select(r => new File(
+            return Task.FromResult(results.Select(r => new File(
                 r.Code,
                 r.Filename.NormalizePath(),
                 r.Size,
                 r.Extension,
-                r.Attributes));
+                r.Attributes)));
+        }
+
+        public void LoadFromDisk()
+        {
+            Cache.Load();
         }
 
         /// <summary>
@@ -160,7 +165,9 @@ namespace slskd.Shares
         /// <returns>The operation context.</returns>
         /// <exception cref="ShareScanInProgressException">Thrown when a scan is already in progress.</exception>
         public Task StartScanAsync()
-            => Cache.FillAsync(Shares, FilterRegexes);
+        {
+            return Cache.FillAsync(Shares, FilterRegexes);
+        }
 
         private void Configure(Options options)
         {

--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -149,7 +149,7 @@ namespace slskd.Shares
             var files = new List<File>();
 
             using var conn = GetConnection();
-            using var cmd = new SqliteCommand("SELECT maskedFilename, code, size, extension, attributeJson FROM files ORDER BY maskedFilename ASC;", conn);
+            using var cmd = new SqliteCommand("SELECT maskedFilename, code, size, extension, attributeJson FROM files;", conn);
             var reader = cmd.ExecuteReader();
 
             while (reader.Read())
@@ -551,7 +551,7 @@ namespace slskd.Shares
         {
             using var conn = GetConnection();
 
-            using var cmd = new SqliteCommand("SELECT name FROM directories ORDER BY name ASC;", conn);
+            using var cmd = new SqliteCommand("SELECT name FROM directories;", conn);
             var reader = cmd.ExecuteReader();
 
             while (reader.Read())
@@ -569,11 +569,11 @@ namespace slskd.Shares
             {
                 if (string.IsNullOrEmpty(directory))
                 {
-                    cmd = new SqliteCommand("SELECT maskedFilename, code, size, extension, attributeJson FROM files ORDER BY maskedFilename ASC;", conn);
+                    cmd = new SqliteCommand("SELECT maskedFilename, code, size, extension, attributeJson FROM files;", conn);
                 }
                 else
                 {
-                    cmd = new SqliteCommand("SELECT maskedFilename, code, size, extension, attributeJson FROM files WHERE maskedFilename LIKE @match ORDER BY maskedFilename ASC;", conn);
+                    cmd = new SqliteCommand("SELECT maskedFilename, code, size, extension, attributeJson FROM files WHERE maskedFilename LIKE @match;", conn);
                     cmd.Parameters.AddWithValue("match", directory + '%');
                 }
 
@@ -622,11 +622,6 @@ namespace slskd.Shares
         {
             using var conn = GetConnection();
 
-            conn.ExecuteNonQuery("INSERT INTO filenames (maskedFilename) VALUES(@maskedFilename);", cmd =>
-            {
-                cmd.Parameters.AddWithValue("maskedFilename", maskedFilename);
-            });
-
             conn.ExecuteNonQuery("INSERT INTO files (maskedFilename, originalFilename, size, touchedAt, code, extension, attributeJson) " +
                 "VALUES(@maskedFilename, @originalFilename, @size, @touchedAt, @code, @extension, @attributeJson) " +
                 "ON CONFLICT DO UPDATE SET originalFilename = excluded.originalFilename, size = excluded.size, touchedAt = excluded.touchedAt, code = excluded.code, extension = excluded.extension, attributeJson = excluded.attributeJson;", cmd =>
@@ -639,6 +634,11 @@ namespace slskd.Shares
                     cmd.Parameters.AddWithValue("extension", file.Extension);
                     cmd.Parameters.AddWithValue("attributeJson", file.Attributes.ToJson());
                 });
+
+            conn.ExecuteNonQuery("INSERT INTO filenames (maskedFilename) VALUES(@maskedFilename);", cmd =>
+            {
+                cmd.Parameters.AddWithValue("maskedFilename", maskedFilename);
+            });
         }
 
         private bool TableExists(string table)

--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -622,7 +622,7 @@ namespace slskd.Shares
         {
             using var conn = GetConnection();
 
-            conn.ExecuteNonQuery("INSERT INTO filenames(maskedFilename) VALUES(@maskedFilename);", cmd =>
+            conn.ExecuteNonQuery("INSERT INTO filenames (maskedFilename) VALUES(@maskedFilename);", cmd =>
             {
                 cmd.Parameters.AddWithValue("maskedFilename", maskedFilename);
             });

--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -342,7 +342,7 @@ namespace slskd.Shares
                 return null;
             }
 
-            var files = ListFiles(directory);
+            var files = ListFiles(directory).OrderBy(f => f.Filename);
             return new Directory(directory, files);
         }
 
@@ -438,6 +438,8 @@ namespace slskd.Shares
             {
                 if (TableExists("directories") && TableExists("filenames") && TableExists("files") && TableExists("exclusions"))
                 {
+                    // todo: check columns
+
                     State.SetValue(state => state with
                     {
                         Filling = false,
@@ -489,8 +491,6 @@ namespace slskd.Shares
             conn.ExecuteNonQuery("DROP TABLE IF EXISTS files; CREATE TABLE files " +
                 "(maskedFilename TEXT PRIMARY KEY, originalFilename TEXT NOT NULL, size BIGINT NOT NULL, touchedAt TEXT NOT NULL, code INTEGER DEFAULT 1 NOT NULL, " +
                 "extension TEXT, attributeJson TEXT NOT NULL);");
-
-            conn.ExecuteNonQuery("DROP TABLE IF EXISTS exclusions; CREATE TABLE exclusions (originalFilename TEXT PRIMARY KEY);");
         }
 
         private SqliteConnection GetConnection()
@@ -612,12 +612,7 @@ namespace slskd.Shares
             if (reader.Read())
             {
                 var fetchedTable = reader.GetString(0);
-                Console.WriteLine($"Fetched: {fetchedTable}");
                 return table == fetchedTable;
-            }
-            else
-            {
-                Console.WriteLine("Read() was false");
             }
 
             return false;

--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -34,60 +34,6 @@ namespace slskd.Shares
     /// <summary>
     ///     Shared file cache.
     /// </summary>
-    public interface ISharedFileCache
-    {
-        /// <summary>
-        ///     Gets the cache state monitor.
-        /// </summary>
-        IStateMonitor<SharedFileCacheState> StateMonitor { get; }
-
-        /// <summary>
-        ///     Returns the contents of the cache.
-        /// </summary>
-        /// <returns>The contents of the cache.</returns>
-        IEnumerable<Directory> Browse();
-
-        /// <summary>
-        ///     Scans the configured shares and fills the cache.
-        /// </summary>
-        /// <remarks>Initiates the scan, then yields execution back to the caller; does not wait for the operation to complete.</remarks>
-        /// <param name="shares">The list of shares from which to fill the cache.</param>
-        /// <param name="filters">The list of regular expressions used to exclude files or paths from scanning.</param>
-        /// <returns>The operation context.</returns>
-        Task FillAsync(IEnumerable<Share> shares, IEnumerable<Regex> filters);
-
-        /// <summary>
-        ///     Returns the contents of the specified <paramref name="directory"/>.
-        /// </summary>
-        /// <param name="directory">The directory for which the contents are to be listed.</param>
-        /// <returns>The contents of the directory.</returns>
-        Directory List(string directory);
-
-        /// <summary>
-        ///     Substitutes the mask in the specified <paramref name="filename"/> with the original path, if the mask is tracked
-        ///     by the cache.
-        /// </summary>
-        /// <param name="filename">The fully qualified filename to unmask.</param>
-        /// <returns>The unmasked filename.</returns>
-        public string Resolve(string filename);
-
-        /// <summary>
-        ///     Searches the cache for the specified <paramref name="query"/> and returns the matching files.
-        /// </summary>
-        /// <param name="query">The query for which to search.</param>
-        /// <returns>The matching files.</returns>
-        IEnumerable<File> Search(SearchQuery query);
-
-        /// <summary>
-        ///     Attempts to load the cache from disk.
-        /// </summary>
-        /// <returns>A value indicating whether the load was successful.</returns>
-        bool TryLoad();
-    }
-
-    /// <summary>
-    ///     Shared file cache.
-    /// </summary>
     public class SharedFileCache : ISharedFileCache
     {
         /// <summary>
@@ -133,7 +79,7 @@ namespace slskd.Shares
             // in the root. to get around this, prime a dictionary with all known directories, and an empty Soulseek.Directory. if
             // there are any files in the directory, this entry will be overwritten with a new Soulseek.Directory containing the
             // files. if not they'll be left as is.
-            foreach (var directory in ListDirectories())
+            foreach (var directory in ListDirectories().OrderBy(d => d))
             {
                 directories.TryAdd(directory, new Directory(directory));
             }
@@ -169,7 +115,7 @@ namespace slskd.Shares
                         f.Size,
                         f.Extension,
                         f.Attributes);
-                })));
+                }).OrderBy(f => f.Filename)));
 
             // merge the dictionary containing all directories with the Soulseek.Directory instances containing their files.
             // entries with no files will remain untouched.

--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -512,6 +512,7 @@ namespace slskd.Shares
             using var filenames = new SqliteCommand("DROP TABLE IF EXISTS filenames; CREATE VIRTUAL TABLE filenames USING fts5(maskedFilename);", SQLite);
             filenames.ExecuteNonQuery();
 
+            // todo add metadata columns
             using var metadata = new SqliteCommand("DROP TABLE IF EXISTS files; CREATE TABLE files (maskedFilename TEXT PRIMARY KEY, originalFilename TEXT NOT NULL, scannedAt TEXT NOT NULL, touchedAt TEXT NOT NULL, metadata TEXT NOT NULL);", SQLite);
             metadata.ExecuteNonQuery();
         }
@@ -541,6 +542,7 @@ namespace slskd.Shares
 
             while (reader.Read())
             {
+                // todo create an instance of Soulseek.File from metadata columns
                 var maskedFilename = reader.GetString(0);
                 var metadata = reader.GetString(1);
 
@@ -572,6 +574,7 @@ namespace slskd.Shares
             filename.Parameters.AddWithValue("maskedFilename", maskedFilename);
             filename.ExecuteNonQuery();
 
+            // todo insert metadata into columns instead of json
             using var metadata = new SqliteCommand("INSERT INTO files (maskedFilename, originalFilename, scannedAt, touchedAt, metadata) " +
                 "VALUES(@maskedFilename, @originalFilename, @scannedAt, @touchedAt, @metadata) " +
                 "ON CONFLICT DO UPDATE SET originalFilename = excluded.originalFilename, scannedAt = excluded.scannedAt, touchedAt = excluded.touchedAt, metadata = excluded.metadata;", SQLite);

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -68,7 +68,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Soulseek" Version="5.1.3" />
+    <PackageReference Include="Soulseek" Version="5.1.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -68,7 +68,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Soulseek" Version="5.1.4" />
+    <PackageReference Include="Soulseek" Version="5.1.5" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Currently shared files are stored in memory within an SQLite database (for full text search) and in a dictionary (for metadata).  This is fast, but uses a lot of memory and large shares cause the application to crash, as reported in #610.

This PR refactors the cache to store all data on disk, and to load the cache from disk on start, negating the need to scan on every start.

These changes allow very large collections to be shared, but negatively impacts the performance of search and browse response creation.

A future update will add an option to use on-disk or in-memory storage so users can select the strategy that works best for their collection.

Remaining tasks:

* [ ] Review the sort order of various responses.  Files and directories should be returned to callers in alphabetical order
* [ ] ~~Add an option to allow the share database to be stored on disk (`/data/shares.db`) or in memory (`file:shares?mode=memory`)~~ Follow-up
* [ ] ~~When using an in memory database, back up to disk (`/data/shares.db`) when the scan is complete, and load from disk when the application starts~~ Follow-up