### PR TITLE
Fix potential bug when reporting upload speed

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -689,7 +689,7 @@ namespace slskd
             {
                 try
                 {
-                    _ = Client.SendUploadSpeedAsync(Convert.ToInt32(args.Transfer.AverageSpeed));
+                    _ = Client.SendUploadSpeedAsync(Convert.ToInt32(Math.Ceiling(args.Transfer.AverageSpeed)));
                 }
                 catch (Exception ex)
                 {

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -685,11 +685,11 @@ namespace slskd
 
             Log.Information($"[{direction}] [{user}/{file}] {oldState} => {state}{(completed ? $" ({xfer.BytesTransferred}/{xfer.Size} = {xfer.PercentComplete}%) @ {xfer.AverageSpeed.SizeSuffix()}/s" : string.Empty)}");
 
-            if (xfer.Direction == TransferDirection.Upload && xfer.State.HasFlag(TransferStates.Completed | TransferStates.Succeeded))
+            if (xfer.Direction == TransferDirection.Upload && xfer.State.HasFlag(TransferStates.Completed | TransferStates.Succeeded) && args.Transfer.AverageSpeed > 0)
             {
                 try
                 {
-                    _ = Client.SendUploadSpeedAsync((int)args.Transfer.AverageSpeed);
+                    _ = Client.SendUploadSpeedAsync(Convert.ToInt32(args.Transfer.AverageSpeed));
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
A user in Discord reported an error in this logic that suggests a zero was somehow passed to `SendUploadSpeedAsync`.  The value may have been zero because the transfer completed abnormally quickly, or the value may have been less than 1, resulting in some internal rounding that produced `0` when converted to an `int`.

This PR uses `Math.Ceiling` to ensure any nonzero `double` winds up a nonzero integer.