### PR TITLE
Add IsRelayAgent to Program, simplify checks

### DIFF
--- a/src/slskd/Core/API/Controllers/ServerController.cs
+++ b/src/slskd/Core/API/Controllers/ServerController.cs
@@ -48,7 +48,6 @@ namespace slskd.Core.API
         private ISoulseekClient Client { get; }
         private IOptionsSnapshot<Options> OptionsSnapshot { get; }
         private IStateSnapshot<State> StateSnapshot { get; }
-        private bool IsAgent => OptionsSnapshot.Value.Relay.Mode.ToEnum<RelayMode>() == RelayMode.Agent;
 
         /// <summary>
         ///     Connects the client.
@@ -61,7 +60,7 @@ namespace slskd.Core.API
         [ProducesResponseType(403)]
         public async Task<IActionResult> Connect()
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -86,7 +85,7 @@ namespace slskd.Core.API
         [ProducesResponseType(403)]
         public IActionResult Disconnect([FromBody] string message)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }

--- a/src/slskd/Messaging/API/Controllers/ConversationsController.cs
+++ b/src/slskd/Messaging/API/Controllers/ConversationsController.cs
@@ -60,7 +60,6 @@ namespace slskd.Messaging.API
         private IStateMonitor<State> ApplicationStateMonitor { get; }
         private IConversationTracker Tracker { get; }
         private IOptionsSnapshot<Options> OptionsSnapshot { get; }
-        private bool IsAgent => OptionsSnapshot.Value.Relay.Mode.ToEnum<RelayMode>() == RelayMode.Agent;
 
         /// <summary>
         ///     Acknowledges the given message id for the given username.
@@ -78,7 +77,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(404)]
         public async Task<IActionResult> Acknowledge([FromRoute]string username, [FromRoute]int id)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -107,7 +106,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(404)]
         public async Task<IActionResult> AcknowledgeAll([FromRoute]string username)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -146,7 +145,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(204)]
         public IActionResult Delete([FromRoute]string username)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -171,7 +170,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(typeof(Dictionary<string, List<PrivateMessageResponse>>), 200)]
         public IActionResult GetAll()
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -198,7 +197,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(404)]
         public IActionResult GetByUsername([FromRoute]string username)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -229,7 +228,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(400)]
         public async Task<IActionResult> Send([FromRoute]string username, [FromBody]string message)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }

--- a/src/slskd/Messaging/API/Controllers/PublicChatController.cs
+++ b/src/slskd/Messaging/API/Controllers/PublicChatController.cs
@@ -44,7 +44,6 @@ namespace slskd.Messaging.API
 
         private ISoulseekClient Client { get; }
         private IOptionsSnapshot<Options> OptionsSnapshot { get; }
-        private bool IsAgent => OptionsSnapshot.Value.Relay.Mode.ToEnum<RelayMode>() == RelayMode.Agent;
 
         /// <summary>
         ///     Starts public chat.
@@ -54,7 +53,7 @@ namespace slskd.Messaging.API
         [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> Start()
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -71,7 +70,7 @@ namespace slskd.Messaging.API
         [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> Stop()
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }

--- a/src/slskd/Messaging/API/Controllers/RoomsController.cs
+++ b/src/slskd/Messaging/API/Controllers/RoomsController.cs
@@ -58,7 +58,6 @@ namespace slskd.Messaging.API
         private IStateMonitor<State> ApplicationStateMonitor { get; }
         private IRoomTracker Tracker { get; }
         private IOptionsSnapshot<Options> OptionsSnapshot { get; }
-        private bool IsAgent => OptionsSnapshot.Value.Relay.Mode.ToEnum<RelayMode>() == RelayMode.Agent;
 
         /// <summary>
         ///     Gets all rooms.
@@ -70,7 +69,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(typeof(Dictionary<string, Dictionary<string, Room>>), 200)]
         public IActionResult GetAll()
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -91,7 +90,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(404)]
         public IActionResult GetByRoomName([FromRoute]string roomName)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -118,7 +117,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(404)]
         public async Task<IActionResult> SendMessage([FromRoute]string roomName, [FromBody]string message)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -146,7 +145,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(404)]
         public async Task<IActionResult> SetTicker([FromRoute] string roomName, [FromBody] string message)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -174,7 +173,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(404)]
         public async Task<IActionResult> AddRoomMember([FromRoute]string roomName, [FromBody]string username)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -201,7 +200,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(404)]
         public IActionResult GetUsersByRoomName([FromRoute]string roomName)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -230,7 +229,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(404)]
         public IActionResult GetMessagesByRoomName([FromRoute]string roomName)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -255,7 +254,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(typeof(List<RoomInfo>), 200)]
         public async Task<IActionResult> GetRooms()
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -289,7 +288,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(304)]
         public async Task<IActionResult> JoinRoom([FromBody]string roomName)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -330,7 +329,7 @@ namespace slskd.Messaging.API
         [ProducesResponseType(404)]
         public async Task<IActionResult> LeaveRoom([FromRoute]string roomName)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -153,6 +153,11 @@ namespace slskd
         public static bool IsDevelopment { get; } = new Version(0, 0, 0, 0) == AssemblyVersion;
 
         /// <summary>
