### PR TITLE
Rename 'Network' functionality to 'Relay'

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -21,7 +21,7 @@
 #     api_key: <a 16-255 character string corresponding to one of the controller's API keys>
 #     secret: <a 16-255 character shared secret matching the controller's config for this agent>
 #   # agent config is optional when running in 'controller' mode
-#   # this specifies all of the agents on the network
+#   # this specifies all of the agents capable of connecting
 #   agents:
 #     my_agent:
 #       secret: <a 16-255 character string unique to this agent>

--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -11,10 +11,10 @@
 #   log_sql: false
 #   experimental: false
 #   volatile: false
-# network:
+# relay:
 #   mode: controller # controller (default), agent, or debug (for local development)
 #   # controller config is required when running in 'agent' mode
-#   # this specifies the network controller that will be controlling this agent
+#   # this specifies the relay controller that will be controlling this agent
 #   controller:
 #     address:
 #     ignore_certificate_errors: false

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -42,7 +42,7 @@ namespace slskd
     using slskd.Core.API;
     using slskd.Integrations.Pushbullet;
     using slskd.Messaging;
-    using slskd.Network;
+    using slskd.Relay;
     using slskd.Search;
     using slskd.Shares;
     using slskd.Transfers;
@@ -89,7 +89,7 @@ namespace slskd
             IUserService userService,
             IShareService shareService,
             IPushbulletService pushbulletService,
