### PR TITLE
Default scan workers to Environment.ProcessorCount

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -170,7 +170,7 @@ Scanning shares is an I/O intensive operation; all of the files and directories 
 are used to allow metadata to be read from several files concurrently. The scan generally gets faster as additional workers are added, but each worker also adds additional I/O pressure and increases CPU and memory usage. At some number of workers
 performance will start to get worse as more are added.  The optimal number of workers will vary from system to system, so if scan performance is important to you it will be a good idea to experiment to see what the optimal number is for your system.
 
-The default number of workers is 16.
+The default number of workers determined by the [Environment.ProcessorCount](https://learn.microsoft.com/en-us/dotnet/api/system.environment.processorcount?view=net-6.0) property.
 
 | Command Line                 | Environment Variable       | Description                                             |
 | ---------------------------- | -------------------------- | ------------------------------------------------------- |

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -381,32 +381,6 @@ namespace slskd
             public ShareCacheOptions Cache { get; init; } = new ShareCacheOptions();
 
             /// <summary>
-            ///     Share caching options.
-            /// </summary>
-            public class ShareCacheOptions
-            {
-                /// <summary>
-                ///     Gets the type of storage to use for the share cache.
-                /// </summary>
-                [Argument(default, "share-cache-storage-mode")]
-                [EnvironmentVariable("SHARE_CACHE_STORAGE_MODE")]
-                [Description("the type of storage to use for the cache")]
-                [Enum(typeof(StorageMode))]
-                [RequiresRestart]
-                public string StorageMode { get; init; } = slskd.StorageMode.Memory.ToString().ToLowerInvariant();
-
-                /// <summary>
-                ///     Gets the number of workers to use while scanning shares.
-                /// </summary>
-                [Argument(default, "share-cache-workers")]
-                [EnvironmentVariable("SHARE_CACHE_WORKERS")]
-                [Description("the number of workers to use while scanning shares")]
-                [Range(1, 128)]
-                [RequiresRestart]
-                public int Workers { get; init; } = 16;
-            }
-
-            /// <summary>
             ///     Extended validation.
             /// </summary>
             /// <param name="validationContext"></param>
@@ -491,6 +465,32 @@ namespace slskd
                 }
 
                 return results;
+            }
+
+            /// <summary>
+            ///     Share caching options.
+            /// </summary>
+            public class ShareCacheOptions
+            {
+                /// <summary>
+                ///     Gets the type of storage to use for the share cache.
+                /// </summary>
+                [Argument(default, "share-cache-storage-mode")]
+                [EnvironmentVariable("SHARE_CACHE_STORAGE_MODE")]
+                [Description("the type of storage to use for the cache")]
+                [Enum(typeof(StorageMode))]
+                [RequiresRestart]
+                public string StorageMode { get; init; } = slskd.StorageMode.Memory.ToString().ToLowerInvariant();
+
+                /// <summary>
+                ///     Gets the number of workers to use while scanning shares.
+                /// </summary>
+                [Argument(default, "share-cache-workers")]
+                [EnvironmentVariable("SHARE_CACHE_WORKERS")]
+                [Description("the number of workers to use while scanning shares")]
+                [Range(1, 128)]
+                [RequiresRestart]
+                public int Workers { get; init; } = Environment.ProcessorCount;
             }
         }
 


### PR DESCRIPTION
The previous default (16) was causing the application to become unresponsive during a scan, depending on the system the app was running on.  This PR uses what it believes is the processor count of the system, which should be the best for most people.

I guess I should note that the performance of the scan has a lot more to do with I/O performance than CPU so this might not make a lot of sense for some systems, but it's better than using a static value.

Closes #659 