### PR TITLE
Add the ability to cancel a share scan

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -1035,7 +1035,7 @@ namespace slskd
                 var lastProgress = Math.Round(previous.ScanProgress * 100);
                 var currentProgress = Math.Round(current.ScanProgress * 100);
 
-                if (lastProgress != currentProgress && Math.Round(currentProgress, 0) % 5d == 0)
+                if (lastProgress != currentProgress && Math.Round(currentProgress, 0) % 1d == 0)
                 {
                     State.SetValue(s => s with { Shares = current });
                     Log.Information("Scanned {Percent}% of shared directories. Found {Files} files so far.", currentProgress, current.Files);

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -94,6 +94,7 @@ namespace slskd
             Console.CancelKeyPress += (_, args) =>
             {
                 ShuttingDown = true;
+                Program.MasterCancellationTokenSource.Cancel();
                 Log.Warning("Received SIGINT");
             };
 
@@ -102,6 +103,7 @@ namespace slskd
                 PosixSignalRegistration.Create(signal, context =>
                 {
                     ShuttingDown = true;
+                    Program.MasterCancellationTokenSource.Cancel();
                     Log.Fatal("Received {Signal}", signal);
                 });
             }

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -985,8 +985,6 @@ namespace slskd
         {
             var (previous, current) = state;
 
-            Console.WriteLine(current);
-
             if (!previous.Scanning && current.Scanning)
             {
                 // the scan is starting

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -384,7 +384,7 @@ namespace slskd
                 else
                 {
                     // todo: should this be forced prior to connection if the cache can't be loaded?
-                    _ = Shares.StartScanAsync();
+                    await Shares.StartScanAsync();
                 }
             }
 

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -385,8 +385,7 @@ namespace slskd
                 }
                 else
                 {
-                    // todo: should this be forced prior to connection if the cache can't be loaded?
-                    _ = Shares.ScanAsync();
+                    await Shares.ScanAsync();
                 }
             }
 

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -386,7 +386,7 @@ namespace slskd
                 else
                 {
                     // todo: should this be forced prior to connection if the cache can't be loaded?
-                    await Shares.StartScanAsync();
+                    _ = Shares.ScanAsync();
                 }
             }
 

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -986,6 +986,8 @@ namespace slskd
         {
             var (previous, current) = state;
 
+            Console.WriteLine(current);
+
             if (!previous.Scanning && current.Scanning)
             {
                 // the scan is starting
@@ -1025,7 +1027,7 @@ namespace slskd
             else if (!previous.Ready && current.Ready)
             {
                 // the share transitioned into ready without completing a scan; it was loaded from disk
-                State.SetValue(state => state with { Shares = state.Shares with { ScanPending = false } });
+                State.SetValue(state => state with { Shares = current with { ScanPending = false } });
                 Log.Information("Share cache loaded from disk successfully. Sharing {Directories} directories and {Files} files", current.Directories, current.Files);
                 _ = CacheBrowseResponse();
             }

--- a/src/slskd/Common/ChannelReader.cs
+++ b/src/slskd/Common/ChannelReader.cs
@@ -130,7 +130,7 @@ namespace slskd.Shares
             }
             finally
             {
-                TaskCompletionSource.SetResult();
+                TaskCompletionSource.TrySetResult();
             }
         }
     }

--- a/src/slskd/Common/ChannelReader.cs
+++ b/src/slskd/Common/ChannelReader.cs
@@ -68,8 +68,7 @@ namespace slskd.Shares
             Handler = handler;
             ExceptionHandler = exceptionHandler;
 
