### PR TITLE
Fixed padding-top to 14px for transfers-header-segment

### DIFF
--- a/src/web/src/components/Transfers/Transfers.css
+++ b/src/web/src/components/Transfers/Transfers.css
@@ -1,13 +1,14 @@
 .transfers-header-segment {
   margin-top: 15px !important;
   height: 78px !important;
-  padding-top: 20px !important;
+  padding-top: 14px !important;
   display: flex;
 }
 
 .transfers-segment-icon {
   padding-top: 5px;
   padding-right: 1em;
+  margin-top: 6px;
 }
 
 .transfers-header-action-button {


### PR DESCRIPTION
Reduced the 6px of ```padding-top``` for ```transfers-header-segment```.
Added ```margin-top``` property to ```transfers-segment-icon``` class to position icons appropriately.