### PR TITLE
Add authorization policies

### DIFF
--- a/src/slskd/Common/Authentication/AuthPolicy.cs
+++ b/src/slskd/Common/Authentication/AuthPolicy.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="LogsController.cs" company="slskd Team">
+﻿// <copyright file="AuthPolicy.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -15,30 +15,14 @@
 //     along with this program.  If not, see https://www.gnu.org/licenses/.
 // </copyright>
 
-namespace slskd.Core.API
+namespace slskd
 {
-    using Microsoft.AspNetCore.Authorization;
-    using Microsoft.AspNetCore.Mvc;
-
     /// <summary>
-    ///     Logs.
+    ///     Authentication policies.
     /// </summary>
-    [Route("api/v{version:apiVersion}/[controller]")]
-    [ApiVersion("0")]
-    [ApiController]
-    [Produces("application/json")]
-    [Consumes("application/json")]
-    public class LogsController : ControllerBase
+    public static class AuthPolicy
     {
-        /// <summary>
-        ///     Gets the last few application logs.
-        /// </summary>
-        /// <returns></returns>
-        [HttpGet]
-        [Authorize(Policy = AuthPolicy.Any)]
-        public IActionResult Logs()
-        {
-            return Ok(Program.LogBuffer);
-        }
+        public const string JwtOnly = "Jwt";
+        public const string Any = "Any";
     }
 }

