### PR TITLE
Set shared file cache journal mode to WAL

### DIFF
--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -511,6 +511,8 @@ namespace slskd.Shares
         {
             using var conn = GetConnection();
 
+            conn.ExecuteNonQuery("PRAGMA journal_mode=WAL");
+
             if (discardExisting)
             {
                 conn.ExecuteNonQuery("DROP TABLE IF EXISTS directories; DROP TABLE IF EXISTS filenames; DROP TABLE IF EXISTS files;");


### PR DESCRIPTION
Other SQLite databases managed by Entity Framework have the journal mode set to WAL by default.  The shared file cache database is created without EF, and therefore WAL needs to be enabled explicitly.