### PR TITLE
Rework API authentication

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -97,6 +97,7 @@
 #     api_keys:
 #       my_api_key:
 #         key: <some example string between 16 and 255 characters>
+#         role: readonly # readonly, readwrite, administrator
 #         cidr: 0.0.0.0/0,::/0
 # logger:
 #   loki: ~

--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -17,7 +17,9 @@
 #   # this specifies the network controller that will be controlling this agent
 #   controller:
 #     address:
-#     secret: <a 16-255 character string that matches the controller>
+#     ignore_certificate_errors: false
+#     api_key: <a 16-255 character string corresponding to one of the controller's API keys>
+#     secret: <a 16-255 character shared secret matching the controller's config for this agent>
 #   # agent config is optional when running in 'controller' mode
 #   # this specifies all of the agents on the network
 #   agents:

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -396,7 +396,7 @@ namespace slskd
             {
                 Log.Warning($"Not connecting to the Soulseek server; username and/or password invalid.  Specify valid credentials and manually connect, or update config and restart.");
             }
-            else if (OptionsAtStartup.Network.OperationMode.ToEnum<OperationMode>() == OperationMode.Agent && !OptionsAtStartup.Flags.DualNetworkMode)
+            else if (OptionsAtStartup.Network.Mode.ToEnum<OperationMode>() == OperationMode.Agent && !OptionsAtStartup.Flags.DualNetworkMode)
             {
                 Log.Information("Running in Agent mode; not connecting to the Soulseek server.");
                 await NetworkClient.StartAsync(cancellationToken);

--- a/src/slskd/Common/Authentication/Role.cs
+++ b/src/slskd/Common/Authentication/Role.cs
@@ -20,7 +20,7 @@ namespace slskd.Authentication
     public enum Role
     {
         ReadOnly = 0,
-        User = 1,
+        ReadWrite = 1,
         Administrator = 2,
     }
 }

--- a/src/slskd/Common/CommonExtensions.cs
+++ b/src/slskd/Common/CommonExtensions.cs
@@ -20,6 +20,7 @@ namespace slskd
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.IdentityModel.Tokens.Jwt;
     using System.IO;
     using System.Linq;
     using System.Numerics;
@@ -176,6 +177,14 @@ namespace slskd
 
             return str.Substring(0, pos) + replacement + str.Substring(pos + phrase.Length);
         }
+
+        /// <summary>
+        ///     Serializes the JWT.
+        /// </summary>
+        /// <param name="jwt">The JWT.</param>
+        /// <returns>The serialized string.</returns>
+        public static string Serialize(this JwtSecurityToken jwt)
+            => new JwtSecurityTokenHandler().WriteToken(jwt);
 
         /// <summary>
         ///     Formats byte to nearest size (KB, MB, etc.)

--- a/src/slskd/Common/Exceptions/OutOfRangeException.cs
+++ b/src/slskd/Common/Exceptions/OutOfRangeException.cs
@@ -1,0 +1,72 @@
+﻿// <copyright file="OutOfRangeException.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    ///     Represents errors that originate when a value falls out of an expected range.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    [Serializable]
+    public class OutOfRangeException : SlskdException
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="OutOfRangeException"/> class.
+        /// </summary>
+        public OutOfRangeException()
+            : base()
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="OutOfRangeException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public OutOfRangeException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="OutOfRangeException"/> class with a specified error message and a
+        ///     reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">
+        ///     The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no
+        ///     inner exception is specified.
+        /// </param>
+        public OutOfRangeException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="OutOfRangeException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The SerializationInfo that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
+        protected OutOfRangeException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -29,6 +29,7 @@ namespace slskd
     using System.Text.RegularExpressions;
     using FluentFTP;
     using NetTools;
+    using slskd.Authentication;
     using slskd.Configuration;
     using slskd.Cryptography;
     using slskd.Network;
@@ -1422,6 +1423,13 @@ namespace slskd
                     [StringLength(255, MinimumLength = 16)]
                     [Secret]
                     public string Key { get; init; }
