### PR TITLE
Temporarily disable API key authentication

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -612,13 +612,13 @@ namespace slskd
                         };
                     });
 
-                services.AddAuthentication(ApiKeyAuthentication.AuthenticationScheme)
-                    .AddScheme<ApiKeyAuthenticationOptions, ApiKeyAuthenticationHandler>(ApiKeyAuthentication.AuthenticationScheme, options =>
-                    {
-                        options.EnableSignalRSupport = true;
-                        options.SignalRRoutePrefix = "/hub";
-                        options.Role = Role.Administrator;
-                    });
+                //services.AddAuthentication(ApiKeyAuthentication.AuthenticationScheme)
+                //    .AddScheme<ApiKeyAuthenticationOptions, ApiKeyAuthenticationHandler>(ApiKeyAuthentication.AuthenticationScheme, options =>
+                //    {
+                //        options.EnableSignalRSupport = true;
+                //        options.SignalRRoutePrefix = "/hub";
+                //        options.Role = Role.Administrator;
+                //    });
             }
             else
             {


### PR DESCRIPTION
Adding this broke the existing JWT authentication, leaving users unable to log in to the UI.

Closes #677 