+        ///     Gets a value indicating whether the application is being run in Relay Agent mode.
+        /// </summary>
+        public static bool IsRelayAgent { get; private set; }
+
+        /// <summary>
         ///     Gets the path where application data is saved.
         /// </summary>
         [Argument('a', "app-dir", "path where application data is saved")]
@@ -357,6 +362,8 @@ namespace slskd
                 Log.Information($"Invalid configuration: {(!OptionsAtStartup.Debug ? ex : ex.Message)}");
                 return;
             }
+
+            IsRelayAgent = OptionsAtStartup.Relay.Enabled && OptionsAtStartup.Relay.Mode.ToEnum<RelayMode>() == RelayMode.Agent;
 
             ConfigureGlobalLogger();
             Log = Serilog.Log.ForContext(typeof(Program));

--- a/src/slskd/Search/API/Controllers/SearchesController.cs
+++ b/src/slskd/Search/API/Controllers/SearchesController.cs
@@ -50,7 +50,6 @@ namespace slskd.Search.API
 
         private ISearchService Searches { get; }
         private IOptionsSnapshot<Options> OptionsSnapshot { get; }
-        private bool IsAgent => OptionsSnapshot.Value.Relay.Mode.ToEnum<RelayMode>() == RelayMode.Agent;
 
         /// <summary>
         ///     Performs a search for the specified <paramref name="request"/>.
