### PR TITLE
Remove warnings about backslashes in file or directory names

### DIFF
--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -231,12 +231,6 @@ namespace slskd.Shares
                 {
                     Log.Debug("Starting scan of {Directory} ({Current}/{Total})", directory, current + 1, unmaskedDirectories.Count);
 
-                    if (Path.DirectorySeparatorChar == '/' && directory.Contains('\\'))
-                    {
-                        Log.Warning("Directory name {Directory} contains one or more backslashes, which are not currently supported. This directory will not be shared.", directory);
-                        continue;
-                    }
-
                     var addedFiles = 0;
                     var filteredFiles = 0;
 
@@ -270,12 +264,6 @@ namespace slskd.Shares
                             if (filters.Any(filter => filter.IsMatch(originalFilename)))
                             {
                                 filteredFiles++;
-                                continue;
-                            }
-
-                            if (Path.DirectorySeparatorChar == '/' && file.Filename.Contains('\\'))
-                            {
-                                Log.Warning("Filename {Filename} contains one or more backslashes, which are not currently supported. This file will not be shared.", file.Filename);
                                 continue;
                             }
 


### PR DESCRIPTION
With full physical filenames now being stored in the shared file cache (#637), paths don't need to be manipulated and backslashes won't cause any issues locally.  There may be compatibility issues with some clients, especially those on Windows, but we'll see.

Closes #628 