### PR TITLE
Relay tweaks and bug fixes

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -224,12 +224,14 @@ Agents need to specify the HTTP or HTTPS address of their controller, the API ke
 
 If using HTTPS; most users won't have a valid certificate (the self-signed certificates that slskd generates at startup are not 'valid' because they are self-signed), and in those cases the `ignore_certificate_errors` option should be set to `true`.
 
-| Command-Line                             | Environment Variable                         | Description                      |
-| ---------------------------------------- | -------------------------------------------- | ---------------------------------|
-| `--controller-address`                   | `SLSKD_CONTROLLER_ADDRESS`                   | Enable the Relay feature         |
-| `--controller-ignore-certificate-errors` | `SLSKD_CONTROLLER_IGNORE_CERTIFICATE_ERRORS` | Ignore certificate errors        |
-| `--controller-api-key`                   | `SLSKD_CONTROLLER_API_KEY`                   | An API key for the controller    |
-| `--controller-secret`                    | `SLSKD_CONTROLLER_SECRET`                    | The shared secret for this agent |
+| Command-Line                             | Environment Variable                         | Description                               |
+| ---------------------------------------- | -------------------------------------------- | ------------------------------------------|
+| `-r\|--relay`                            | `SLSKD_RELAY`                                | Enable the Relay feature                  |
+| `-m\|--relay-mode`                       | `SLSKD_RELAY_MODE`                           | The Relay mode (Controller, Agent, Debug) |
+| `--controller-address`                   | `SLSKD_CONTROLLER_ADDRESS`                   | Enable the Relay feature                  |
+| `--controller-ignore-certificate-errors` | `SLSKD_CONTROLLER_IGNORE_CERTIFICATE_ERRORS` | Ignore certificate errors                 |
+| `--controller-api-key`                   | `SLSKD_CONTROLLER_API_KEY`                   | An API key for the controller             |
+| `--controller-secret`                    | `SLSKD_CONTROLLER_SECRET`                    | The shared secret for this agent          |
 
 ```yaml
 instance_name: some_instance

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -1052,7 +1052,6 @@ namespace slskd
                     // ...but if it completed successfully, immediately update again to lower the pending flag
                     State.SetValue(state => state with { Shares = state.Shares with { ScanPending = false } });
                     Log.Information("Shares scanned successfully. Found {Directories} directories and {Files} files in {Duration}ms", current.Directories, current.Files, (DateTime.UtcNow - SharesRefreshStarted).TotalMilliseconds);
-                    rebuildBrowseCache = true;
 
                     SharesRefreshStarted = default;
 

--- a/src/slskd/Relay/API/Controllers/RelayController.cs
+++ b/src/slskd/Relay/API/Controllers/RelayController.cs
@@ -150,7 +150,7 @@ namespace slskd.Relay
                 // caller is the same caller that received the request, and that the caller knows the shared secret.
                 if (!Relay.TryValidateFileStreamResponseCredential(token: guid, agentName, filename, credential))
                 {
-                    Log.Warning("Failed to authenticate file upload token {Token} from a caller claiming to be agent {Agent}", agentName);
+                    Log.Warning("Failed to authenticate file upload token {Token} from a caller claiming to be agent {Agent}", guid, agentName);
                     return Unauthorized();
                 }
 
@@ -220,7 +220,7 @@ namespace slskd.Relay
 
             if (!Relay.TryValidateShareUploadCredential(token: guid, agentName, credential))
             {
-                Log.Warning("Failed to authenticate share upload from caller claiming to be agent {Agent}");
+                Log.Warning("Failed to authenticate share upload from caller claiming to be agent {Agent} using token {Token}", agentName, guid);
                 return Unauthorized();
             }
 

--- a/src/slskd/Relay/API/Hubs/RelayHub.cs
+++ b/src/slskd/Relay/API/Hubs/RelayHub.cs
@@ -169,7 +169,7 @@ namespace slskd.Relay
                 throw new UnauthorizedAccessException();
             }
 
-            Log.Warning("Agent {Agent} (connection {ConnectionId}) from {IP} reported upload failure for {Id}: {Message}", id, exception.Message, RemoteIpAddress);
+            Log.Warning("Agent {Agent} (connection {ConnectionId}) from {IP} reported upload failure for {Id}: {Message}", record.Agent, Context.ConnectionId, RemoteIpAddress, id, exception.Message);
 
             Relay.NotifyFileStreamException(id, exception);
         }

--- a/src/slskd/Relay/RelayClient.cs
+++ b/src/slskd/Relay/RelayClient.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Options;
 namespace slskd.Relay
 {
     using System;
+    using System.Diagnostics;
     using System.IO;
     using System.Net.Http;
     using System.Threading;
@@ -254,7 +255,12 @@ namespace slskd.Relay
                 request.Headers.Add("X-API-Key", OptionsMonitor.CurrentValue.Relay.Controller.ApiKey);
                 request.Content = content;
 
-                Log.Information("Beginning upload of shares");
+                var size = ((double)stream.Length).SizeSuffix();
+                var sw = new Stopwatch();
+                sw.Start();
+
+                Log.Information("Beginning upload of shares ({Size})", size);
+                Log.Debug("Shares: {Shares}", Shares.LocalHost.Shares.ToJson());
                 var response = await CreateHttpClient().SendAsync(request, cancellationToken);
 
                 if (!response.IsSuccessStatusCode)
@@ -262,7 +268,8 @@ namespace slskd.Relay
                     throw new RelayException($"Failed to upload shares to relay controller: {response.StatusCode}");
                 }
 
-                Log.Information("Upload shares succeeded");
+                sw.Stop();
+                Log.Information("Upload of shares succeeded ({Size} in {Duration}ms)", size, sw.ElapsedMilliseconds);
             }
             finally
             {

--- a/src/slskd/Relay/RelayClient.cs
+++ b/src/slskd/Relay/RelayClient.cs
@@ -207,7 +207,7 @@ namespace slskd.Relay
         /// <returns>The operation context.</returns>
         public Task SynchronizeAsync(CancellationToken cancellationToken = default)
         {
-            return UploadSharesAsync();
+            return UploadSharesAsync(cancellationToken);
         }
 
         private RelayClientState TranslateState(HubConnectionState hub) => hub switch

--- a/src/slskd/Relay/RelayClient.cs
+++ b/src/slskd/Relay/RelayClient.cs
@@ -317,11 +317,11 @@ namespace slskd.Relay
 
                     if (!response.IsSuccessStatusCode)
                     {
-                        Log.Error("Upload of file {Filename} with ID {Id} failed: {StatusCode}", response.StatusCode);
+                        Log.Error("Upload of file {Filename} with ID {Id} failed: {StatusCode}", filename, token, response.StatusCode);
                     }
                     else
                     {
-                        Log.Information("Upload of file {Filename} with ID {Id} succeeded.", filename);
+                        Log.Information("Upload of file {Filename} with ID {Id} succeeded.", filename, token);
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Updates docs, fixes a bunch of logging issues, and tweaks the `Ready` state change of the shares service to delay the update until after share statistics are re-computed.

Closes #769 
Closes #770 
Closes #771
Closes #772 