### PR TITLE
Fix 404 when retrieving directory contents

### DIFF
--- a/src/slskd/Users/API/Controllers/UsersController.cs
+++ b/src/slskd/Users/API/Controllers/UsersController.cs
@@ -144,25 +144,30 @@ namespace slskd.Users.API
         }
 
         /// <summary>
-        ///     Retrieves the files from the specified <paramref name="directory"/> from the specified <paramref name="username"/>.
+        ///     Retrieves the files from the specified directory from the specified <paramref name="username"/>.
         /// </summary>
         /// <param name="username">The username of the user.</param>
-        /// <param name="directory">The desired directory.</param>
+        /// <param name="request">The directory contents request.</param>
         /// <returns></returns>
         [HttpPost("{username}/directory")]
         [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(Directory), 200)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> Directory([FromRoute, Required] string username, [FromBody, Required] string directory)
+        public async Task<IActionResult> Directory([FromRoute, Required] string username, [FromBody, Required] DirectoryContentsRequest request)
         {
             if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
 
+            if (request == null || string.IsNullOrEmpty(request.Directory))
+            {
+                return BadRequest();
+            }
+
             try
             {
-                var result = await Client.GetDirectoryContentsAsync(username, directory);
+                var result = await Client.GetDirectoryContentsAsync(username, request.Directory);
                 return Ok(result);
             }
             catch (UserOfflineException ex)

--- a/src/slskd/Users/API/Controllers/UsersController.cs
+++ b/src/slskd/Users/API/Controllers/UsersController.cs
@@ -146,14 +146,14 @@ namespace slskd.Users.API
         /// <summary>
         ///     Retrieves the files from the specified <paramref name="directory"/> from the specified <paramref name="username"/>.
         /// </summary>
-        /// <param name="directory">The desired directory.</param>
         /// <param name="username">The username of the user.</param>
+        /// <param name="directory">The desired directory.</param>
         /// <returns></returns>
-        [HttpGet("{username}/directory/{directory}")]
+        [HttpPost("{username}/directory")]
         [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(Directory), 200)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> Directory([FromRoute, Required] string username, [FromRoute, Required] string directory)
+        public async Task<IActionResult> Directory([FromRoute, Required] string username, [FromBody, Required] string directory)
         {
             if (Program.IsRelayAgent)
             {

--- a/src/slskd/Users/API/DTO/DirectoryContentsRequest.cs
+++ b/src/slskd/Users/API/DTO/DirectoryContentsRequest.cs
@@ -1,0 +1,24 @@
+﻿// <copyright file="DirectoryContentsRequest.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd.Users.API
+{
+    public class DirectoryContentsRequest
+    {
+        public string Directory { get; set; }
+    }
+}

--- a/src/web/src/components/Search/Response.js
+++ b/src/web/src/components/Search/Response.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import * as transfers from '../../lib/transfers';
+import { toast } from 'react-toastify';
 
 import { formatBytes, getDirectoryName } from '../../lib/util';
 
@@ -30,6 +31,7 @@ class Response extends Component {
     tree: buildTree(this.props.response), 
     downloadRequest: undefined, 
     downloadError: '',
+    fetchingDirectoryContents: false,
     isFolded: this.props.isInitiallyFolded,
   };
 
@@ -61,15 +63,24 @@ class Response extends Component {
   };
 
   getFullDirectory = async (username, directory) => {
-    const { name, files } = await getDirectoryContents({ username, directory });
-    files.forEach((file, index) => {
-      const newFilename = `${directory}\\${file.filename}`;
-      files[index] = { ...files[index], filename: newFilename };
-    });
+    this.setState({ fetchingDirectoryContents: true });
 
-    const newTree = this.state.tree;
-    newTree[name] = files;
-    this.setState({ tree: { ...newTree } });
+    try {
+      const { name, files } = await getDirectoryContents({ username, directory });
+      files.forEach((file, index) => {
+        const newFilename = `${directory}\\${file.filename}`;
+        files[index] = { ...files[index], filename: newFilename };
+      });
+  
+      const newTree = this.state.tree;
+      newTree[name] = files;
+      this.setState({ tree: { ...newTree } });
+    } catch (error) {
+      console.error(error);
+      toast.error(error?.response?.data ?? error?.message ?? error);
+    } finally {
+      this.setState({ fetchingDirectoryContents: false });
+    }
   };
 
   toggleFolded = () => {
@@ -80,7 +91,7 @@ class Response extends Component {
     let {response} = this.props;
     let free = response.hasFreeUploadSlot;
 
-    let { tree, downloadRequest, downloadError, isFolded } = this.state;
+    let { tree, downloadRequest, downloadError, isFolded, fetchingDirectoryContents } = this.state;
 
     let selectedFiles = Object.keys(tree)
       .reduce((list, dict) => list.concat(tree[dict]), [])
@@ -121,9 +132,12 @@ class Response extends Component {
               disabled={downloadRequest === 'inProgress'}
               onSelectionChange={this.onFileSelectionChange}
               footer={<button
+                disabled={fetchingDirectoryContents}
                 onClick={() => this.getFullDirectory(response.username, dir)} 
                 style={{ cursor: 'pointer', width: '100%', backgroundColor: 'transparent', border: 'none' }}>
-                <Icon name='folder'/>Get Full Directory Contents
+                <Icon
+                  name={fetchingDirectoryContents ? 'circle notch' : 'folder'}
+                  loading={fetchingDirectoryContents}/>Get Full Directory Contents
               </button>}
             />
           )}

--- a/src/web/src/lib/users.js
+++ b/src/web/src/lib/users.js
@@ -21,5 +21,5 @@ export const getBrowseStatus = ({ username }) => {
 };
 
 export const getDirectoryContents = async ({ username, directory }) => {
-  return (await api.get(`/users/${encodeURIComponent(username)}/directory/${encodeURIComponent(directory)}`)).data;
+  return (await api.post(`/users/${encodeURIComponent(username)}/directory`, { directory })).data;
 };


### PR DESCRIPTION
This tweaks the existing API logic to pass the directory name in a POST body instead of a GET route, which fixes a bunch of encoding issues that can't be overcome with ASP.NET (like forward slashes in a route, even if they are URL encoded)

Closes #792