### PR TITLE
Implement more explicit schema checks when initializing the shared file cache

### DIFF
--- a/src/slskd/Common/Exceptions/ShareInitializationException.cs
+++ b/src/slskd/Common/Exceptions/ShareInitializationException.cs
@@ -1,0 +1,72 @@
+﻿// <copyright file="ShareInitializationException.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    ///     Represents an error that occurs when multiple share scans are attempted concurrently.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    [Serializable]
+    public class ShareInitializationException : SlskdException
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ShareInitializationException"/> class.
+        /// </summary>
+        public ShareInitializationException()
+            : base()
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ShareInitializationException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public ShareInitializationException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ShareInitializationException"/> class with a specified error message and a
+        ///     reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">
+        ///     The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no
+        ///     inner exception is specified.
+        /// </param>
+        public ShareInitializationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ShareInitializationException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The SerializationInfo that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
+        protected ShareInitializationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -94,7 +94,6 @@ namespace slskd.Shares
         private List<Share> SharesList { get; set; } = new List<Share>();
         private IManagedState<ShareState> State { get; } = new ManagedState<ShareState>();
         private SemaphoreSlim SyncRoot { get; } = new SemaphoreSlim(1, 1);
-        private List<Regex> FilterRegexes { get; set; } = new List<Regex>();
         private StorageMode CacheStorageMode { get; }
         private ILogger Log { get; } = Serilog.Log.ForContext<ShareService>();
 
@@ -218,7 +217,7 @@ namespace slskd.Shares
         /// <exception cref="ShareScanInProgressException">Thrown when a scan is already in progress.</exception>
         public Task ScanAsync()
         {
-            return Scanner.ScanAsync(Shares, FilterRegexes);
+            return Scanner.ScanAsync(Shares, OptionsMonitor.CurrentValue.Shares);
         }
 
         /// <summary>
@@ -251,6 +250,8 @@ namespace slskd.Shares
         /// <returns>The operation context.</returns>
         public async Task InitializeAsync(bool forceRescan = false)
         {
+            Log.Information("Initializing shares");
+
             try
             {
                 if (forceRescan)
@@ -258,31 +259,54 @@ namespace slskd.Shares
                     Log.Warning("Performing a forced re-scan of shares");
                     await ScanAsync();
                 }
-                else if (CacheStorageMode == StorageMode.Memory || (CacheStorageMode == StorageMode.Disk && !ShareRepository.TryValidateDatabase(Program.ConnectionStrings.Shares)))
+                else if (CacheStorageMode == StorageMode.Memory)
                 {
-                    Log.Debug($"Share cache {(CacheStorageMode == StorageMode.Memory ? "StorageMode is 'Memory'" : "database is missing from disk")}. Attempting to load from backup...");
+                    Log.Information("Share cache StorageMode is 'Memory'. Attempting to load from backup...");
 
-                    // the backup is missing; we can't do anything but recreate it from scratch
-                    if (!ShareRepository.TryValidateDatabase(Program.ConnectionStrings.SharesBackup))
+                    if (ShareRepository.TryValidateDatabase(Program.ConnectionStrings.SharesBackup))
                     {
-                        Log.Warning("Share cache couldn't be loaded from backup");
-                        await InitializeAsync(forceRescan: true);
-                    }
-                    else
-                    {
-                        Log.Debug("Share cache backup located. Attempting to restore...");
+                        Log.Information("Share cache backup validated. Attempting to restore...");
 
                         Repository.RestoreFrom(connectionString: Program.ConnectionStrings.SharesBackup);
 
                         Log.Information("Share cache successfully restored from backup");
                     }
+                    else
+                    {
+                        Log.Warning("Share cache backup is missing, corrupt, or is out of date");
+                        throw new ShareInitializationException("Share cache backup is missing, corrupt, or is out of date");
+                    }
                 }
-                else
+                else if (CacheStorageMode == StorageMode.Disk)
                 {
-                    // the cache mode is disk and the existing db is valid. nothing to do.
+                    Log.Information("Share cache StorageMode is 'Disk'. Attempting to validate...");
+
+                    if (ShareRepository.TryValidateDatabase(Program.ConnectionStrings.Shares))
+                    {
+                        // no-op
+                    }
+                    else
+                    {
+                        Log.Warning("Share cache is missing, corrupt, or is out of date. Attempting to load from backup...");
+
+                        if (ShareRepository.TryValidateDatabase(Program.ConnectionStrings.SharesBackup))
+                        {
+                            Log.Information("Share cache backup validated. Attempting to restore...");
+
+                            Repository.RestoreFrom(connectionString: Program.ConnectionStrings.SharesBackup);
+
+                            Log.Information("Share cache successfully restored from backup");
+                        }
+                        else
+                        {
+                            Log.Warning("Share cache and backup are both missing, corrupt, or is out of date");
+                            throw new ShareInitializationException("Share cache and backup are both missing, corrupt, or is out of date");
+                        }
+                    }
                 }
 
                 // one of several thigns happened above before we got here:
+                //   this method was called with forceRescan = true
                 //   the storage mode is memory, and we loaded the in-memory db from a valid backup
                 //   the storage mode is disk, and the file is there and valid
                 //   the storage mode is disk but either missing or invalid, and we restored from a valid backup
@@ -335,13 +359,8 @@ namespace slskd.Shares
                     .OrderByDescending(share => share.LocalPath.Length) // process subdirectories first.  this allows them to be aliased separately from their parent
                     .ToList();
 
-                var regexes = options.Shares.Filters
-                    .Select(filter => new Regex(filter, RegexOptions.Compiled))
-                    .ToList();
-
                 SharesList = shares;
-                FilterRegexes = regexes;
-
+                
                 State.SetValue(state => state with { ScanPending = true });
 
                 LastOptionsHash = optionsHash;


### PR DESCRIPTION
Previously the schema validation logic only checked for the three main tables; it now checks the entire schema (less indexes) to be extra sure.

I also refactored the initialization logic because it had some conditionals that were difficult to understand.

This should hopefully prevent cases when a 'bad' database file passes validation and causes problems.

Related to #683 