-            INetworkService networkService,
+            IRelayService relayService,
             IHubContext<ApplicationHub> applicationHub,
             IHubContext<LogsHub> logHub)
         {
@@ -135,8 +135,8 @@ namespace slskd
             Users = userService;
             ApplicationHub = applicationHub;
 
-            Network = networkService;
-            Network.StateMonitor.OnChange(networkState => State.SetValue(state => state with { Network = networkState.Current }));
+            Relay = relayService;
+            Relay.StateMonitor.OnChange(relayState => State.SetValue(state => state with { Relay = relayState.Current }));
 
             LogHub = logHub;
             Program.LogEmitted += (_, log) => LogHub.EmitLogAsync(log);
@@ -199,7 +199,7 @@ namespace slskd
         private IHubContext<LogsHub> LogHub { get; set; }
         private IUserService Users { get; set; }
         private IShareService Shares { get; set; }
-        private INetworkService Network { get; set; }
+        private IRelayService Relay { get; set; }
         private IMemoryCache Cache { get; set; } = new MemoryCache(new MemoryCacheOptions());
         private IEnumerable<Regex> CompiledSearchResponseFilters { get; set; }
         private IEnumerable<Guid> ActiveDownloadIdsAtPreviousShutdown { get; set; } = Enumerable.Empty<Guid>();
@@ -398,17 +398,17 @@ namespace slskd
             {
                 Log.Warning($"Not connecting to the Soulseek server; username and/or password invalid.  Specify valid credentials and manually connect, or update config and restart.");
             }
-            else if (OptionsAtStartup.Network.Mode.ToEnum<OperationMode>() == OperationMode.Agent)
+            else if (OptionsAtStartup.Relay.Mode.ToEnum<OperationMode>() == OperationMode.Agent)
             {
-                Log.Information("Running in Agent mode; not connecting to the Soulseek server.");
-                await Network.Client.StartAsync(cancellationToken);
+                Log.Information("Running in Agent relay mode; not connecting to the Soulseek server.");
+                await Relay.Client.StartAsync(cancellationToken);
             }
             else
             {
-                if (OptionsAtStartup.Network.Mode.ToEnum<OperationMode>() == OperationMode.Debug)
+                if (OptionsAtStartup.Relay.Mode.ToEnum<OperationMode>() == OperationMode.Debug)
                 {
-                    Log.Warning("Running in Debug network mode; connecting to controller");
-                    _ = Network.Client.StartAsync(cancellationToken);
+                    Log.Warning("Running in Debug relay mode; connecting to controller");
+                    _ = Relay.Client.StartAsync(cancellationToken);
                 }
 
                 await Client.ConnectAsync(OptionsAtStartup.Soulseek.Username, OptionsAtStartup.Soulseek.Password).ConfigureAwait(false);
@@ -1108,7 +1108,7 @@ namespace slskd
             if (rebuildBrowseCache)
             {
                 _ = CacheBrowseResponse();
-                _ = Network.Client.SynchronizeAsync();
+                _ = Relay.Client.SynchronizeAsync();
             }
         }
 

--- a/src/slskd/Common/Exceptions/RelayException.cs
+++ b/src/slskd/Common/Exceptions/RelayException.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NetworkException.cs" company="slskd Team">
+﻿// <copyright file="RelayException.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -26,27 +26,27 @@ namespace slskd
     /// </summary>
     [ExcludeFromCodeCoverage]
     [Serializable]
-    public class NetworkException : SlskdException
+    public class RelayException : SlskdException
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="NetworkException"/> class.
+        ///     Initializes a new instance of the <see cref="RelayException"/> class.
         /// </summary>
-        public NetworkException()
+        public RelayException()
             : base()
         {
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="NetworkException"/> class with a specified error message.
+        ///     Initializes a new instance of the <see cref="RelayException"/> class with a specified error message.
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
-        public NetworkException(string message)
+        public RelayException(string message)
             : base(message)
         {
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="NetworkException"/> class with a specified error message and a
+        ///     Initializes a new instance of the <see cref="RelayException"/> class with a specified error message and a
         ///     reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
@@ -54,17 +54,17 @@ namespace slskd
         ///     The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no
         ///     inner exception is specified.
         /// </param>
-        public NetworkException(string message, Exception innerException)
+        public RelayException(string message, Exception innerException)
             : base(message, innerException)
         {
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="NetworkException"/> class with serialized data.
+        ///     Initializes a new instance of the <see cref="RelayException"/> class with serialized data.
         /// </summary>
         /// <param name="info">The SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
-        protected NetworkException(SerializationInfo info, StreamingContext context)
+        protected RelayException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }

--- a/src/slskd/Common/Exceptions/RelayException.cs
+++ b/src/slskd/Common/Exceptions/RelayException.cs
@@ -22,7 +22,7 @@ namespace slskd
     using System.Runtime.Serialization;
 
     /// <summary>
-    ///     Represents an error related to the slskd network feature.
+    ///     Represents an error related to the slskd relay feature.
     /// </summary>
     [ExcludeFromCodeCoverage]
     [Serializable]

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -32,7 +32,7 @@ namespace slskd
     using slskd.Authentication;
     using slskd.Configuration;
     using slskd.Cryptography;
-    using slskd.Network;
+    using slskd.Relay;
     using slskd.Shares;
     using slskd.Validation;
     using Soulseek.Diagnostics;
@@ -196,10 +196,10 @@ namespace slskd
         public string ConfigurationFile { get; init; } = Program.DefaultConfigurationFile;
 
         /// <summary>
-        ///     Gets network options.
+        ///     Gets relay options.
         /// </summary>
         [Validate]
-        public NetworkOptions Network { get; init; } = new NetworkOptions();
+        public RelayOptions Relay { get; init; } = new RelayOptions();
 
         /// <summary>
         ///     Gets directory options.
@@ -288,9 +288,9 @@ namespace slskd
         {
             var results = new List<ValidationResult>();
 
-            if (InstanceName == "local" && Network.Mode.ToEnum<OperationMode>() == OperationMode.Agent)
+            if (InstanceName == "local" && Relay.Mode.ToEnum<OperationMode>() == OperationMode.Agent)
             {
-                results.Add(new ValidationResult("Instance name must be something other than 'local' when operating in Network Agent mode"));
+                results.Add(new ValidationResult("Instance name must be something other than 'local' when operating in Relay Agent mode"));
             }
 
             return results;
@@ -384,29 +384,29 @@ namespace slskd
         }
 
         /// <summary>
-        ///     Network options.
+        ///     Relay options.
         /// </summary>
-        public class NetworkOptions : IValidatableObject
+        public class RelayOptions : IValidatableObject
         {
             /// <summary>
             ///     Gets the application operation mode.
             /// </summary>
-            [Argument('m', "network-operation-mode")]
-            [EnvironmentVariable("NETWORK_OPERATION_MODE")]
-            [Description("network operation mode; controller, agent")]
+            [Argument('m', "relay-operation-mode")]
+            [EnvironmentVariable("RELAY_OPERATION_MODE")]
+            [Description("relay operation mode; controller, agent")]
             [RequiresRestart]
             [Enum(typeof(OperationMode))]
-            public string Mode { get; init; } = slskd.Network.OperationMode.Controller.ToString().ToLowerInvariant();
+            public string Mode { get; init; } = slskd.Relay.OperationMode.Controller.ToString().ToLowerInvariant();
 
             /// <summary>
             ///     Gets the controller configuration.
             /// </summary>
-            public NetworkControllerConfigurationOptions Controller { get; init; } = new NetworkControllerConfigurationOptions();
+            public RelayControllerConfigurationOptions Controller { get; init; } = new RelayControllerConfigurationOptions();
 
             /// <summary>
             ///     Gets the agent configuration.
             /// </summary>
-            public Dictionary<string, NetworkAgentConfigurationOptions> Agents { get; init; } = new();
+            public Dictionary<string, RelayAgentConfigurationOptions> Agents { get; init; } = new();
 
             public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
             {
@@ -414,7 +414,7 @@ namespace slskd
                 var results = new List<ValidationResult>();
                 var modeResults = new List<ValidationResult>();
 
-                if (mode == slskd.Network.OperationMode.Agent && !Validator.TryValidateObject(Controller, new ValidationContext(Controller), modeResults, validateAllProperties: true))
+                if (mode == slskd.Relay.OperationMode.Agent && !Validator.TryValidateObject(Controller, new ValidationContext(Controller), modeResults, validateAllProperties: true))
                 {
                     results.Add(new CompositeValidationResult("Controller", modeResults));
                 }
@@ -439,9 +439,9 @@ namespace slskd
             }
 
             /// <summary>
-            ///     Network controller configuration options.
+            ///     Relay controller configuration options.
             /// </summary>
-            public class NetworkControllerConfigurationOptions
+            public class RelayControllerConfigurationOptions
             {
                 /// <summary>
                 ///     Gets the controller address.
@@ -485,9 +485,9 @@ namespace slskd
             }
 
             /// <summary>
-            ///     Network agent configuration options.
+            ///     Relay agent configuration options.
             /// </summary>
-            public class NetworkAgentConfigurationOptions
+            public class RelayAgentConfigurationOptions
             {
                 /// <summary>
                 ///     Gets the agent secret.

--- a/src/slskd/Core/State.cs
+++ b/src/slskd/Core/State.cs
@@ -35,7 +35,7 @@ namespace slskd
         public bool PendingReconnect { get; init; }
         public bool PendingRestart { get; init; }
         public ServerState Server { get; init; } = new ServerState();
-        public NetworkState Network { get; init; } = new NetworkState();
+        public RelayState Relay { get; init; } = new RelayState();
         public UserState User { get; init; } = new UserState();
         public DistributedNetworkState DistributedNetwork { get; init; } = new DistributedNetworkState();
         public ShareState Shares { get; init; } = new ShareState();
@@ -65,14 +65,14 @@ namespace slskd
         public bool IsTransitioning => State.HasFlag(SoulseekClientStates.Connecting) || State.HasFlag(SoulseekClientStates.Disconnecting) || State.HasFlag(SoulseekClientStates.LoggingIn);
     }
 
-    public record NetworkState
+    public record RelayState
     {
         public OperationMode Mode { get; init; }
-        public NetworkControllerState Controller { get; init; } = new NetworkControllerState();
+        public RelayControllerState Controller { get; init; } = new RelayControllerState();
         public IReadOnlyCollection<Agent> Agents { get; init; } = Enumerable.Empty<Agent>().ToList().AsReadOnly();
     }
 
-    public record NetworkControllerState
+    public record RelayControllerState
     {
         public string Address { get; init; }
         public RelayClientState State { get; init; } = RelayClientState.Disconnected;

--- a/src/slskd/Core/State.cs
+++ b/src/slskd/Core/State.cs
@@ -75,7 +75,7 @@ namespace slskd
     public record NetworkControllerState
     {
         public string Address { get; init; }
-        public NetworkClientState State { get; init; } = NetworkClientState.Disconnected;
+        public RelayClientState State { get; init; } = RelayClientState.Disconnected;
     }
 
     public record UserState

--- a/src/slskd/Core/State.cs
+++ b/src/slskd/Core/State.cs
@@ -22,7 +22,7 @@ namespace slskd
     using System.Linq;
     using System.Net;
     using System.Text.Json.Serialization;
-    using slskd.Network;
+    using slskd.Relay;
     using slskd.Users;
     using Soulseek;
 

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -58,7 +58,7 @@ namespace slskd
     using slskd.Integrations.FTP;
     using slskd.Integrations.Pushbullet;
     using slskd.Messaging;
-    using slskd.Network;
+    using slskd.Relay;
     using slskd.Search;
     using slskd.Search.API;
     using slskd.Shares;
@@ -543,7 +543,7 @@ namespace slskd
             services.AddSingleton<IDownloadService, DownloadService>();
             services.AddSingleton<IUploadService, UploadService>();
 
-            services.AddSingleton<INetworkService, RelayService>();
+            services.AddSingleton<IRelayService, RelayService>();
 
             services.AddSingleton<IFTPClientFactory, FTPClientFactory>();
             services.AddSingleton<IFTPService, FTPService>();
@@ -819,7 +819,7 @@ namespace slskd
                 endpoints.MapHub<ApplicationHub>("/hub/application");
                 endpoints.MapHub<LogsHub>("/hub/logs");
                 endpoints.MapHub<SearchHub>("/hub/search");
-                endpoints.MapHub<RelayHub>("/hub/agents");
+                endpoints.MapHub<RelayHub>("/hub/relay");
 
                 endpoints.MapControllers();
                 endpoints.MapHealthChecks("/health");

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -543,7 +543,7 @@ namespace slskd
             services.AddSingleton<IDownloadService, DownloadService>();
             services.AddSingleton<IUploadService, UploadService>();
 
-            services.AddSingleton<INetworkService, NetworkService>();
+            services.AddSingleton<INetworkService, RelayService>();
 
             services.AddSingleton<IFTPClientFactory, FTPClientFactory>();
             services.AddSingleton<IFTPService, FTPService>();
@@ -819,7 +819,7 @@ namespace slskd
                 endpoints.MapHub<ApplicationHub>("/hub/application");
                 endpoints.MapHub<LogsHub>("/hub/logs");
                 endpoints.MapHub<SearchHub>("/hub/search");
-                endpoints.MapHub<NetworkHub>("/hub/agents");
+                endpoints.MapHub<RelayHub>("/hub/agents");
 
                 endpoints.MapControllers();
                 endpoints.MapHealthChecks("/health");

--- a/src/slskd/Relay/API/Controllers/RelayController.cs
+++ b/src/slskd/Relay/API/Controllers/RelayController.cs
@@ -121,7 +121,7 @@ namespace slskd.Relay
 
                 Log.Information("File upload of {Filename} ({Token}) from agent {Agent} validated and authenticated. Forwarding file stream.", filename, token, agentName);
 
-                // pass the stream back to the network service, which will in turn pass it to the upload service, and use it to
+                // pass the stream back to the relay service, which will in turn pass it to the upload service, and use it to
                 // feed data into the remote upload. await this call, it will complete when the upload is complete, one way or the other.
                 await Relay.HandleFileStreamResponse(agentName, id: guid, stream);
 

--- a/src/slskd/Relay/API/Controllers/RelayController.cs
+++ b/src/slskd/Relay/API/Controllers/RelayController.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NetworkController.cs" company="slskd Team">
+﻿// <copyright file="RelayController.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -15,7 +15,7 @@
 //     along with this program.  If not, see https://www.gnu.org/licenses/.
 // </copyright>
 
-namespace slskd.Network
+namespace slskd.Relay
 {
     using System;
     using System.Collections.Generic;
@@ -31,21 +31,21 @@ namespace slskd.Network
     using slskd.Shares;
 
     /// <summary>
-    ///     Network.
+    ///     Relay.
     /// </summary>
     [Route("api/v{version:apiVersion}/[controller]")]
     [ApiVersion("0")]
     [ApiController]
-    public class NetworkController : ControllerBase
+    public class RelayController : ControllerBase
     {
-        public NetworkController(
-            INetworkService networkService)
+        public RelayController(
+            IRelayService relayService)
         {
-            Network = networkService;
+            Relay = relayService;
         }
 
-        private ILogger Log { get; } = Serilog.Log.ForContext<NetworkController>();
-        private INetworkService Network { get; }
+        private ILogger Log { get; } = Serilog.Log.ForContext<RelayController>();
+        private IRelayService Relay { get; }
 
         /// <summary>
         ///     Uploads a file.
@@ -102,7 +102,7 @@ namespace slskd.Network
                     return BadRequest();
                 }
 
-                if (!Network.RegisteredAgents.Any(a => a.Name == agentName))
+                if (!Relay.RegisteredAgents.Any(a => a.Name == agentName))
                 {
                     return Unauthorized();
                 }
@@ -113,7 +113,7 @@ namespace slskd.Network
                 // provide the encrypted value as the credential with the request. the validation below verifies a bunch of
                 // things, including that the encrypted value matches the expected value. the goal here is to ensure that the
                 // caller is the same caller that received the request, and that the caller knows the shared secret.
-                if (!Network.TryValidateFileStreamResponseCredential(token: guid, agentName, filename, credential))
+                if (!Relay.TryValidateFileStreamResponseCredential(token: guid, agentName, filename, credential))
                 {
                     Log.Warning("Failed to authenticate file upload token {Token} from a caller claiming to be agent {Agent}", agentName);
                     return Unauthorized();
@@ -123,7 +123,7 @@ namespace slskd.Network
 
                 // pass the stream back to the network service, which will in turn pass it to the upload service, and use it to
                 // feed data into the remote upload. await this call, it will complete when the upload is complete, one way or the other.
-                await Network.HandleFileStreamResponse(agentName, id: guid, stream);
+                await Relay.HandleFileStreamResponse(agentName, id: guid, stream);
 
                 Log.Information("File upload of {Filename} ({Token}) from agent {Agent} complete", filename, token, agentName);
                 return Ok();
@@ -173,12 +173,12 @@ namespace slskd.Network
                 return BadRequest();
             }
 
-            if (!Network.RegisteredAgents.Any(a => a.Name == agentName))
+            if (!Relay.RegisteredAgents.Any(a => a.Name == agentName))
             {
                 return Unauthorized();
             }
 
-            if (!Network.TryValidateShareUploadCredential(token: guid, agentName, credential))
+            if (!Relay.TryValidateShareUploadCredential(token: guid, agentName, credential))
             {
                 Log.Warning("Failed to authenticate share upload from caller claiming to be agent {Agent}");
                 return Unauthorized();
@@ -198,7 +198,7 @@ namespace slskd.Network
 
                 Log.Debug("Upload of share from {Agent} to {Filename} complete", agentName, temp);
 
-                await Network.HandleShareUpload(agentName, id: guid, shares, temp);
+                await Relay.HandleShareUpload(agentName, id: guid, shares, temp);
 
                 return Ok();
             }

--- a/src/slskd/Relay/API/Hubs/RelayHub.cs
+++ b/src/slskd/Relay/API/Hubs/RelayHub.cs
@@ -142,7 +142,7 @@ namespace slskd.Relay
         }
 
         /// <summary>
-        ///     Notifies the controller that the agent was unable to upload the file requested by a call to <see cref="INetworkHub.RequestFileUpload"/>.
+        ///     Notifies the controller that the agent was unable to upload the file requested by a call to <see cref="IRelayHub.RequestFileUpload"/>.
         /// </summary>
         /// <param name="id">The unique identifier of the request.</param>
         /// <param name="exception">The Exception that caused the failure.</param>

--- a/src/slskd/Relay/DummyRelayClient.cs
+++ b/src/slskd/Relay/DummyRelayClient.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NetworkClientState.cs" company="slskd Team">
+﻿// <copyright file="DummyNetworkClient.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -15,13 +15,21 @@
 //     along with this program.  If not, see https://www.gnu.org/licenses/.
 // </copyright>
 
-namespace slskd.Network
+namespace slskd.Relay
 {
-    public enum NetworkClientState
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class DummyRelayClient : INetworkClient
     {
-        Disconnected,
-        Connected,
-        Connecting,
-        Reconnecting,
+        public IStateMonitor<NetworkClientState> StateMonitor => new ManagedState<NetworkClientState>();
+
+        public void Dispose() { }
+
+        public Task StartAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task SynchronizeAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 }

--- a/src/slskd/Relay/DummyRelayClient.cs
+++ b/src/slskd/Relay/DummyRelayClient.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DummyNetworkClient.cs" company="slskd Team">
+﻿// <copyright file="DummyRelayClient.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -20,9 +20,9 @@ namespace slskd.Relay
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class DummyRelayClient : INetworkClient
+    public class DummyRelayClient : IRelayClient
     {
-        public IStateMonitor<NetworkClientState> StateMonitor => new ManagedState<NetworkClientState>();
+        public IStateMonitor<RelayClientState> StateMonitor => new ManagedState<RelayClientState>();
 
         public void Dispose() { }
 

--- a/src/slskd/Relay/RelayClientState.cs
+++ b/src/slskd/Relay/RelayClientState.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DummyNetworkClient.cs" company="slskd Team">
+﻿// <copyright file="RelayClientState.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -15,21 +15,13 @@
 //     along with this program.  If not, see https://www.gnu.org/licenses/.
 // </copyright>
 
-namespace slskd.Network
+namespace slskd.Relay
 {
-    using System.Threading;
-    using System.Threading.Tasks;
-
-    public class DummyNetworkClient : INetworkClient
+    public enum RelayClientState
     {
-        public IStateMonitor<NetworkClientState> StateMonitor => new ManagedState<NetworkClientState>();
-
-        public void Dispose() { }
-
-        public Task StartAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
-
-        public Task StopAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
-
-        public Task SynchronizeAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        Disconnected,
+        Connected,
+        Connecting,
+        Reconnecting,
     }
 }

--- a/src/slskd/Relay/RelayService.cs
+++ b/src/slskd/Relay/RelayService.cs
@@ -276,7 +276,7 @@ namespace slskd.Relay
         }
 
         /// <summary>
-        ///     Gets the network client (agent).
+        ///     Gets the relay client (agent).
         /// </summary>
         public IRelayClient Client { get; private set; }
 

--- a/src/slskd/Relay/Types/Agent.cs
+++ b/src/slskd/Relay/Types/Agent.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="OperationMode.cs" company="slskd Team">
+﻿// <copyright file="Agent.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -15,26 +15,11 @@
 //     along with this program.  If not, see https://www.gnu.org/licenses/.
 // </copyright>
 
-namespace slskd.Network
+namespace slskd.Relay
 {
-    /// <summary>
-    ///     The network operation mode.
-    /// </summary>
-    public enum OperationMode
+    public record Agent
     {
-        /// <summary>
-        ///     Controller operation mode.
-        /// </summary>
-        Controller = 0,
-
-        /// <summary>
-        ///     Agent operation mode.
-        /// </summary>
-        Agent = 1,
-
-        /// <summary>
-        ///     Debug mode; enables operation as both a controller and agent.
-        /// </summary>
-        Debug = 2,
+        public string Name { get; init; }
+        public string IPAddress { get; init; }
     }
 }

--- a/src/slskd/Relay/Types/OperationMode.cs
+++ b/src/slskd/Relay/Types/OperationMode.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Agent.cs" company="slskd Team">
+﻿// <copyright file="OperationMode.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -15,11 +15,26 @@
 //     along with this program.  If not, see https://www.gnu.org/licenses/.
 // </copyright>
 
-namespace slskd.Network
+namespace slskd.Relay
 {
-    public record Agent
+    /// <summary>
+    ///     The network operation mode.
+    /// </summary>
+    public enum OperationMode
     {
-        public string Name { get; init; }
-        public string IPAddress { get; init; }
+        /// <summary>
+        ///     Controller operation mode.
+        /// </summary>
+        Controller = 0,
+
+        /// <summary>
+        ///     Agent operation mode.
+        /// </summary>
+        Agent = 1,
+
+        /// <summary>
+        ///     Debug mode; enables operation as both a controller and agent.
+        /// </summary>
+        Debug = 2,
     }
 }

--- a/src/slskd/Relay/Types/OperationMode.cs
+++ b/src/slskd/Relay/Types/OperationMode.cs
@@ -18,7 +18,7 @@
 namespace slskd.Relay
 {
     /// <summary>
-    ///     The network operation mode.
+    ///     The relay operation mode.
     /// </summary>
     public enum OperationMode
     {

--- a/src/slskd/Transfers/Uploads/UploadService.cs
+++ b/src/slskd/Transfers/Uploads/UploadService.cs
@@ -30,7 +30,7 @@ namespace slskd.Transfers.Uploads
     using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
     using Serilog;
-    using slskd.Network;
+    using slskd.Relay;
     using slskd.Shares;
     using slskd.Users;
 
@@ -44,13 +44,13 @@ namespace slskd.Transfers.Uploads
             ISoulseekClient soulseekClient,
             IOptionsMonitor<Options> optionsMonitor,
             IShareService shareService,
-            INetworkService networkService,
+            IRelayService relayService,
             IDbContextFactory<TransfersDbContext> contextFactory)
         {
             Users = userService;
             Client = soulseekClient;
             Shares = shareService;
-            Network = networkService;
+            Relay = relayService;
             ContextFactory = contextFactory;
             OptionsMonitor = optionsMonitor;
 
@@ -75,7 +75,7 @@ namespace slskd.Transfers.Uploads
         private IShareService Shares { get; set; }
         private IUserService Users { get; set; }
         private IOptionsMonitor<Options> OptionsMonitor { get; }
-        private INetworkService Network { get; }
+        private IRelayService Relay { get; }
 
         /// <summary>
         ///     Adds the specified <paramref name="transfer"/>. Supersedes any existing record for the same file and username.
@@ -137,7 +137,7 @@ namespace slskd.Transfers.Uploads
                 }
                 else
                 {
-                    var (exists, length) = await Network.GetFileInfoAsync(agentName: host, filename);
+                    var (exists, length) = await Relay.GetFileInfoAsync(agentName: host, filename);
 
                     if (!exists || length <= 0)
                     {
@@ -269,11 +269,11 @@ namespace slskd.Transfers.Uploads
                             username,
                             filename,
                             size: localFileLength,
-                            inputStreamFactory: () => Network.GetFileStreamAsync(agentName: host, filename, id),
+                            inputStreamFactory: () => Relay.GetFileStreamAsync(agentName: host, filename, id),
                             options: topts,
                             cancellationToken: cts.Token);
 
-                        Network.TryCloseFileStream(host, id);
+                        Relay.TryCloseFileStream(host, id);
 
                         transfer = transfer.WithSoulseekTransfer(completedTransfer);
                     }
@@ -294,7 +294,7 @@ namespace slskd.Transfers.Uploads
                     // todo: broadcast
                     SynchronizedUpdate(transfer, cancellable: false);
 
-                    Network.TryCloseFileStream(host, id, ex);
+                    Relay.TryCloseFileStream(host, id, ex);
 
                     throw;
                 }
@@ -309,7 +309,7 @@ namespace slskd.Transfers.Uploads
                     // todo: broadcast
                     SynchronizedUpdate(transfer, cancellable: false);
 
-                    Network.TryCloseFileStream(host, id, ex);
+                    Relay.TryCloseFileStream(host, id, ex);
                     throw;
                 }
                 finally


### PR DESCRIPTION
This was confusing me a bit, and it's fresh in my mind.  Relay is a more descriptive name anyway.