### PR TITLE
Display the correct buttons in the header when viewing a search that returned no results

### DIFF
--- a/src/web/src/components/Search/Detail/SearchDetail.js
+++ b/src/web/src/components/Search/Detail/SearchDetail.js
@@ -118,7 +118,7 @@ const SearchDetail = ({ search, creating, stopping, removing, disabled, onCreate
 
   const filteredCount = results?.length - sortedAndFilteredResults.length;
   const remainingCount = sortedAndFilteredResults.length - displayCount;
-  const loaded = (!removing && !creating && !loading && results && results.length > 0);
+  const loaded = (!removing && !creating && !loading && results);
 
   if (error) {
     return (<ErrorSegment caption={error?.message ?? error}/>);


### PR DESCRIPTION
This PR should fix an issue with displaying a 'Stop' button in the SearchDetailHeader instead of 'Delete' and 'Search Again' when viewing a search that returned no results.

Closes #648 