+
+                    /// <summary>
+                    ///     Gets the role for the key.
+                    /// </summary>
+                    [Description("user role for the key; readonly, readwrite, administrator")]
+                    [Enum(typeof(Role))]
+                    public string Role { get; init; } = slskd.Authentication.Role.ReadOnly.ToString();
 
                     /// <summary>
                     ///     Gets the comma separated list of CIDRs that are authorized to use the key.

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -296,7 +296,7 @@ namespace slskd
         {
             var results = new List<ValidationResult>();
 
-            if (InstanceName == "local" && Network.OperationMode.ToEnum<OperationMode>() == OperationMode.Agent)
+            if (InstanceName == "local" && Network.Mode.ToEnum<OperationMode>() == OperationMode.Agent)
             {
                 results.Add(new ValidationResult("Instance name must be something other than 'local' when operating in Network Agent mode"));
             }
@@ -395,7 +395,7 @@ namespace slskd
             [Description("network operation mode; controller, agent")]
             [RequiresRestart]
             [Enum(typeof(OperationMode))]
-            public string OperationMode { get; init; } = slskd.Network.OperationMode.Controller.ToString().ToLowerInvariant();
+            public string Mode { get; init; } = slskd.Network.OperationMode.Controller.ToString().ToLowerInvariant();
 
             /// <summary>
             ///     Gets the controller configuration.
@@ -409,7 +409,7 @@ namespace slskd
 
             public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
             {
-                var mode = OperationMode.ToEnum<OperationMode>();
+                var mode = Mode.ToEnum<OperationMode>();
                 var results = new List<ValidationResult>();
                 var modeResults = new List<ValidationResult>();
 
@@ -461,10 +461,22 @@ namespace slskd
                 public bool IgnoreCertificateErrors { get; init; } = false;
 
                 /// <summary>
+                ///     Gets the controller API key.
+                /// </summary>
+                [Argument(default, "controller-api-key")]
+                [EnvironmentVariable("CONTROLLER_API_KEY")]
+                [Description("controller api key")]
+                [StringLength(255, MinimumLength = 16)]
+                [NotNullOrWhiteSpace]
+                [Secret]
+                public string ApiKey { get; init; }
+
+                /// <summary>
                 ///     Gets the controller secret.
                 /// </summary>
                 [Argument(default, "controller-secret")]
                 [EnvironmentVariable("CONTROLLER_SECRET")]
+                [Description("shared secret")]
                 [StringLength(255, MinimumLength = 16)]
                 [NotNullOrWhiteSpace]
                 [Secret]

--- a/src/slskd/Core/Security/SecurityService.cs
+++ b/src/slskd/Core/Security/SecurityService.cs
@@ -1,0 +1,100 @@
+﻿// <copyright file="SecurityService.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+using Microsoft.Extensions.Options;
+
+namespace slskd
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IdentityModel.Tokens.Jwt;
+    using System.Linq;
+    using System.Net;
+    using System.Security.Claims;
+    using Microsoft.IdentityModel.Tokens;
+    using NetTools;
+    using slskd.Authentication;
+
+    public interface ISecurityService
+    {
+        JwtSecurityToken GenerateJwt(string username, Role role, int? ttl = null);
+        (string Name, Role Role) AuthenticateWithApiKey(string key, IPAddress callerIpAddress);
+    }
+
+    public class SecurityService : ISecurityService
+    {
+        public SecurityService(
+            SymmetricSecurityKey jwtSigningKey,
+            OptionsAtStartup optionsAtStartup,
+            IOptionsMonitor<Options> optionsMonitor)
+        {
+            JwtSigningKey = jwtSigningKey;
+            OptionsAtStartup = optionsAtStartup;
+            OptionsMonitor = optionsMonitor;
+        }
+
+        private SymmetricSecurityKey JwtSigningKey { get; }
+        private OptionsAtStartup OptionsAtStartup { get; }
+        private IOptionsMonitor<Options> OptionsMonitor { get; }
+
+        public (string Name, Role Role) AuthenticateWithApiKey(string key, IPAddress callerIpAddress)
+        {
+            var record = OptionsMonitor.CurrentValue.Web.Authentication.ApiKeys
+                .FirstOrDefault(k => k.Value.Key == key);
+
+            if (record.Key == null)
+            {
+                throw new NotFoundException($"The provided API key does not match an existing key");
+            }
+
+            if (!record.Value.Cidr.Split(',')
+                .Select(cidr => IPAddressRange.Parse(cidr))
+                .Any(range => range.Contains(callerIpAddress)))
+            {
+                throw new OutOfRangeException("The remote IP address is not within the range specified for the key");
+            }
+
+            return (record.Key, record.Value.Role.ToEnum<Role>());
+        }
+
+        public JwtSecurityToken GenerateJwt(string username, Role role, int? ttl = null)
+        {
+            var issuedUtc = DateTime.UtcNow;
+            var expiresUtc = DateTime.UtcNow.AddMilliseconds(ttl ?? OptionsAtStartup.Web.Authentication.Jwt.Ttl);
+
+            var claims = new List<Claim>()
+            {
+                new Claim(ClaimTypes.Name, username),
+                new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+                new Claim(ClaimTypes.Role, role.ToString()),
+                new Claim("name", username),
+                new Claim("iat", ((DateTimeOffset)issuedUtc).ToUnixTimeSeconds().ToString()),
+            };
+
+            var credentials = new SigningCredentials(JwtSigningKey, SecurityAlgorithms.HmacSha256);
+
+            var token = new JwtSecurityToken(
+                issuer: Program.AppName,
+                claims: claims,
+                notBefore: issuedUtc,
+                expires: expiresUtc,
+                signingCredentials: credentials);
+
+            return token;
+        }
+    }
+}

--- a/src/slskd/Network/API/Controllers/NetworkController.cs
+++ b/src/slskd/Network/API/Controllers/NetworkController.cs
@@ -56,7 +56,7 @@ namespace slskd.Network
         [RequestSizeLimit(10L * 1024L * 1024L * 1024L)]
         [RequestFormLimits(MultipartBodyLengthLimit = 10L * 1024L * 1024L * 1024L)]
         [DisableFormValueModelBinding]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> UploadFile(string token)
         {
             if (!Guid.TryParse(token, out var guid))
@@ -140,7 +140,7 @@ namespace slskd.Network
         /// <param name="token">The unique identifier for the request.</param>
         /// <returns></returns>
         [HttpPost("shares/{token}")]
-        [Authorize]
+        [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> UploadShares(string token)
         {
             if (!Guid.TryParse(token, out var guid))

--- a/src/slskd/Network/NetworkClient.cs
+++ b/src/slskd/Network/NetworkClient.cs
@@ -93,7 +93,7 @@ namespace slskd.Network
         /// <returns></returns>
         public async Task StartAsync(CancellationToken cancellationToken = default)
         {
-            if (OptionsMonitor.CurrentValue.Network.OperationMode.ToEnum<OperationMode>() != OperationMode.Agent && !OptionsMonitor.CurrentValue.Flags.DualNetworkMode)
+            if (OptionsMonitor.CurrentValue.Network.Mode.ToEnum<OperationMode>() != OperationMode.Agent && !OptionsMonitor.CurrentValue.Flags.DualNetworkMode)
             {
                 throw new InvalidOperationException($"Network client can only be started when operation mode is {OperationMode.Agent}");
             }
@@ -328,7 +328,7 @@ namespace slskd.Network
 
         private void Configure(Options options)
         {
-            if (options.Network.OperationMode.ToEnum<OperationMode>() != OperationMode.Agent && !options.Flags.DualNetworkMode)
+            if (options.Network.Mode.ToEnum<OperationMode>() != OperationMode.Agent && !options.Flags.DualNetworkMode)
             {
                 return;
             }
@@ -352,7 +352,21 @@ namespace slskd.Network
                 StartCancellationTokenSource?.Cancel();
 
                 HubConnection = new HubConnectionBuilder()
-                    .WithUrl($"{options.Network.Controller.Address}/hub/agents")
+                    .WithUrl($"{options.Network.Controller.Address}/hub/agents", builder =>
+                    {
+                        builder.AccessTokenProvider = () => Task.FromResult(options.Network.Controller.ApiKey);
+                        // options.HttpMessageHandlerFactory = (message) =>
+                        // {
+                        //     if (message is HttpClientHandler clientHandler)
+                        //     {
+                        //         // always verify the SSL certificate
+                        //         clientHandler.ServerCertificateCustomValidationCallback +=
+                        //                 (sender, certificate, chain, sslPolicyErrors) => true;
+                        //     }
+
+                        //     return message;
+                        // };
+                    })
                     .WithAutomaticReconnect(new[]
                     {
                         TimeSpan.FromSeconds(0),

--- a/src/slskd/Network/NetworkClient.cs
+++ b/src/slskd/Network/NetworkClient.cs
@@ -322,9 +322,24 @@ namespace slskd.Network
 
         private HttpClient CreateHttpClient()
         {
-            var client = new HttpClient();
+            var options = OptionsMonitor.CurrentValue.Network.Controller;
+            HttpClient client;
+
+            if (options.IgnoreCertificateErrors)
+            {
+                client = new HttpClient(new HttpClientHandler()
+                {
+                    ClientCertificateOptions = ClientCertificateOption.Manual,
+                    ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+                });
+            }
+            else
+            {
+                client = new HttpClient();
+            }
+
             client.Timeout = TimeSpan.FromMilliseconds(int.MaxValue);
-            client.BaseAddress = new(OptionsMonitor.CurrentValue.Network.Controller.Address);
+            client.BaseAddress = new(options.Address);
             return client;
         }
 

--- a/src/slskd/Network/NetworkClient.cs
+++ b/src/slskd/Network/NetworkClient.cs
@@ -357,17 +357,15 @@ namespace slskd.Network
                     .WithUrl($"{options.Network.Controller.Address}/hub/agents", builder =>
                     {
                         builder.AccessTokenProvider = () => Task.FromResult(options.Network.Controller.ApiKey);
-                        // options.HttpMessageHandlerFactory = (message) =>
-                        // {
-                        //     if (message is HttpClientHandler clientHandler)
-                        //     {
-                        //         // always verify the SSL certificate
-                        //         clientHandler.ServerCertificateCustomValidationCallback +=
-                        //                 (sender, certificate, chain, sslPolicyErrors) => true;
-                        //     }
+                        builder.HttpMessageHandlerFactory = (message) =>
+                        {
+                            if (message is HttpClientHandler clientHandler && options.Network.Controller.IgnoreCertificateErrors)
+                            {
+                                clientHandler.ServerCertificateCustomValidationCallback += (_, _, _, _) => true;
+                            }
 
-                        //     return message;
-                        // };
+                            return message;
+                        };
                     })
                     .WithAutomaticReconnect(new[]
                     {

--- a/src/slskd/Network/NetworkClient.cs
+++ b/src/slskd/Network/NetworkClient.cs
@@ -176,6 +176,7 @@ namespace slskd.Network
                 { new StreamContent(stream), "database", "shares" },
             };
 
+            request.Headers.Add("X-API-Key", OptionsMonitor.CurrentValue.Network.Controller.ApiKey);
             request.Content = content;
 
             Log.Information("Beginning upload of shares");
@@ -228,6 +229,7 @@ namespace slskd.Network
                         { new StreamContent(stream), "file", filename },
                     };
 
+                    request.Headers.Add("X-API-Key", OptionsMonitor.CurrentValue.Network.Controller.ApiKey);
                     request.Content = content;
 
                     Log.Information("Beginning upload of file {Filename} with ID {Id}", filename, token);


### PR DESCRIPTION
It turns out the existing code I wrote to handle API keys with SignalR didn't work.  This PR makes it work, and allows users to optionally ignore certificate errors when connecting to a controller over HTTPS, but when the controller doesn't have a valid certificate (such as when it is self signed, as slskd uses by default)