-            CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            CancellationToken = CancellationTokenSource.Token;
+            CancellationToken = cancellationToken;
 
             if (automaticallyStart)
             {
@@ -91,7 +90,6 @@ namespace slskd.Shares
         private Action<T> Handler { get; }
         private Action<Exception> ExceptionHandler { get; }
         private TaskCompletionSource TaskCompletionSource { get; } = new TaskCompletionSource();
-        private CancellationTokenSource CancellationTokenSource { get; }
         private CancellationToken CancellationToken { get; }
         private object SyncRoot { get; } = new object();
 
@@ -114,7 +112,7 @@ namespace slskd.Shares
         {
             try
             {
-                while (!CancellationTokenSource.Token.IsCancellationRequested && !Channel.Reader.Completion.IsCompleted)
+                while (!Channel.Reader.Completion.IsCompleted)
                 {
                     var item = await Channel.Reader.ReadAsync(CancellationToken);
                     Handler(item);

--- a/src/slskd/Core/API/Controllers/ApplicationController.cs
+++ b/src/slskd/Core/API/Controllers/ApplicationController.cs
@@ -72,6 +72,7 @@ namespace slskd.Core.API
         [Authorize]
         public IActionResult Shutdown()
         {
+            Program.MasterCancellationTokenSource.Cancel();
             Lifetime.StopApplication();
 
             Task.Run(async () =>
@@ -91,6 +92,7 @@ namespace slskd.Core.API
         [Authorize]
         public IActionResult Restart()
         {
+            Program.MasterCancellationTokenSource.Cancel();
             Process.Start(Process.GetCurrentProcess().MainModule.FileName, Environment.CommandLine);
             Lifetime.StopApplication();
 

--- a/src/slskd/Core/State.cs
+++ b/src/slskd/Core/State.cs
@@ -104,6 +104,7 @@ namespace slskd
         public bool Scanning { get; init; }
         public bool Ready { get; init; }
         public bool Faulted { get; init; }
+        public bool Cancelled { get; init; }
         public double ScanProgress { get; init; }
         public int Directories { get; init; }
         public int Files { get; init; }
@@ -125,6 +126,8 @@ namespace slskd
         ///     Gets a value indicating whether the cache is faulted.
         /// </summary>
         public bool Faulted { get; init; } = false;
+
+        public bool Cancelled { get; init; } = false;
 
         /// <summary>
         ///     Gets the current fill progress.

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -30,6 +30,7 @@ namespace slskd
     using System.Security.Cryptography.X509Certificates;
     using System.Text;
     using System.Text.Json.Serialization;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Authentication.JwtBearer;
     using Microsoft.AspNetCore.Builder;
@@ -188,6 +189,16 @@ namespace slskd
         ///     Gets a buffer containing the last few log events.
         /// </summary>
         public static ConcurrentFixedSizeQueue<LogRecord> LogBuffer { get; } = new ConcurrentFixedSizeQueue<LogRecord>(size: 100);
+
+        /// <summary>
+        ///     Gets the master cancellation token source for the program.
+        /// </summary>
+        /// <remarks>
+        ///     The token from this source should be used (or linked) to any long-running asynchronous task, so that when the application
+        ///     begins to shut down these tasks also shut down in a timely manner. Actions that control the lifecycle of the program
+        ///     (POSIX signals, a restart from the API, etc) should cancel this source.
+        /// </remarks>
+        public static CancellationTokenSource MasterCancellationTokenSource { get; } = new CancellationTokenSource();
 
         private static IConfigurationRoot Configuration { get; set; }
         private static OptionsAtStartup OptionsAtStartup { get; } = new OptionsAtStartup();

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -340,8 +340,10 @@ namespace slskd
                 Log.Warning($"Please report any issues here: {IssuesUrl}");
             }
 
+            Log.Information("System: .NET {DotNet}, {OS}, {BitNess} bit, {ProcessorCount} processors", Environment.Version, Environment.OSVersion, Environment.Is64BitOperatingSystem ? 64 : 32, Environment.ProcessorCount);
+            Log.Information("Process ID: {ProcessId} ({BitNess} bit)", ProcessId, Environment.Is64BitProcess ? 64 : 32);
+
             Log.Information("Invocation ID: {InvocationId}", InvocationId);
-            Log.Information("Process ID: {ProcessId}", ProcessId);
             Log.Information("Instance Name: {InstanceName}", OptionsAtStartup.InstanceName);
 
             // SQLite must have specific capabilities to function properly. this shouldn't be a concern for shrinkwrapped

--- a/src/slskd/Shares/API/Controllers/SharesController.cs
+++ b/src/slskd/Shares/API/Controllers/SharesController.cs
@@ -176,11 +176,11 @@ namespace slskd.Shares.API
         [Authorize]
         [ProducesResponseType(204)]
         [ProducesResponseType(409)]
-        public async Task<IActionResult> RescanSharesAsync()
+        public IActionResult RescanSharesAsync()
         {
             try
             {
-                await Shares.StartScanAsync();
+                _ = Shares.ScanAsync();
             }
             catch (ShareScanInProgressException)
             {

--- a/src/slskd/Shares/API/Controllers/SharesController.cs
+++ b/src/slskd/Shares/API/Controllers/SharesController.cs
@@ -189,5 +189,26 @@ namespace slskd.Shares.API
 
             return Ok();
         }
+
+        /// <summary>
+        ///     Cancels a share scan, if one is running.
+        /// </summary>
+        /// <returns></returns>
+        /// <response code="204">The request completed successfully.</response>
+        /// <response code="409">A share scan was not in progress.</response>
+        [HttpDelete]
+        [Route("")]
+        [Authorize]
+        [ProducesResponseType(204)]
+        [ProducesResponseType(404)]
+        public IActionResult CancelShareScan()
+        {
+            if (Shares.TryCancelScan())
+            {
+                return StatusCode(204);
+            }
+
+            return NotFound();
+        }
     }
 }

--- a/src/slskd/Shares/IShareService.cs
+++ b/src/slskd/Shares/IShareService.cs
@@ -70,11 +70,24 @@ namespace slskd.Shares
         Task<IEnumerable<File>> SearchAsync(SearchQuery query);
 
         /// <summary>
+        ///     Scans the configured shares.
+        /// </summary>
+        /// <returns>The operation context.</returns>
+        /// <exception cref="ShareScanInProgressException">Thrown when a scan is already in progress.</exception>
+        Task ScanAsync();
+
+        /// <summary>
         ///     Starts a scan of the configured shares.
         /// </summary>
         /// <returns>The operation context.</returns>
         /// <exception cref="ShareScanInProgressException">Thrown when a scan is already in progress.</exception>
         Task StartScanAsync();
+
+        /// <summary>
+        ///     Cancels the currently running scan, if one is running.
+        /// </summary>
+        /// <returns>A value indicating whether a scan was cancelled.</returns>
+        bool TryCancelScan();
 
         /// <summary>
         ///     Attempt to load shares from disk.

--- a/src/slskd/Shares/IShareService.cs
+++ b/src/slskd/Shares/IShareService.cs
@@ -42,7 +42,7 @@ namespace slskd.Shares
         ///     Returns the entire contents of the share.
         /// </summary>
         /// <returns>The entire contents of the share.</returns>
-        Task<IEnumerable<Directory>> BrowseAsync();
+        Task<IEnumerable<Directory>> BrowseAsync(Share share = null);
 
         /// <summary>
         ///     Returns the contents of the specified <paramref name="directory"/>.
@@ -75,6 +75,13 @@ namespace slskd.Shares
         /// <returns>The operation context.</returns>
         /// <exception cref="ShareScanInProgressException">Thrown when a scan is already in progress.</exception>
         Task ScanAsync();
+
+        /// <summary>
+        ///     Gets summary information for the specified <paramref name="share"/>.
+        /// </summary>
+        /// <param name="share">The share to summarize.</param>
+        /// <returns>The summary information.</returns>
+        Task<(int Directories, int Files)> SummarizeShareAsync(Share share);
 
         /// <summary>
         ///     Cancels the currently running scan, if one is running.

--- a/src/slskd/Shares/IShareService.cs
+++ b/src/slskd/Shares/IShareService.cs
@@ -77,13 +77,6 @@ namespace slskd.Shares
         Task ScanAsync();
 
         /// <summary>
-        ///     Starts a scan of the configured shares.
-        /// </summary>
-        /// <returns>The operation context.</returns>
-        /// <exception cref="ShareScanInProgressException">Thrown when a scan is already in progress.</exception>
-        Task StartScanAsync();
-
-        /// <summary>
         ///     Cancels the currently running scan, if one is running.
         /// </summary>
         /// <returns>A value indicating whether a scan was cancelled.</returns>

--- a/src/slskd/Shares/ISharedFileCache.cs
+++ b/src/slskd/Shares/ISharedFileCache.cs
@@ -69,14 +69,6 @@ namespace slskd.Shares
         IEnumerable<File> Search(SearchQuery query);
 
         /// <summary>
-        ///     Starts a scan of the configured shares and fills the cache.
-        /// </summary>
-        /// <param name="shares">The list of shares from which to fill the cache.</param>
-        /// <param name="filters">The list of regular expressions used to exclude files or paths from scanning.</param>
-        /// <returns>The operation context.</returns>
-        Task StartFillAsync(IEnumerable<Share> shares, IEnumerable<Regex> filters);
-
-        /// <summary>
         ///     Cancels the currently running fill operation, if one is running.
         /// </summary>
         /// <returns>A value indicating whether a fill operation was cancelled.</returns>

--- a/src/slskd/Shares/ISharedFileCache.cs
+++ b/src/slskd/Shares/ISharedFileCache.cs
@@ -35,8 +35,23 @@ namespace slskd.Shares
         /// <summary>
         ///     Returns the contents of the cache.
         /// </summary>
+        /// <param name="share">The optional share to which to limit the scope of the browse.</param>
         /// <returns>The contents of the cache.</returns>
-        IEnumerable<Directory> Browse();
+        IEnumerable<Directory> Browse(Share share = null);
+
+        /// <summary>
+        ///     Returns the number of directories in the specified <paramref name="share"/>.
+        /// </summary>
+        /// <param name="share">The share for which the directories are to be counted.</param>
+        /// <returns>The number of directories.</returns>
+        int CountDirectories(Share share);
+
+        /// <summary>
+        ///     Returns the number of files in the specified <paramref name="share"/>.
+        /// </summary>
+        /// <param name="share">The share for which the files are to be counted.</param>
+        /// <returns>The number of files.</returns>
+        int CountFiles(Share share);
 
         /// <summary>
         ///     Scans the configured shares and fills the cache.

--- a/src/slskd/Shares/ISharedFileCache.cs
+++ b/src/slskd/Shares/ISharedFileCache.cs
@@ -19,7 +19,6 @@ namespace slskd.Shares
 {
     using System.Collections.Generic;
     using System.Text.RegularExpressions;
-    using System.Threading;
     using System.Threading.Tasks;
     using Soulseek;
 
@@ -42,12 +41,10 @@ namespace slskd.Shares
         /// <summary>
         ///     Scans the configured shares and fills the cache.
         /// </summary>
-        /// <remarks>Initiates the scan, then yields execution back to the caller; does not wait for the operation to complete.</remarks>
         /// <param name="shares">The list of shares from which to fill the cache.</param>
         /// <param name="filters">The list of regular expressions used to exclude files or paths from scanning.</param>
-        /// <param name="cancellationToken">The optional cancellation token to monitor.</param>
         /// <returns>The operation context.</returns>
-        Task FillAsync(IEnumerable<Share> shares, IEnumerable<Regex> filters, CancellationToken cancellationToken = default);
+        Task FillAsync(IEnumerable<Share> shares, IEnumerable<Regex> filters);
 
         /// <summary>
         ///     Returns the contents of the specified <paramref name="directory"/>.
@@ -62,7 +59,7 @@ namespace slskd.Shares
         /// </summary>
         /// <param name="filename">The fully qualified filename to unmask.</param>
         /// <returns>The unmasked filename.</returns>
-        public string Resolve(string filename);
+        string Resolve(string filename);
 
         /// <summary>
         ///     Searches the cache for the specified <paramref name="query"/> and returns the matching files.
@@ -70,6 +67,20 @@ namespace slskd.Shares
         /// <param name="query">The query for which to search.</param>
         /// <returns>The matching files.</returns>
         IEnumerable<File> Search(SearchQuery query);
+
+        /// <summary>
+        ///     Starts a scan of the configured shares and fills the cache.
+        /// </summary>
+        /// <param name="shares">The list of shares from which to fill the cache.</param>
+        /// <param name="filters">The list of regular expressions used to exclude files or paths from scanning.</param>
+        /// <returns>The operation context.</returns>
+        Task StartFillAsync(IEnumerable<Share> shares, IEnumerable<Regex> filters);
+
+        /// <summary>
+        ///     Cancels the currently running fill operation, if one is running.
+        /// </summary>
+        /// <returns>A value indicating whether a fill operation was cancelled.</returns>
+        bool TryCancelFill();
 
         /// <summary>
         ///     Attempts to load the cache from disk.

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -52,9 +52,10 @@ namespace slskd.Shares
                 State.SetValue(state => state with
                 {
                     // scan is pending if faulted, or if state DIDN'T just transition from filling to not filling AND a scan was already pending
-                    ScanPending = current.Faulted || (!(previous.Filling && !current.Filling) && state.ScanPending),
+                    ScanPending = current.Faulted || current.Cancelled || (!(previous.Filling && !current.Filling) && state.ScanPending),
                     Scanning = current.Filling,
                     Faulted = current.Faulted,
+                    Cancelled = current.Cancelled,
                     Ready = current.Filled,
                     ScanProgress = current.FillProgress,
                     Directories = current.Directories,
@@ -166,16 +167,6 @@ namespace slskd.Shares
         public Task ScanAsync()
         {
             return Cache.FillAsync(Shares, FilterRegexes);
-        }
-
-        /// <summary>
-        ///     Starts a scan of the configured shares.
-        /// </summary>
-        /// <returns>The operation context.</returns>
-        /// <exception cref="ShareScanInProgressException">Thrown when a scan is already in progress.</exception>
-        public Task StartScanAsync()
-        {
-            return Cache.StartFillAsync(Shares, FilterRegexes);
         }
 
         /// <summary>

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -91,9 +91,9 @@ namespace slskd.Shares
         ///     Returns the entire contents of the share.
         /// </summary>
         /// <returns>The entire contents of the share.</returns>
-        public Task<IEnumerable<Directory>> BrowseAsync()
+        public Task<IEnumerable<Directory>> BrowseAsync(Share share = null)
         {
-            var results = Cache.Browse();
+            var results = Cache.Browse(share);
             var normalizedResults = results.Select(r => new Directory(r.Name.NormalizePath(), r.Files));
 
             return Task.FromResult(normalizedResults);
@@ -167,6 +167,18 @@ namespace slskd.Shares
         public Task ScanAsync()
         {
             return Cache.FillAsync(Shares, FilterRegexes);
+        }
+
+        /// <summary>
+        ///     Gets summary information for the specified <paramref name="share"/>.
+        /// </summary>
+        /// <param name="share">The share to summarize.</param>
+        /// <returns>The summary information.</returns>
+        public Task<(int Directories, int Files)> SummarizeShareAsync(Share share)
+        {
+            var dirs = Cache.CountDirectories(share);
+            var files = Cache.CountFiles(share);
+            return Task.FromResult((dirs, files));
         }
 
         /// <summary>

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -159,13 +159,32 @@ namespace slskd.Shares
         }
 
         /// <summary>
+        ///     Scans the configured shares.
+        /// </summary>
+        /// <returns>The operation context.</returns>
+        /// <exception cref="ShareScanInProgressException">Thrown when a scan is already in progress.</exception>
+        public Task ScanAsync()
+        {
+            return Cache.FillAsync(Shares, FilterRegexes);
+        }
+
+        /// <summary>
         ///     Starts a scan of the configured shares.
         /// </summary>
         /// <returns>The operation context.</returns>
         /// <exception cref="ShareScanInProgressException">Thrown when a scan is already in progress.</exception>
         public Task StartScanAsync()
         {
-            return Cache.FillAsync(Shares, FilterRegexes);
+            return Cache.StartFillAsync(Shares, FilterRegexes);
+        }
+
+        /// <summary>
+        ///     Cancels the currently running scan, if one is running.
+        /// </summary>
+        /// <returns>A value indicating whether a scan was cancelled.</returns>
+        public bool TryCancelScan()
+        {
+            return Cache.TryCancelFill();
         }
 
         /// <summary>

--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -157,7 +157,7 @@ namespace slskd.Shares
                 throw new ShareScanInProgressException("Shared files are already being scanned.");
             }
 
-            CancellationTokenSource = new CancellationTokenSource();
+            CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(Program.MasterCancellationTokenSource.Token);
             var cancellationToken = CancellationTokenSource.Token;
 
             try

--- a/src/web/src/components/System/Shares/index.js
+++ b/src/web/src/components/System/Shares/index.js
@@ -19,10 +19,11 @@ import ShareTable from './ShareTable';
 
 const Index = ({ state = {} } = {}) => {
   const [loading, setLoading] = useState(true);
+  const [working, setWorking] = useState(false);
   const [shares, setShares] = useState([]);
   const [modal, setModal] = useState(false);
 
-  const { scanning, scanProgress, scanPending } = state;
+  const { scanning, scanProgress, scanPending, directories, files } = state;
   const scanned = !scanning;
 
   useEffect(() => {
@@ -47,30 +48,76 @@ const Index = ({ state = {} } = {}) => {
     }
   };
 
+  const rescan = async () => {
+    try {
+      setWorking(true);
+      await sharesLib.rescan();
+    } catch (error) {
+      console.error(error);
+      toast.error(error?.response?.data ?? error?.message ?? error);
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  const cancel = async () => {
+    try {
+      setWorking(true);
+      await sharesLib.cancel();
+    } catch (error) {
+      console.error(error);
+      toast.error(error?.response?.data ?? error?.message ?? error ?? 'Failed to cancel the scan');
+    } finally {
+      setWorking(false);      
+    }
+  };
+
+  const ScanButton = () => <ShrinkableButton
+    primary={!scanPending}
+    color={scanPending ? 'yellow' : undefined}
+    icon='refresh'
+    loading={working}
+    disabled={working}
+    mediaQuery={'(max-width: 516px)'} 
+    onClick={() => rescan()}
+  >Rescan Shares</ShrinkableButton>;
+
+  const CancelButton = () => <ShrinkableButton
+    color='red'
+    icon='x'
+    disabled={working}
+    mediaQuery={'(max-width: 516px)'}
+    onClick={() => cancel()}
+  >Cancel Scan</ShrinkableButton>;
+
   const shared = shares.filter(share => !share.isExcluded);
   const excluded = shares.filter(share => share.isExcluded);
 
   return (
     <>
-      <div className="header-buttons">
-        <ShrinkableButton
-          primary={!scanPending}
-          color={scanPending ? 'yellow' : undefined}
-          icon='refresh'
-          loading={scanning}
-          disabled={scanning || loading}
-          mediaQuery={'(max-width: 516px)'} 
-          onClick={() => sharesLib.rescan()}
-        >{scanning ? 'Scanning shares' : 'Rescan Shares'}</ShrinkableButton>
-      </div>
-      <Divider/>
       <Switch
-        filling={(loading || scanning) && <LoaderSegment>{Math.round(scanProgress * 100)}%</LoaderSegment>}
+        loading={loading && <LoaderSegment/>}
       >
-        <ShareTable shares={shared} onClick={setModal}/>
-        <ExclusionTable exclusions={excluded}/>
+        <div className="header-buttons">
+          <Switch
+            scanning={scanning && <CancelButton/>}
+          >
+            <ScanButton/>
+          </Switch>
+        </div>
+        <Divider/>
+        <Switch
+          filling={scanning && <LoaderSegment>
+            <div>
+              <div>{Math.round(scanProgress * 100)}%</div>
+              <div className='share-scan-detail'>Found {files} files in {directories} directories</div>
+            </div></LoaderSegment>}
+        >
+          <ShareTable shares={shared} onClick={setModal}/>
+          <ExclusionTable exclusions={excluded}/>
+        </Switch>
+        <ContentsModal share={modal} onClose={() => setModal(false)}/>
       </Switch>
-      <ContentsModal share={modal} onClose={() => setModal(false)}/>
     </>    
   );
 };

--- a/src/web/src/components/System/System.css
+++ b/src/web/src/components/System/System.css
@@ -63,3 +63,8 @@
 .share-count-column {
   width: 110px;
 }
+
+.share-scan-detail {
+  margin-top: 10px;
+  font-size: 14px;
+}

--- a/src/web/src/lib/shares.js
+++ b/src/web/src/lib/shares.js
@@ -21,3 +21,7 @@ export const browse = async ({ id } = {}) => {
 export const rescan = async () => {
   return (await api.put('/shares')).data;
 };
+
+export const cancel = async () => {
+  return (await api.delete('/shares')).data;
+};


### PR DESCRIPTION
I decided to tackle a bunch of stuff all at once:

* Adds an application-level cancellation token to help things shut down in a timely manner, especially when a scan is in progress
* Adds the ability to cancel share scans, along with an API endpoint and button on the UI
* Fixes a number of issues with share counts and state (reverses a bug that was added recently)
* Vastly improves the performance of the display of share configuration
* Forces a share scan if the application can't load the shared file cache on start (this also fixes the issue with share counts/status being unknown, as shares are either loaded, or scanned at startup)
* Updates the UI every 1% of scan progress, instead of 5% (this is all the monitoring I want to provide at the moment)

Closes #490 
Closes #443 
Closes #532 