### PR TITLE
Add support for resume-able uploads from Relay Agents

### DIFF
--- a/src/slskd/Relay/API/Controllers/RelayController.cs
+++ b/src/slskd/Relay/API/Controllers/RelayController.cs
@@ -134,6 +134,8 @@ namespace slskd.Relay
                 catch (Exception ex)
                 {
                     Log.Warning("Failed to handle file upload for token {Token} from a caller claiming to be agent {Agent}: {Message}", token, agentName, ex.Message);
+                    Log.Debug(ex, "Failed to handle file upload");
+
                     return BadRequest();
                 }
 

--- a/src/slskd/Relay/API/Hubs/RelayHub.cs
+++ b/src/slskd/Relay/API/Hubs/RelayHub.cs
@@ -50,9 +50,10 @@ namespace slskd.Relay
         ///     Requests the specified <paramref name="filename"/> from the agent.
         /// </summary>
         /// <param name="filename">The name of the file.</param>
+        /// <param name="startOffset">The starting offset for the transfer.</param>
         /// <param name="id">The unique identifier for the request.</param>
         /// <returns>The operation context.</returns>
-        Task RequestFileUpload(string filename, Guid id);
+        Task RequestFileUpload(string filename, long startOffset, Guid id);
     }
 
     /// <summary>

--- a/src/slskd/Relay/RelayClient.cs
+++ b/src/slskd/Relay/RelayClient.cs
@@ -289,7 +289,7 @@ namespace slskd.Relay
 
         private string ComputeCredential(Guid token) => ComputeCredential(token.ToString());
 
