### PR TITLE
Change version delimiter for hash to plus

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -42,7 +42,7 @@ done
 if [ -z "$version" ]; then 
   tag=$(git describe --tags --abbrev=0)
   sha=$(git rev-parse --short HEAD)
-  version=$tag-$sha
+  version=$tag+$sha
 fi
 
 if [ "$dotnet_only" == true ]; then

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -131,7 +131,7 @@ namespace slskd
         /// <summary>
         ///     Gets the semantic application version.
         /// </summary>
-        public static string SemanticVersion { get; } = InformationalVersion.Split('-').First();
+        public static string SemanticVersion { get; } = InformationalVersion.Split('+').First();
 
         /// <summary>
         ///     Gets the full application version, including both assembly and informational versions.


### PR DESCRIPTION
Should fix #642

Now conforms with SemVer 2 and shouldn't give errors if the short hash is only numbers