### PR TITLE
Don't use the built-in System.IO.Path methods for handling normalized paths

### DIFF
--- a/src/slskd/Common/CommonExtensions.cs
+++ b/src/slskd/Common/CommonExtensions.cs
@@ -302,6 +302,26 @@ namespace slskd
         }
 
         /// <summary>
+        ///     <see cref="Path.GetDirectoryName"/>, but for paths normalized to use backslashes.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public static string GetNormalizedDirectoryName(this string path)
+        {
+            return string.Join('\\', path.Split('\\').SkipLast(1));
+        }
+
+        /// <summary>
+        ///     <see cref="Path.GetFileName"/>, but for paths normalized to use backslashes.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public static string GetNormalizedFileName(this string path)
+        {
+            return string.Join('\\', path.Split('\\').TakeLast(1));
+        }
+
+        /// <summary>
         ///     Converts a fully qualified remote filename to a local filename, swapping directory characters for those specific
         ///     to the local OS, removing any characters that are invalid for the local OS, and making the path relative to the
         ///     remote store (including the filename and the parent folder).

--- a/src/slskd/Shares/SqliteShareRepository.cs
+++ b/src/slskd/Shares/SqliteShareRepository.cs
@@ -365,7 +365,7 @@ namespace slskd.Shares
 
                     var attributeList = attributeJson.FromJson<List<FileAttribute>>();
 
-                    filename = includeFullPath ? filename : Path.GetFileName(filename);
+                    filename = includeFullPath ? filename : filename.GetNormalizedFileName();
 
                     var file = new Soulseek.File(code, filename, size, extension, attributeList);
 

--- a/src/slskd/Transfers/Downloads/DownloadService.cs
+++ b/src/slskd/Transfers/Downloads/DownloadService.cs
@@ -451,6 +451,7 @@ namespace slskd.Transfers.Downloads
 
             System.Diagnostics.Stopwatch sw = default;
 
+            // todo: remove this.  or check that Path.GetFileName works as expected if it is to be kept
             if (experimental)
             {
                 sw = new System.Diagnostics.Stopwatch();


### PR DESCRIPTION
`System.IO.Path` behavior is os-specific, and I need logic that works with backslashes independent of OS.  This PR adds a couple of extension methods to do this.