### PR TITLE
Detect change in share configuration, 'dirty' scan, or any other reason shares are in a known bad or questionable state at startup and force scan if needed

### DIFF
--- a/src/slskd/Shares/IShareRepository.cs
+++ b/src/slskd/Shares/IShareRepository.cs
@@ -81,6 +81,12 @@ namespace slskd.Shares
         string FindFilename(string maskedFilename);
 
         /// <summary>
+        ///     Finds and returns the most recent scan record.
+        /// </summary>
+        /// <returns>The most recent scan record, or default if no scan was found.</returns>
+        (long Timestamp, string OptionsJson) FindLatestScan();
+
+        /// <summary>
         ///     Inserts a directory.
         /// </summary>
         /// <param name="name">The fully qualified local name of the directory.</param>

--- a/src/slskd/Shares/IShareRepository.cs
+++ b/src/slskd/Shares/IShareRepository.cs
@@ -84,7 +84,12 @@ namespace slskd.Shares
         ///     Finds and returns the most recent scan record.
         /// </summary>
         /// <returns>The most recent scan record, or default if no scan was found.</returns>
-        (long Timestamp, string OptionsJson) FindLatestScan();
+        Scan FindLatestScan();
+
+        /// <summary>
+        ///     Flags the latest scan as suspect, indicating that the cached contents may have divered from physical storage.
+        /// </summary>
+        void FlagLatestScanAsSuspect();
 
         /// <summary>
         ///     Inserts a directory.

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -410,6 +410,13 @@ namespace slskd.Shares
                     }
                 }
 
+                var cachedOptions = Local.Repository.FindLatestScan();
+
+                if (cachedOptions == default || cachedOptions.OptionsJson != OptionsMonitor.CurrentValue.Shares.ToJson())
+                {
+                    throw new ShareInitializationException("Share options changed since the last scan");
+                }
+
                 Local.Repository.EnableKeepalive(true);
 
                 Log.Debug("Recomputing share statistics...");

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -296,6 +296,7 @@ namespace slskd.Shares
         /// </summary>
         public void RequestScan()
         {
+            Local.Repository.FlagLatestScanAsSuspect();
             State.SetValue(state => state with { ScanPending = true });
         }
 

--- a/src/slskd/Shares/SqliteShareRepository.cs
+++ b/src/slskd/Shares/SqliteShareRepository.cs
@@ -19,7 +19,6 @@ namespace slskd.Shares
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Timers;
     using Microsoft.Data.Sqlite;
@@ -223,6 +222,28 @@ namespace slskd.Shares
             var resolved = reader.GetString(0);
             Log.Debug($"Resolved requested shared file {maskedFilename} to {resolved}");
             return resolved;
+        }
+
+        /// <summary>
+        ///     Finds and returns the most recent scan record.
+        /// </summary>
+        /// <returns>The most recent scan record, or default if no scan was found.</returns>
+        public (long Timestamp, string OptionsJson) FindLatestScan()
+        {
+            using var conn = GetConnection();
+            using var cmd = new SqliteCommand("SELECT timestamp, options FROM scans ORDER BY timestamp DESC LIMIT 1", conn);
+
+            var reader = cmd.ExecuteReader();
+
+            if (!reader.Read())
+            {
+                return default;
+            }
+
+            var timestamp = reader.GetInt64(0);
+            var optionsJson = reader.GetString(1);
+
+            return (timestamp, optionsJson);
         }
 
         /// <summary>

--- a/src/slskd/Shares/Types/Scan.cs
+++ b/src/slskd/Shares/Types/Scan.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="Scan.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd.Shares
+{
+    public record Scan
+    {
+        public long StartedAt { get; init; }
+        public string OptionsJson { get; init; }
+        public long? EndedAt { get; init; }
+        public bool Suspect { get; init; }
+    }
+}


### PR DESCRIPTION
This PR helps ensure that the application always starts with a valid share cache.

Forces a scan:

* [x] If no scan records exist at startup
* [x] If the most recent scan record has been marked as suspect
* [x] If the most recent scan record has a null end timestamp
* [x] If options changed offline (already tested, but might as well test again)
* [x] Doesn't force a scan if none of the above is true

Closes #658 