### PR TITLE
Don't double sort search results

### DIFF
--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -433,7 +433,7 @@ namespace slskd.Shares
                     results.Add(file);
                 }
 
-                return results.OrderBy(f => f.Filename);
+                return results;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Search results are sorted by SQLite, and the code erroneously sorts them again before returning.  This should improve response times a little bit.