### PR TITLE
Add version table to shares db

### DIFF
--- a/src/slskd/Shares/SqliteShareRepository.cs
+++ b/src/slskd/Shares/SqliteShareRepository.cs
@@ -157,8 +157,10 @@ namespace slskd.Shares
 
             if (discardExisting)
             {
-                conn.ExecuteNonQuery("DROP TABLE IF EXISTS scans; DROP TABLE IF EXISTS directories; DROP TABLE IF EXISTS filenames; DROP TABLE IF EXISTS files;");
+                conn.ExecuteNonQuery("DROP TABLE IF EXISTS version; DROP TABLE IF EXISTS scans; DROP TABLE IF EXISTS directories; DROP TABLE IF EXISTS filenames; DROP TABLE IF EXISTS files;");
             }
+
+            conn.ExecuteNonQuery("CREATE TABLE IF NOT EXISTS version (a INTEGER PRIMARY KEY)");
 
             conn.ExecuteNonQuery("CREATE TABLE IF NOT EXISTS scans (timestamp INTEGER PRIMARY KEY, options TEXT NOT NULL, end INTEGER DEFAULT NULL);");
 
@@ -507,6 +509,7 @@ namespace slskd.Shares
             // select '{ "' || name || '", "' || sql || '" },' from sqlite_master where type = 'table'
             var schema = new Dictionary<string, string>()
             {
+                { "version", "CREATE TABLE version (a INTEGER PRIMARY KEY)" },
                 { "scans", "CREATE TABLE scans (timestamp INTEGER PRIMARY KEY, options TEXT NOT NULL, end INTEGER DEFAULT NULL)" },
                 { "directories", "CREATE TABLE directories (name TEXT PRIMARY KEY, timestamp INTEGER NOT NULL)" },
                 { "filenames", "CREATE VIRTUAL TABLE filenames USING fts5(maskedFilename)" },


### PR DESCRIPTION
#723 changed how paths are stored in the share database, and @mathiascode correctly reminded me that I'd need a migration path for existing databases.  I, of course, forgot all about that when I created the [0.16.28 release](https://github.com/slskd/slskd/releases/tag/0.16.28) last night, and anyone that happened to update right away is probably broken.

This PR introduces a new `version` table to the SQLite database that stores shares.  This table has a single integer column, `a`.

The code checks the database layout on start, and if the expected layout doesn't match the file, the existing file is discarded and shares are re-scanned. 

Moving forward, when I introduce a breaking change to this database (or any other ephemeral database, like searches), I'll change the name of the column in the `version` table, which will force a rebuild.

I still don't have a solution for migrating changes without data loss, but I'll tackle that the first time I make a breaking change to the transfers table.