@@ -64,7 +63,7 @@ namespace slskd.Search.API
         [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> Post([FromBody] SearchRequest request)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -106,7 +105,7 @@ namespace slskd.Search.API
         [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> GetById([FromRoute] Guid id, [FromQuery] bool includeResponses = false)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -132,7 +131,7 @@ namespace slskd.Search.API
         [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> GetResponsesById([FromRoute] Guid id)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -155,7 +154,7 @@ namespace slskd.Search.API
         [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> GetAll()
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -177,7 +176,7 @@ namespace slskd.Search.API
         [ProducesResponseType(304)]
         public async Task<IActionResult> Cancel([FromRoute] Guid id)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -210,7 +209,7 @@ namespace slskd.Search.API
         [ProducesResponseType(404)]
         public async Task<IActionResult> Delete([FromRoute] Guid id)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }

--- a/src/slskd/Transfers/API/Controllers/TransfersController.cs
+++ b/src/slskd/Transfers/API/Controllers/TransfersController.cs
@@ -52,7 +52,6 @@ namespace slskd.Transfers.API
 
         private ITransferService Transfers { get; }
         private IOptionsSnapshot<Options> OptionsSnapshot { get; }
-        private bool IsAgent => OptionsSnapshot.Value.Relay.Mode.ToEnum<RelayMode>() == RelayMode.Agent;
 
         /// <summary>
         ///     Cancels the specified download.
@@ -69,7 +68,7 @@ namespace slskd.Transfers.API
         [ProducesResponseType(404)]
         public IActionResult CancelDownloadAsync([FromRoute, Required] string username, [FromRoute, Required]string id, [FromQuery]bool remove = false)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -106,7 +105,7 @@ namespace slskd.Transfers.API
         [ProducesResponseType(204)]
         public IActionResult ClearCompletedDownloads()
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -138,7 +137,7 @@ namespace slskd.Transfers.API
         [ProducesResponseType(404)]
         public IActionResult CancelUpload([FromRoute, Required] string username, [FromRoute, Required]string id, [FromQuery]bool remove = false)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -175,7 +174,7 @@ namespace slskd.Transfers.API
         [ProducesResponseType(204)]
         public IActionResult ClearCompletedUploads()
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -208,7 +207,7 @@ namespace slskd.Transfers.API
         [ProducesResponseType(typeof(string), 500)]
         public async Task<IActionResult> EnqueueAsync([FromRoute, Required]string username, [FromBody]IEnumerable<QueueDownloadRequest> requests)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -234,7 +233,7 @@ namespace slskd.Transfers.API
         [ProducesResponseType(200)]
         public IActionResult GetDownloadsAsync([FromQuery]bool includeRemoved = false)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -266,7 +265,7 @@ namespace slskd.Transfers.API
         [ProducesResponseType(200)]
         public IActionResult GetDownloadsAsync([FromRoute, Required] string username)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -298,7 +297,7 @@ namespace slskd.Transfers.API
         [ProducesResponseType(404)]
         public IActionResult GetDownload([FromRoute, Required] string username, [FromRoute, Required] string id)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -333,7 +332,7 @@ namespace slskd.Transfers.API
         [ProducesResponseType(404)]
         public async Task<IActionResult> GetPlaceInQueueAsync([FromRoute, Required] string username, [FromRoute, Required] string id)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -368,7 +367,7 @@ namespace slskd.Transfers.API
         [ProducesResponseType(200)]
         public IActionResult GetUploads([FromQuery] bool includeRemoved = false)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -400,7 +399,7 @@ namespace slskd.Transfers.API
         [ProducesResponseType(200)]
         public IActionResult GetUploads([FromRoute, Required] string username)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -438,7 +437,7 @@ namespace slskd.Transfers.API
         [ProducesResponseType(200)]
         public IActionResult GetUploads([FromRoute, Required] string username, [FromRoute, Required] string id)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }

--- a/src/slskd/Users/API/Controllers/UsersController.cs
+++ b/src/slskd/Users/API/Controllers/UsersController.cs
@@ -56,7 +56,6 @@ namespace slskd.Users.API
         private ISoulseekClient Client { get; }
         private IUserService Users { get; }
         private IOptionsSnapshot<Options> OptionsSnapshot { get; }
-        private bool IsAgent => OptionsSnapshot.Value.Relay.Mode.ToEnum<RelayMode>() == RelayMode.Agent;
 
         /// <summary>
         ///     Retrieves the address of the specified <paramref name="username"/>.
@@ -70,7 +69,7 @@ namespace slskd.Users.API
         [ProducesResponseType(404)]
         public async Task<IActionResult> Endpoint([FromRoute, Required] string username)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -97,7 +96,7 @@ namespace slskd.Users.API
         [ProducesResponseType(404)]
         public async Task<IActionResult> Browse([FromRoute, Required] string username)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -131,7 +130,7 @@ namespace slskd.Users.API
         [ProducesResponseType(404)]
         public IActionResult BrowseStatus([FromRoute, Required] string username)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -156,7 +155,7 @@ namespace slskd.Users.API
         [ProducesResponseType(404)]
         public async Task<IActionResult> Directory([FromRoute, Required] string username, [FromRoute, Required] string directory)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -183,7 +182,7 @@ namespace slskd.Users.API
         [ProducesResponseType(404)]
         public async Task<IActionResult> Info([FromRoute, Required] string username)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
@@ -210,7 +209,7 @@ namespace slskd.Users.API
         [ProducesResponseType(404)]
         public async Task<IActionResult> Status([FromRoute, Required] string username)
         {
-            if (IsAgent)
+            if (Program.IsRelayAgent)
             {
                 return Forbid();
             }


### PR DESCRIPTION
This adds an `IsRelayMode` property to `Program` which is statically available everywhere.  The logic now tests for `Enabled` in addition to the mode being set.