### PR TITLE
When scanning shares, apply filters to directories as well as files

### DIFF
--- a/src/slskd/Shares/SharedFileCache.cs
+++ b/src/slskd/Shares/SharedFileCache.cs
@@ -216,12 +216,14 @@ namespace slskd.Shares
                     {
                         try
                         {
-                            return System.IO.Directory.GetDirectories(share.LocalPath, "*", new EnumerationOptions()
+                            var directories = System.IO.Directory.GetDirectories(share.LocalPath, "*", new EnumerationOptions()
                             {
                                 AttributesToSkip = FileAttributes.Hidden | FileAttributes.System,
                                 IgnoreInaccessible = true,
                                 RecurseSubdirectories = true,
                             });
+
+                            return directories.Where(directory => !filters.Any(filter => filter.IsMatch(directory)));
                         }
                         catch (Exception ex)
                         {


### PR DESCRIPTION
Currently filters are checked against files as they are being scanned, but not directories.  This can leave a bunch of empty directories in the share.

Closes #665 