### PR TITLE
Add blacklist for files

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -61,6 +61,9 @@
 #       strategy: roundrobin
 #       slots: 1
 #       speed_limit: 100
+#   blacklisted:
+#     members:
+#       - <username to blacklist>
 #   user_defined:
 #     my_buddies:
 #       upload:

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -750,6 +750,11 @@ namespace slskd
             public LeecherOptions Leechers { get; init; } = new LeecherOptions();
 
             /// <summary>
+            ///     Gets options for the blacklisted user group.
+            /// </summary>
+            public BlacklistedOptions Blacklisted { get; init; } = new BlacklistedOptions();
+
+            /// <summary>
             ///     Gets user defined groups and options.
             /// </summary>
             [Validate]
@@ -778,6 +783,17 @@ namespace slskd
                 /// </summary>
                 [Validate]
                 public UploadOptions Upload { get; init; } = new UploadOptions();
+            }
+
+            /// <summary>
+            ///     Built in blacklisted group options.
+            /// </summary>
+            public class BlacklistedOptions
+            {
+                /// <summary>
+                ///     Gets the list of group member usernames.
+                /// </summary>
+                public string[] Members { get; init; } = Array.Empty<string>();
             }
 
             /// <summary>


### PR DESCRIPTION
Prevents blacklisted users from:

* Receiving search results
* Browsing files
* Retrieving directory contents
* Enqueueing downloads

Adding someone to the blacklist doesn't cancel transfers in flight; users will need to do that themselves.

This could be expanded to ignore messages in chat rooms and private messages, but that's probably best done separately for now.