--- a/src/slskd/Core/API/Controllers/ApplicationController.cs
+++ b/src/slskd/Core/API/Controllers/ApplicationController.cs
@@ -58,7 +58,7 @@ namespace slskd.Core.API
         /// </summary>
         /// <returns></returns>
         [HttpGet]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         public IActionResult State()
         {
             return Ok(ApplicationStateMonitor.CurrentValue);
@@ -69,7 +69,7 @@ namespace slskd.Core.API
         /// </summary>
         /// <returns></returns>
         [HttpDelete]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.JwtOnly)]
         public IActionResult Shutdown()
         {
             Program.MasterCancellationTokenSource.Cancel();
@@ -89,7 +89,7 @@ namespace slskd.Core.API
         /// </summary>
         /// <returns></returns>
         [HttpPut]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.JwtOnly)]
         public IActionResult Restart()
         {
             Program.MasterCancellationTokenSource.Cancel();
@@ -104,7 +104,7 @@ namespace slskd.Core.API
         /// </summary>
         /// <returns></returns>
         [HttpGet("version")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         public IActionResult GetVersion()
         {
             return Ok(Program.SemanticVersion);
@@ -115,7 +115,7 @@ namespace slskd.Core.API
         /// </summary>
         /// <returns></returns>
         [HttpGet("version/latest")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> CheckVersion([FromQuery] bool forceCheck = false)
         {
             if (forceCheck)
@@ -131,7 +131,7 @@ namespace slskd.Core.API
         /// </summary>
         /// <returns></returns>
         [HttpPost("gc")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         public IActionResult CollectGarbage()
         {
             Application.CollectGarbage();
@@ -140,7 +140,7 @@ namespace slskd.Core.API
         }
 
         [HttpGet("dump")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> DumpMemory()
         {
             using var dumper = new Dumper();

--- a/src/slskd/Core/API/Controllers/MetricsController.cs
+++ b/src/slskd/Core/API/Controllers/MetricsController.cs
@@ -36,7 +36,7 @@ namespace slskd.Core.API
         /// </summary>
         /// <returns></returns>
         [HttpGet]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> Get()
         {
             var response = await Metrics.BuildAsync();

--- a/src/slskd/Core/API/Controllers/OptionsController.cs
+++ b/src/slskd/Core/API/Controllers/OptionsController.cs
@@ -56,7 +56,7 @@ namespace slskd.Core.API
         /// </summary>
         /// <returns></returns>
         [HttpGet]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(Options), 200)]
         public IActionResult Current()
         {
@@ -69,7 +69,7 @@ namespace slskd.Core.API
         /// <returns></returns>
         [HttpGet]
         [Route("startup")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(Options), 200)]
         public IActionResult Startup()
         {
@@ -82,7 +82,7 @@ namespace slskd.Core.API
         /// <returns></returns>
         [HttpGet]
         [Route("debug")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.JwtOnly)]
         [ProducesResponseType(typeof(string), 200)]
         public IActionResult Debug()
         {
@@ -95,7 +95,7 @@ namespace slskd.Core.API
         }
 
         [HttpGet]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.JwtOnly)]
         [Route("yaml/location")]
         public IActionResult GetYamlFileLocation()
         {
@@ -103,7 +103,7 @@ namespace slskd.Core.API
         }
 
         [HttpGet]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.JwtOnly)]
         [Route("yaml")]
         public IActionResult GetYamlFile()
         {
@@ -117,7 +117,7 @@ namespace slskd.Core.API
         }
 
         [HttpPost]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.JwtOnly)]
         [Route("yaml")]
         public IActionResult UpdateYamlFile([FromBody] string yaml)
         {
@@ -144,7 +144,7 @@ namespace slskd.Core.API
         }
 
         [HttpPost]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [Route("yaml/validate")]
         public IActionResult ValidateYamlFile([FromBody] string yaml)
         {

--- a/src/slskd/Core/API/Controllers/ServerController.cs
+++ b/src/slskd/Core/API/Controllers/ServerController.cs
@@ -54,7 +54,7 @@ namespace slskd.Core.API
         /// <returns></returns>
         [HttpPut]
         [Route("")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(200)]
         [ProducesResponseType(403)]
         public async Task<IActionResult> Connect()
@@ -74,7 +74,7 @@ namespace slskd.Core.API
         /// <returns></returns>
         [HttpDelete]
         [Route("")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(204)]
         [ProducesResponseType(403)]
         public IActionResult Disconnect([FromBody] string message)
@@ -94,7 +94,7 @@ namespace slskd.Core.API
         /// <response code="200"></response>
         [HttpGet]
         [Route("")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(ServerState), 200)]
         [ProducesResponseType(403)]
         public IActionResult Get()

--- a/src/slskd/Core/API/Controllers/SessionController.cs
+++ b/src/slskd/Core/API/Controllers/SessionController.cs
@@ -61,7 +61,7 @@ namespace slskd.Core.API
         /// <response code="403">The authentication is is invalid.</response>
         [HttpGet]
         [Route("")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(200)]
         [ProducesResponseType(401)]
         public IActionResult Check()

--- a/src/slskd/Core/API/Hubs/ApplicationHub.cs
+++ b/src/slskd/Core/API/Hubs/ApplicationHub.cs
@@ -60,7 +60,7 @@ namespace slskd.Core.API
     /// <summary>
     ///     The application SignalR hub.
     /// </summary>
-    [Authorize]
+    [Authorize(Policy = AuthPolicy.Any)]
     public class ApplicationHub : Hub
     {
         public ApplicationHub(

--- a/src/slskd/Core/API/Hubs/LogsHub.cs
+++ b/src/slskd/Core/API/Hubs/LogsHub.cs
@@ -47,7 +47,7 @@ namespace slskd.Core.API
     /// <summary>
     ///     The logs SignalR hub.
     /// </summary>
-    [Authorize]
+    [Authorize(Policy = AuthPolicy.Any)]
     public class LogsHub : Hub
     {
         public override async Task OnConnectedAsync()

--- a/src/slskd/Messaging/API/Controllers/ConversationsController.cs
+++ b/src/slskd/Messaging/API/Controllers/ConversationsController.cs
@@ -66,7 +66,7 @@ namespace slskd.Messaging.API
         ///     A conversation with the specified username, or a message matching the specified id could not be found.
         /// </response>
         [HttpPut("{username}/{id}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(200)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> Acknowledge([FromRoute]string username, [FromRoute]int id)
@@ -90,7 +90,7 @@ namespace slskd.Messaging.API
         /// <response code="200">The request completed successfully.</response>
         /// <response code="404">A conversation with the specified username could not be found.</response>
         [HttpPut("{username}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(200)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> AcknowledgeAll([FromRoute]string username)
@@ -124,7 +124,7 @@ namespace slskd.Messaging.API
         /// <response code="204">The request completed successfully.</response>
         /// <response code="404">A conversation with the specified username could not be found.</response>
         [HttpDelete("{username}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(404)]
         [ProducesResponseType(204)]
         public IActionResult Delete([FromRoute]string username)
@@ -145,7 +145,7 @@ namespace slskd.Messaging.API
         /// <returns></returns>
         /// <response code="200">The request completed successfully.</response>
         [HttpGet("")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(Dictionary<string, List<PrivateMessageResponse>>), 200)]
         public IActionResult GetAll()
         {
@@ -166,7 +166,7 @@ namespace slskd.Messaging.API
         /// <response code="200">The request completed successfully.</response>
         /// <response code="404">A matching search was not found.</response>
         [HttpGet("{username}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(List<PrivateMessageResponse>), 200)]
         [ProducesResponseType(404)]
         public IActionResult GetByUsername([FromRoute]string username)
@@ -192,7 +192,7 @@ namespace slskd.Messaging.API
         /// <response code="201">The request completed successfully.</response>
         /// <response code="400">The specified message is null or empty.</response>
         [HttpPost("{username}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(201)]
         [ProducesResponseType(400)]
         public async Task<IActionResult> Send([FromRoute]string username, [FromBody]string message)

--- a/src/slskd/Messaging/API/Controllers/PublicChatController.cs
+++ b/src/slskd/Messaging/API/Controllers/PublicChatController.cs
@@ -45,7 +45,7 @@ namespace slskd.Messaging.API
         /// </summary>
         /// <returns></returns>
         [HttpPost]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> Start()
         {
             await Client.StartPublicChatAsync();
@@ -57,7 +57,7 @@ namespace slskd.Messaging.API
         /// </summary>
         /// <returns></returns>
         [HttpDelete]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> Stop()
         {
             await Client.StopPublicChatAsync();

--- a/src/slskd/Messaging/API/Controllers/RoomsController.cs
+++ b/src/slskd/Messaging/API/Controllers/RoomsController.cs
@@ -59,7 +59,7 @@ namespace slskd.Messaging.API
         /// <returns></returns>
         /// <response code="200">The request completed successfully.</response>
         [HttpGet("joined")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(Dictionary<string, Dictionary<string, Room>>), 200)]
         public IActionResult GetAll()
         {
@@ -74,7 +74,7 @@ namespace slskd.Messaging.API
         /// <response code="200">The request completed successfully.</response>
         /// <response code="404">The specified roomName could not be found.</response>
         [HttpGet("joined/{roomName}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(Room), 200)]
         [ProducesResponseType(404)]
         public IActionResult GetByRoomName([FromRoute]string roomName)
@@ -96,7 +96,7 @@ namespace slskd.Messaging.API
         /// <response code="201">The request completed successfully.</response>
         /// <response code="404">The specified roomName could not be found.</response>
         [HttpPost("joined/{roomName}/messages")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(201)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> SendMessage([FromRoute]string roomName, [FromBody]string message)
@@ -119,7 +119,7 @@ namespace slskd.Messaging.API
         /// <response code="201">The request completed successfully.</response>
         /// <response code="404">The specified roomName could not be found.</response>
         [HttpPost("joined/{roomName}/ticker")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(201)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> SetTicker([FromRoute] string roomName, [FromBody] string message)
@@ -142,7 +142,7 @@ namespace slskd.Messaging.API
         /// <response code="201">The request completed successfully.</response>
         /// <response code="404">The specified roomName could not be found.</response>
         [HttpPost("joined/{roomName}/members")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(201)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> AddRoomMember([FromRoute]string roomName, [FromBody]string username)
@@ -164,7 +164,7 @@ namespace slskd.Messaging.API
         /// <response code="200">The request completed successfully.</response>
         /// <response code="404">The specified roomName could not be found.</response>
         [HttpGet("joined/{roomName}/users")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(IList<UserData>), 200)]
         [ProducesResponseType(404)]
         public IActionResult GetUsersByRoomName([FromRoute]string roomName)
@@ -188,7 +188,7 @@ namespace slskd.Messaging.API
         /// <response code="200">The request completed successfully.</response>
         /// <response code="404">The specified roomName could not be found.</response>
         [HttpGet("joined/{roomName}/messages")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(IList<RoomMessage>), 200)]
         [ProducesResponseType(404)]
         public IActionResult GetMessagesByRoomName([FromRoute]string roomName)
@@ -209,7 +209,7 @@ namespace slskd.Messaging.API
         /// </summary>
         /// <returns></returns>
         [HttpGet("available")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(List<RoomInfo>), 200)]
         public async Task<IActionResult> GetRooms()
         {
@@ -237,7 +237,7 @@ namespace slskd.Messaging.API
         /// <response code="201">The request completed successfully.</response>
         /// <response code="304">The room has already been joined.</response>
         [HttpPost("joined")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(Room), 201)]
         [ProducesResponseType(304)]
         public async Task<IActionResult> JoinRoom([FromBody]string roomName)
@@ -273,7 +273,7 @@ namespace slskd.Messaging.API
         /// <response code="204">The request completed successfully.</response>
         /// <response code="404">The room has not been joined.</response>
         [HttpDelete("joined/{roomName}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(204)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> LeaveRoom([FromRoute]string roomName)

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -645,6 +645,12 @@ namespace slskd
                         policy.AuthenticationSchemes.Add(PassthroughAuthentication.AuthenticationScheme);
                         policy.RequireAuthenticatedUser();
                     });
+
+                    options.AddPolicy(AuthPolicy.JwtOnly, policy =>
+                    {
+                        policy.AuthenticationSchemes.Add(PassthroughAuthentication.AuthenticationScheme);
+                        policy.RequireAuthenticatedUser();
+                    });
                 });
 
                 services.AddAuthentication(PassthroughAuthentication.AuthenticationScheme)

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -579,6 +579,22 @@ namespace slskd
 
             if (!OptionsAtStartup.Web.Authentication.Disabled)
             {
+                services.AddAuthorization(options =>
+                {
+                    options.AddPolicy(AuthPolicy.JwtOnly, policy =>
+                    {
+                        policy.AuthenticationSchemes.Add(JwtBearerDefaults.AuthenticationScheme);
+                        policy.RequireAuthenticatedUser();
+                    });
+
+                    options.AddPolicy(AuthPolicy.Any, policy =>
+                    {
+                        policy.AuthenticationSchemes.Add(ApiKeyAuthentication.AuthenticationScheme);
+                        policy.AuthenticationSchemes.Add(JwtBearerDefaults.AuthenticationScheme);
+                        policy.RequireAuthenticatedUser();
+                    });
+                });
+
                 services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                     .AddJwtBearer(options =>
                     {
@@ -610,19 +626,26 @@ namespace slskd
                                 return Task.CompletedTask;
                             },
                         };
+                    })
+                    .AddScheme<ApiKeyAuthenticationOptions, ApiKeyAuthenticationHandler>(ApiKeyAuthentication.AuthenticationScheme, options =>
+                    {
+                        options.EnableSignalRSupport = true;
+                        options.SignalRRoutePrefix = "/hub";
+                        options.Role = Role.Administrator;
                     });
-
-                //services.AddAuthentication(ApiKeyAuthentication.AuthenticationScheme)
-                //    .AddScheme<ApiKeyAuthenticationOptions, ApiKeyAuthenticationHandler>(ApiKeyAuthentication.AuthenticationScheme, options =>
-                //    {
-                //        options.EnableSignalRSupport = true;
-                //        options.SignalRRoutePrefix = "/hub";
-                //        options.Role = Role.Administrator;
-                //    });
             }
             else
             {
                 Log.Warning("Authentication of web requests is DISABLED");
+
+                services.AddAuthorization(options =>
+                {
+                    options.AddPolicy(AuthPolicy.Any, policy =>
+                    {
+                        policy.AuthenticationSchemes.Add(PassthroughAuthentication.AuthenticationScheme);
+                        policy.RequireAuthenticatedUser();
+                    });
+                });
 
                 services.AddAuthentication(PassthroughAuthentication.AuthenticationScheme)
                     .AddScheme<PassthroughAuthenticationOptions, PassthroughAuthenticationHandler>(PassthroughAuthentication.AuthenticationScheme, options =>

--- a/src/slskd/Search/API/Controllers/SearchesController.cs
+++ b/src/slskd/Search/API/Controllers/SearchesController.cs
@@ -54,7 +54,7 @@ namespace slskd.Search.API
         /// <response code="400">The specified <paramref name="request"/> was malformed.</response>
         /// <response code="500">The search terminated abnormally.</response>
         [HttpPost("")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> Post([FromBody] SearchRequest request)
         {
             if (string.IsNullOrWhiteSpace(request.SearchText))
@@ -91,7 +91,7 @@ namespace slskd.Search.API
         /// <response code="200">The request completed successfully.</response>
         /// <response code="404">A matching search was not found.</response>
         [HttpGet("{id}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> GetById([FromRoute] Guid id, [FromQuery] bool includeResponses = false)
         {
             var search = await Searches.FindAsync(search => search.Id == id, includeResponses);
@@ -112,7 +112,7 @@ namespace slskd.Search.API
         /// <response code="200">The request completed successfully.</response>
         /// <response code="404">A matching search was not found.</response>
         [HttpGet("{id}/responses")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> GetResponsesById([FromRoute] Guid id)
         {
             var search = await Searches.FindAsync(search => search.Id == id, includeResponses: true);
@@ -130,7 +130,7 @@ namespace slskd.Search.API
         /// </summary>
         /// <returns></returns>
         [HttpGet("")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> GetAll()
         {
             var searches = await Searches.ListAsync();
@@ -145,7 +145,7 @@ namespace slskd.Search.API
         /// <response code="304">The search was not in progress.</response>
         /// <returns></returns>
         [HttpPut("{id}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(200)]
         [ProducesResponseType(304)]
         public async Task<IActionResult> Cancel([FromRoute] Guid id)
@@ -173,7 +173,7 @@ namespace slskd.Search.API
         /// <response code="404">A search with the specified id could not be found.</response>
         /// <returns></returns>
         [HttpDelete("{id}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(204)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> Delete([FromRoute] Guid id)

--- a/src/slskd/Search/API/Hubs/SearchHub.cs
+++ b/src/slskd/Search/API/Hubs/SearchHub.cs
@@ -73,7 +73,7 @@ namespace slskd.Search.API
     /// <summary>
     ///     The search SignalR hub.
     /// </summary>
-    [Authorize]
+    [Authorize(Policy = AuthPolicy.Any)]
     public class SearchHub : Hub
     {
         public SearchHub(

--- a/src/slskd/Shares/API/Controllers/SharesController.cs
+++ b/src/slskd/Shares/API/Controllers/SharesController.cs
@@ -32,7 +32,6 @@ namespace slskd.Shares.API
     [Produces("application/json")]
     [Consumes("application/json")]
     [Route("api/v{version:apiVersion}/[controller]")]
-    [Authorize]
     public class SharesController : ControllerBase
     {
         /// <summary>
@@ -53,7 +52,7 @@ namespace slskd.Shares.API
         /// <response code="200">The request completed successfully.</response>
         /// <returns></returns>
         [HttpGet("")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(IEnumerable<SummarizedShare>), 200)]
         public async Task<IActionResult> List()
         {
@@ -87,7 +86,7 @@ namespace slskd.Shares.API
         /// <response code="404">The requested share could not be found.</response>
         /// <returns></returns>
         [HttpGet("{id}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(SummarizedShare), 200)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> Get(string id)
@@ -122,7 +121,7 @@ namespace slskd.Shares.API
         /// <returns></returns>
         /// <response code="200">The request completed successfully.</response>
         [HttpGet("contents")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(IEnumerable<Directory>), 200)]
         public async Task<IActionResult> BrowseAll()
         {
@@ -137,6 +136,7 @@ namespace slskd.Shares.API
         /// <response code="200">The request completed successfully.</response>
         /// <response code="404">The requested share could not be found.</response>
         [HttpGet("{id}/contents")]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(IEnumerable<Directory>), 200)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> BrowseShare(string id)
@@ -161,7 +161,7 @@ namespace slskd.Shares.API
         /// <response code="409">A share scan is already in progress.</response>
         [HttpPut]
         [Route("")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(204)]
         [ProducesResponseType(409)]
         public IActionResult RescanSharesAsync()
@@ -186,7 +186,7 @@ namespace slskd.Shares.API
         /// <response code="409">A share scan was not in progress.</response>
         [HttpDelete]
         [Route("")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(204)]
         [ProducesResponseType(404)]
         public IActionResult CancelShareScan()

--- a/src/slskd/Transfers/API/Controllers/TransfersController.cs
+++ b/src/slskd/Transfers/API/Controllers/TransfersController.cs
@@ -57,7 +57,7 @@ namespace slskd.Transfers.API
         /// <response code="204">The download was cancelled successfully.</response>
         /// <response code="404">The specified download was not found.</response>
         [HttpDelete("downloads/{username}/{id}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(204)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> CancelDownloadAsync([FromRoute, Required] string username, [FromRoute, Required]string id, [FromQuery]bool remove = false)
@@ -94,7 +94,7 @@ namespace slskd.Transfers.API
         /// <response code="204">The upload was cancelled successfully.</response>
         /// <response code="404">The specified upload was not found.</response>
         [HttpDelete("uploads/{username}/{id}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(204)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> CancelUpload([FromRoute, Required] string username, [FromRoute, Required]string id, [FromQuery]bool remove = false)
@@ -131,7 +131,7 @@ namespace slskd.Transfers.API
         /// <response code="403">The download was rejected.</response>
         /// <response code="500">An unexpected error was encountered.</response>
         [HttpPost("downloads/{username}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(201)]
         [ProducesResponseType(typeof(string), 403)]
         [ProducesResponseType(typeof(string), 500)]
@@ -154,7 +154,7 @@ namespace slskd.Transfers.API
         /// <returns></returns>
         /// <response code="200">The request completed successfully.</response>
         [HttpGet("downloads")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(200)]
         public async Task<IActionResult> GetDownloadsAsync([FromQuery]bool includeRemoved = false)
         {
@@ -181,7 +181,7 @@ namespace slskd.Transfers.API
         /// <returns></returns>
         /// <response code="200">The request completed successfully.</response>
         [HttpGet("downloads/{username}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(200)]
         public async Task<IActionResult> GetDownloadsAsync([FromRoute, Required] string username)
         {
@@ -207,7 +207,7 @@ namespace slskd.Transfers.API
         }
 
         [HttpGet("downloads/{username}/{id}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(API.Transfer), 200)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> GetDownload([FromRoute, Required] string username, [FromRoute, Required] string id)
@@ -237,7 +237,7 @@ namespace slskd.Transfers.API
         /// <response code="200">The request completed successfully.</response>
         /// <response code="404">The specified download was not found.</response>
         [HttpGet("downloads/{username}/{id}/position")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(API.Transfer), 200)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> GetPlaceInQueueAsync([FromRoute, Required] string username, [FromRoute, Required] string id)
@@ -268,7 +268,7 @@ namespace slskd.Transfers.API
         /// <returns></returns>
         /// <response code="200">The request completed successfully.</response>
         [HttpGet("uploads")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(200)]
         public async Task<IActionResult> GetUploads([FromQuery] bool includeRemoved = false)
         {
@@ -295,7 +295,7 @@ namespace slskd.Transfers.API
         /// <returns></returns>
         /// <response code="200">The request completed successfully.</response>
         [HttpGet("uploads/{username}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(200)]
         public async Task<IActionResult> GetUploads([FromRoute, Required] string username)
         {
@@ -328,7 +328,7 @@ namespace slskd.Transfers.API
         /// <returns></returns>
         /// <response code="200">The request completed successfully.</response>
         [HttpGet("uploads/{username}/{id}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(200)]
         public async Task<IActionResult> GetUploads([FromRoute, Required] string username, [FromRoute, Required] string id)
         {

--- a/src/slskd/Users/API/Controllers/UsersController.cs
+++ b/src/slskd/Users/API/Controllers/UsersController.cs
@@ -59,7 +59,7 @@ namespace slskd.Users.API
         /// <returns></returns>
         /// <response code="200">The request completed successfully.</response>
         [HttpGet("{username}/endpoint")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(IPEndPoint), 200)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> Endpoint([FromRoute, Required] string username)
@@ -81,7 +81,7 @@ namespace slskd.Users.API
         /// <param name="username">The username of the user.</param>
         /// <returns></returns>
         [HttpGet("{username}/browse")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(IEnumerable<Directory>), 200)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> Browse([FromRoute, Required] string username)
@@ -110,7 +110,7 @@ namespace slskd.Users.API
         /// <param name="username">The username of the user.</param>
         /// <returns></returns>
         [HttpGet("{username}/browse/status")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(decimal), 200)]
         [ProducesResponseType(404)]
         public IActionResult BrowseStatus([FromRoute, Required] string username)
@@ -129,7 +129,7 @@ namespace slskd.Users.API
         /// <param name="username">The username of the user.</param>
         /// <returns></returns>
         [HttpGet("{username}/info")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(Info), 200)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> Info([FromRoute, Required] string username)
@@ -151,7 +151,7 @@ namespace slskd.Users.API
         /// <param name="username">The username of the user.</param>
         /// <returns></returns>
         [HttpGet("{username}/status")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(Status), 200)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> Status([FromRoute, Required] string username)


### PR DESCRIPTION
#674 added the ability to authenticate API calls with an API key, which worked for API keys but broke the existing JWT implementation, and had to be rolled back in #678.

After some trial and error and combing through unhelpful ASP.NET documentation, I've concluded that the only way to support two different authentication schemes concurrently is to use the built in `Policy` stuff, so this PR adds that.

I was planning to restrict remote editing of options to JWTs at some point, and this was a great opportunity to add that as well.  Endpoints that use the `AuthPolicy.JwtOnly` policy can only be used when the caller has authenticated with a JWT.  The rationale is that API keys are more likely to be leaked or stolen, and because they don't expire, they pose a greater security risk.  There's also not really a use case for modifying (and especially not retrieving the YAML file) via API.