### PR TITLE
Upload shares to controller after a local scan

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -1057,6 +1057,7 @@ namespace slskd
             if (rebuildBrowseCache || previous.Hosts.ToJson() != current.Hosts.ToJson())
             {
                 _ = CacheBrowseResponse();
+                _ = NetworkClient.SynchronizeAsync();
             }
         }
 


### PR DESCRIPTION
This may lead to redundant uploads on start if the controller connection is ever established prior to share initialization.  It should be obvious, and I doubt the ordering would ever change, anyway.