### PR TITLE
Normalize all paths shared with the Soulseek network to use backslashes

### DIFF
--- a/src/slskd/Shares/ShareScanner.cs
+++ b/src/slskd/Shares/ShareScanner.cs
@@ -232,7 +232,7 @@ namespace slskd.Shares
 
                             var share = Shares.First(share => directory.StartsWith(share.LocalPath));
 
-                            Repository.InsertDirectory(directory.ReplaceFirst(share.LocalPath, share.RemotePath), timestamp);
+                            Repository.InsertDirectory(directory.ReplaceFirst(share.LocalPath, share.RemotePath).NormalizePathForSoulseek(), timestamp);
 
                             // recursively find all files in the directory and stick a record in a dictionary, keyed on the sanitized
                             // filename and with a value of a Soulseek.File object
@@ -254,7 +254,7 @@ namespace slskd.Shares
                                 foreach (var originalFilename in newFiles)
                                 {
                                     var info = new FileInfo(originalFilename);
-                                    var file = SoulseekFileFactory.Create(originalFilename, maskedFilename: originalFilename.ReplaceFirst(share.LocalPath, share.RemotePath));
+                                    var file = SoulseekFileFactory.Create(originalFilename, maskedFilename: originalFilename.ReplaceFirst(share.LocalPath, share.RemotePath).NormalizePathForSoulseek());
 
                                     if (filters.Any(filter => filter.IsMatch(originalFilename)))
                                     {

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -155,15 +155,14 @@ namespace slskd.Shares
             // files. if not they'll be left as is.
             foreach (var directory in AllRepositories.SelectMany(r => r.ListDirectories(prefix)))
             {
-                var name = directory.NormalizePathForSoulseek();
-                directories.TryAdd(name, new Directory(name));
+                directories.TryAdd(directory, new Directory(directory));
             }
 
             var files = AllRepositories.SelectMany(r => r.ListFiles(prefix, includeFullPath: true));
 
             var groups = files
                 .GroupBy(file => Path.GetDirectoryName(file.Filename))
-                .Select(group => new Directory(group.Key.NormalizePathForSoulseek(), group.Select(f =>
+                .Select(group => new Directory(group.Key, group.Select(f =>
                 {
                     return new File(
                         f.Code,
@@ -229,9 +228,7 @@ namespace slskd.Shares
         /// <returns>The contents of the directory.</returns>
         public Task<Directory> ListDirectoryAsync(string directory)
         {
-            var localPath = directory.LocalizePath();
-
-            var files = AllRepositories.SelectMany(r => r.ListFiles(localPath));
+            var files = AllRepositories.SelectMany(r => r.ListFiles(directory));
 
             return Task.FromResult(new Directory(directory, files));
         }
@@ -248,9 +245,7 @@ namespace slskd.Shares
         public Task<(string Host, string Filename)> ResolveFileAsync(string remoteFilename)
         {
             string resolvedHost = "local";
-            string resolvedFilename = default;
-
-            resolvedFilename = Local.Repository.FindFilename(remoteFilename.LocalizePath());
+            string resolvedFilename = Local.Repository.FindFilename(remoteFilename);
 
             if (!string.IsNullOrEmpty(resolvedFilename))
             {
@@ -261,7 +256,7 @@ namespace slskd.Shares
             // this is the slow, dumb way to do this, but it's plenty fast in this context.
             foreach (var host in HostDictionary.Values)
             {
-                resolvedFilename = host.Repository.FindFilename(remoteFilename.LocalizePath());
+                resolvedFilename = host.Repository.FindFilename(remoteFilename);
 
                 if (!string.IsNullOrEmpty(resolvedFilename))
                 {
@@ -289,12 +284,7 @@ namespace slskd.Shares
         {
             var results = AllRepositories.SelectMany(r => r.Search(query));
 
-            return Task.FromResult(results.Select(r => new File(
-                r.Code,
-                r.Filename.NormalizePathForSoulseek(),
-                r.Size,
-                r.Extension,
-                r.Attributes)));
+            return Task.FromResult(results);
         }
 
         /// <summary>

--- a/src/slskd/Transfers/Uploads/UploadService.cs
+++ b/src/slskd/Transfers/Uploads/UploadService.cs
@@ -119,7 +119,7 @@ namespace slskd.Transfers.Uploads
 
             try
             {
-                (host, localFilename) = await Shares.ResolveFileAsync(filename.LocalizePath());
+                (host, localFilename) = await Shares.ResolveFileAsync(filename);
 
                 if (host == "local")
                 {


### PR DESCRIPTION
I thought I was in a good place with this, but now am encountering issues with the new network mode where the agent and controller are using different operating systems.  The path localization logic doesn't work for these because the masked paths saved in the shared file database use localized slashes.

This PR updates the scanner logic to save masked files with backslashes, regardless of operating system.  There's no longer a need to normalize paths on the way out to the network, so that logic is removed.

I'm really not sure why I didn't just do this in the first place; it's the much more logical option.  I'll probably find out when new bugs surface after this is merged 🙃 