-        private Task HandleFileUploadRequest(string filename, Guid token)
+        private Task HandleFileUploadRequest(string filename, long startOffset, Guid token)
         {
             _ = Task.Run(async () =>
             {
@@ -308,6 +308,9 @@ namespace slskd.Relay
                     }
 
                     using var stream = new FileStream(localFileInfo.FullName, FileMode.Open, FileAccess.Read);
+
+                    stream.Seek(startOffset, SeekOrigin.Begin);
+
                     using var request = new HttpRequestMessage(HttpMethod.Post, $"api/v0/relay/files/{token}");
                     using var content = new MultipartFormDataContent
                     {
@@ -485,7 +488,7 @@ namespace slskd.Relay
                 HubConnection.Reconnecting += HubConnection_Reconnecting;
                 HubConnection.Closed += HubConnection_Closed;
 
-                HubConnection.On<string, Guid>(nameof(IRelayHub.RequestFileUpload), HandleFileUploadRequest);
+                HubConnection.On<string, long, Guid>(nameof(IRelayHub.RequestFileUpload), HandleFileUploadRequest);
                 HubConnection.On<string, Guid>(nameof(IRelayHub.RequestFileInfo), HandleFileInfoRequest);
                 HubConnection.On<string>(nameof(IRelayHub.Challenge), HandleAuthenticationChallenge);
 

--- a/src/slskd/Relay/RelayService.cs
+++ b/src/slskd/Relay/RelayService.cs
@@ -143,11 +143,12 @@ namespace slskd.Relay
         /// </remarks>
         /// <param name="agentName">The agent from which to retrieve the file.</param>
         /// <param name="filename">The file to retrieve.</param>
+        /// <param name="startOffset">The starting offset for the transfer.</param>
         /// <param name="id">A unique ID for the stream.</param>
         /// <param name="timeout">An optional timeout value.</param>
         /// <param name="cancellationToken">An optional token to monitor for cancellation requests.</param>
         /// <returns>The operation context, including a stream containing the requested file.</returns>
-        Task<Stream> GetFileStreamAsync(string agentName, string filename, Guid id, int timeout = 3000, CancellationToken cancellationToken = default);
+        Task<Stream> GetFileStreamAsync(string agentName, string filename, long startOffset, Guid id, int timeout = 3000, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Handles the client response for a <see cref="GetFileInfoAsync"/> request.
@@ -444,11 +445,12 @@ namespace slskd.Relay
         /// </remarks>
         /// <param name="agentName">The agent from which to retrieve the file.</param>
         /// <param name="filename">The file to retrieve.</param>
+        /// <param name="startOffset">The starting offset for the transfer.</param>
         /// <param name="id">A unique ID for the stream.</param>
         /// <param name="timeout">An optional timeout value.</param>
         /// <param name="cancellationToken">An optional token to monitor for cancellation requests.</param>
         /// <returns>The operation context, including a stream containing the requested file.</returns>
-        public async Task<Stream> GetFileStreamAsync(string agentName, string filename, Guid id, int timeout = 3000, CancellationToken cancellationToken = default)
+        public async Task<Stream> GetFileStreamAsync(string agentName, string filename, long startOffset, Guid id, int timeout = 3000, CancellationToken cancellationToken = default)
         {
             if (!RegisteredAgentDictionary.TryGetValue(agentName, out var record))
             {
@@ -468,7 +470,7 @@ namespace slskd.Relay
 
             Log.Information("Created wait {Key}", key);
 
-            await RelayHub.Clients.Client(record.ConnectionId).RequestFileUpload(filename, id);
+            await RelayHub.Clients.Client(record.ConnectionId).RequestFileUpload(filename, startOffset, id);
             Log.Information("Requested file {Filename} from Agent {Agent} with ID {Id}. Waiting for incoming connection.", filename, agentName, id);
 
             var task = await Task.WhenAny(wait, Task.Delay(timeout, cancellationToken));

--- a/src/slskd/Transfers/Uploads/UploadService.cs
+++ b/src/slskd/Transfers/Uploads/UploadService.cs
@@ -245,6 +245,7 @@ namespace slskd.Transfers.Uploads
                             // todo: broadcast
                             SynchronizedUpdate(transfer);
                         }),
+                        seekInputStreamAutomatically: false,
                         disposeInputStreamOnCompletion: true,
                         governor: (tx, req, ct) => Governor.GetBytesAsync(tx.Username, req, ct),
                         reporter: (tx, att, grant, act) => Governor.ReturnBytes(tx.Username, att, grant, act),
@@ -257,7 +258,12 @@ namespace slskd.Transfers.Uploads
                             username,
                             filename,
                             size: localFileLength,
-                            inputStreamFactory: () => Task.FromResult((Stream)new FileStream(localFilename, FileMode.Open, FileAccess.Read)),
+                            inputStreamFactory: (startOffset) =>
+                            {
+                                var stream = new FileStream(localFilename, FileMode.Open, FileAccess.Read);
+                                stream.Seek(startOffset, SeekOrigin.Begin);
+                                return Task.FromResult((Stream)stream);
+                            },
                             options: topts,
                             cancellationToken: cts.Token);
 
@@ -269,7 +275,7 @@ namespace slskd.Transfers.Uploads
                             username,
                             filename,
                             size: localFileLength,
-                            inputStreamFactory: () => Relay.GetFileStreamAsync(agentName: host, filename, id),
+                            inputStreamFactory: (startOffset) => Relay.GetFileStreamAsync(agentName: host, filename, startOffset, id),
                             options: topts,
                             cancellationToken: cts.Token);
 

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -66,7 +66,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="7.1.1" />
     <PackageReference Include="Serilog.Sinks.Http" Version="8.0.0" />
-    <PackageReference Include="Soulseek" Version="6.0.0-pre.1" />
+    <PackageReference Include="Soulseek" Version="6.0.0-pre.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -66,7 +66,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="7.1.1" />
     <PackageReference Include="Serilog.Sinks.Http" Version="8.0.0" />
-    <PackageReference Include="Soulseek" Version="6.0.0-pre.2" />
+    <PackageReference Include="Soulseek" Version="6.0.0-pre.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
The initial implementation would only upload entire files, and the stream that comes from the HTTP controller receiving the files isn't capable of seeking, so resumed uploads would fail.

This PR updates Soulseek.NET to a new preview version that passes the requested start offset down to the input stream factory of `UploadAsync()`, and adds an option to turn off automatic seeking of input streams, offloading that responsibility to the caller (slskd, in this case).

The Relay controller now passes the start offset down to the agent, and the agent seeks the file stream prior to uploading.

Tested and confirmed working for both agent and non-agent (local) uploads.

Closes #768 