### PR TITLE
Add keepalive for share databases

### DIFF
--- a/src/slskd/Shares/IShareRepository.cs
+++ b/src/slskd/Shares/IShareRepository.cs
@@ -24,7 +24,7 @@ namespace slskd.Shares
     /// <summary>
     ///     Persistent storage of shared files and metadata.
     /// </summary>
-    public interface IShareRepository
+    public interface IShareRepository : IDisposable
     {
         /// <summary>
         ///     Gets the connection string for this repository.
@@ -66,6 +66,12 @@ namespace slskd.Shares
         /// </summary>
         /// <param name="filename">The destination file.</param>
         void DumpTo(string filename);
+
+        /// <summary>
+        ///     Enable connection keepalive.
+        /// </summary>
+        /// <param name="enable">A value indicating whether the keepalive logic should be executed.</param>
+        void EnableKeepalive(bool enable);
 
         /// <summary>
         ///     Finds the filename of the file matching the specified <paramref name="maskedFilename"/>.

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -400,6 +400,8 @@ namespace slskd.Shares
                     }
                 }
 
+                Local.Repository.EnableKeepalive(true);
+
                 // one of several thigns happened above before we got here:
                 //   this method was called with forceRescan = true
                 //   the storage mode is memory, and we loaded the in-memory db from a valid backup


### PR DESCRIPTION
I was able to verify this morning that in-memory databases are likely to be destroyed after the application has been running for some time.  When this happens logs fill up with errors due to failed search lookups, as reported in #683.

According to [SQLite documentation](https://www.sqlite.org/inmemorydb.html),

>  The database is automatically deleted and memory is reclaimed when the last connection to the database closes.

Searches come in from the network continuously, and each causes a new connection to be created and the `filenames` table queried.  It should be very unlikely for this problem to occur, but clearly it is.

As a workaround I've added a new `KeepaliveConnection` to go with each share database.  This connection is opened when the share repository is created, and only closed when the repository is disposed (basically, never).  This should mean that at least one connection is open at all times, preventing deletion.

I've also added a 1 second timer and a check to ensure the database hasn't been dropped and re-created.  If this check fails, the application will crash.

Closes #683