### PR TITLE
Add ARMv6 (Raspberry Pi 1/Zero) support by including linux-armv6 binaries in releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           - "linux-arm"
           - "linux-arm64"
           - "linux-musl-x64"
+          - "linux-musl-armv6"
           - "linux-musl-arm"
           - "linux-musl-arm64"
           - "osx-x64"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           - "win-arm"
           - "win-arm64"
           - "linux-x64"
+          - "linux-armv6"
           - "linux-arm"
           - "linux-arm64"
           - "linux-musl-x64"

--- a/docs/system_requirements.md
+++ b/docs/system_requirements.md
@@ -10,14 +10,6 @@ Users concerned about optimal performance should consider something faster.
 
 # Known Issues
 
-## Any device with an ARMv6 or earlier processor
-
-Not supported by the .NET runtime.  This may change in future versions.
-
-## Raspberry Pi Zero (any variant)
-
-At the moment all Pi Zeros are ARMv6.
-
 ## Devices using a copy-on-write filesystem such as BTRFS or ZFS
 
 slskd uses SQLite to store transactional data associated with things like transfers and searches, and these reads and writes experience too much I/O latency for the application to work properly with these filesystems.


### PR DESCRIPTION
Closes #419 