### PR TITLE
Update contentPath to use AppContext.BaseDirectory

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -736,7 +736,7 @@ namespace slskd
 
             // serve static content from the configured path
             FileServerOptions fileServerOptions = default;
-            var contentPath = Path.GetFullPath(OptionsAtStartup.Web.ContentPath);
+            var contentPath = Path.Combine(AppContext.BaseDirectory, OptionsAtStartup.Web.ContentPath);
 
             fileServerOptions = new FileServerOptions
             {


### PR DESCRIPTION
### Description
- This PR addresses #633 
- It makes changes to ```Program.cs``` and ```contentPath```
- It avoids using the absolute path which can allow for security issues, and instead lets the user give relative paths with respect to the application directory.