### PR TITLE
Add the ability to configure Relay Agents to download files downloaded by the controller

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -17,10 +17,11 @@
 #   # controller config is required when running in 'agent' mode
 #   # this specifies the relay controller that will be controlling this agent
 #   controller:
-#     address:
+#     address: https://some.site.com:5000
 #     ignore_certificate_errors: false
 #     api_key: <a 16-255 character string corresponding to one of the controller's API keys>
 #     secret: <a 16-255 character shared secret matching the controller's config for this agent>
+#     downloads: false
 #   # agent config is optional when running in 'controller' mode
 #   # this specifies all of the agents capable of connecting
 #   agents:

--- a/docs/config.md
+++ b/docs/config.md
@@ -226,14 +226,17 @@ Agents need to specify the HTTP or HTTPS address of their controller, the API ke
 
 If using HTTPS; most users won't have a valid certificate (the self-signed certificates that slskd generates at startup are not 'valid' because they are self-signed), and in those cases the `ignore_certificate_errors` option should be set to `true`.
 
-| Command-Line                             | Environment Variable                         | Description                               |
-| ---------------------------------------- | -------------------------------------------- | ------------------------------------------|
-| `-r\|--relay`                            | `SLSKD_RELAY`                                | Enable the Relay feature                  |
-| `-m\|--relay-mode`                       | `SLSKD_RELAY_MODE`                           | The Relay mode (Controller, Agent, Debug) |
-| `--controller-address`                   | `SLSKD_CONTROLLER_ADDRESS`                   | The address of the controller             |
-| `--controller-ignore-certificate-errors` | `SLSKD_CONTROLLER_IGNORE_CERTIFICATE_ERRORS` | Ignore certificate errors                 |
-| `--controller-api-key`                   | `SLSKD_CONTROLLER_API_KEY`                   | An API key for the controller             |
-| `--controller-secret`                    | `SLSKD_CONTROLLER_SECRET`                    | The shared secret for this agent          |
+Agents can optionally receive completed downloads from the controller by enabling the `downloads` option.  With this option enabled, agents will automatically download new files from the controller and save them to the configured local downloads directory.
+
+| Command-Line                             | Environment Variable                         | Description                                     |
+| ---------------------------------------- | -------------------------------------------- | ------------------------------------------------|
+| `-r\|--relay`                            | `SLSKD_RELAY`                                | Enable the Relay feature                        |
+| `-m\|--relay-mode`                       | `SLSKD_RELAY_MODE`                           | The Relay mode (Controller, Agent, Debug)       |
+| `--controller-address`                   | `SLSKD_CONTROLLER_ADDRESS`                   | The address of the controller                   |
+| `--controller-ignore-certificate-errors` | `SLSKD_CONTROLLER_IGNORE_CERTIFICATE_ERRORS` | Ignore certificate errors                       |
+| `--controller-api-key`                   | `SLSKD_CONTROLLER_API_KEY`                   | An API key for the controller                   |
+| `--controller-secret`                    | `SLSKD_CONTROLLER_SECRET`                    | The shared secret for this agent                |
+| `--controller-downloads`                 | `SLSKD_CONTROLLER_DOWNLOADS`                 | Receive completed downloads from the controller |
 
 ```yaml
 instance_name: some_instance
@@ -245,6 +248,7 @@ relay:
     ignore_certificate_errors: true
     api_key: <a valid API key for the controller instance>
     secret: <a secret value that matches the controller for this instance>
+    downloads: false
 ```
 
 # Limits and User Groups

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -500,6 +500,14 @@ namespace slskd
                 [NotNullOrWhiteSpace]
                 [Secret]
                 public string Secret { get; init; }
+
+                /// <summary>
+                ///     Gets a value indicating whether to receive completed downloads from the controller.
+                /// </summary>
+                [Argument(default, "controller-downloads")]
+                [EnvironmentVariable("CONTROLLER_DOWNLOADS")]
+                [Description("receive completed downloads from the controller")]
+                public bool Downloads { get; init; } = false;
             }
 
             /// <summary>

--- a/src/slskd/Relay/API/Hubs/RelayHub.cs
+++ b/src/slskd/Relay/API/Hubs/RelayHub.cs
@@ -54,6 +54,14 @@ namespace slskd.Relay
         /// <param name="id">The unique identifier for the request.</param>
         /// <returns>The operation context.</returns>
         Task RequestFileUpload(string filename, long startOffset, Guid id);
+
+        /// <summary>
+        ///     Notifies the agent that the download of the specified <paramref name="filename"/> is complete and that the file is ready for downloading.
+        /// </summary>
+        /// <param name="filename">The name of the newly downloaded file.</param>
+        /// <param name="id">The unique identifier for the request.</param>
+        /// <returns>The operation context.</returns>
+        Task NotifyFileDownloadCompleted(string filename, Guid id);
     }
 
     /// <summary>

--- a/src/slskd/Relay/RelayClient.cs
+++ b/src/slskd/Relay/RelayClient.cs
@@ -400,6 +400,11 @@ namespace slskd.Relay
 
         private Task HandleNotifyFileDownloadCompleted(string filename, Guid token)
         {
+            if (!OptionsMonitor.CurrentValue.Relay.Controller.Downloads)
+            {
+                return Task.CompletedTask;
+            }
+
             Log.Information("Relay controller sent a download notification for {Filename} ({Token})", filename, token);
 
             _ = Task.Run(async () =>

--- a/src/slskd/Relay/RelayClient.cs
+++ b/src/slskd/Relay/RelayClient.cs
@@ -428,6 +428,8 @@ namespace slskd.Relay
                     response.EnsureSuccessStatusCode();
 
                     using var remoteStream = await response.Content.ReadAsStreamAsync();
+
+                    Directory.CreateDirectory(Path.GetDirectoryName(destinationFile));
                     using var localStream = new FileStream(destinationFile, FileMode.Create);
                     await remoteStream.CopyToAsync(localStream);
                 },

--- a/src/slskd/Relay/RelayClient.cs
+++ b/src/slskd/Relay/RelayClient.cs
@@ -244,15 +244,17 @@ namespace slskd.Relay
                 var stream = new FileStream(temp, FileMode.Open, FileAccess.Read);
 
                 using var request = new HttpRequestMessage(HttpMethod.Post, $"api/v0/relay/shares/{token}");
+
+                request.Headers.Add("X-API-Key", OptionsMonitor.CurrentValue.Relay.Controller.ApiKey);
+                request.Headers.Add("X-Relay-Agent", OptionsMonitor.CurrentValue.InstanceName);
+                request.Headers.Add("X-Relay-Credential", ComputeCredential(token));
+
                 using var content = new MultipartFormDataContent
                 {
-                    { new StringContent(OptionsMonitor.CurrentValue.InstanceName), "name" },
-                    { new StringContent(ComputeCredential(token)), "credential" },
                     { new StringContent(Shares.LocalHost.Shares.ToJson()), "shares" },
                     { new StreamContent(stream), "database", "shares" },
                 };
 
-                request.Headers.Add("X-API-Key", OptionsMonitor.CurrentValue.Relay.Controller.ApiKey);
                 request.Content = content;
 
                 var size = ((double)stream.Length).SizeSuffix();
@@ -312,6 +314,11 @@ namespace slskd.Relay
                     stream.Seek(startOffset, SeekOrigin.Begin);
 
                     using var request = new HttpRequestMessage(HttpMethod.Post, $"api/v0/relay/files/{token}");
+
+                    request.Headers.Add("X-API-Key", OptionsMonitor.CurrentValue.Relay.Controller.ApiKey);
+                    request.Headers.Add("X-Relay-Agent", OptionsMonitor.CurrentValue.InstanceName);
+                    request.Headers.Add("X-Relay-Credential", ComputeCredential(token));
+
                     using var content = new MultipartFormDataContent
                     {
                         { new StringContent(OptionsMonitor.CurrentValue.InstanceName), "name" },
@@ -319,7 +326,6 @@ namespace slskd.Relay
                         { new StreamContent(stream), "file", filename },
                     };
 
-                    request.Headers.Add("X-API-Key", OptionsMonitor.CurrentValue.Relay.Controller.ApiKey);
                     request.Content = content;
 
                     Log.Information("Beginning upload of file {Filename} with ID {Id}", filename, token);

--- a/src/slskd/Relay/RelayClient.cs
+++ b/src/slskd/Relay/RelayClient.cs
@@ -415,7 +415,7 @@ namespace slskd.Relay
                 {
                     // if we're debugging, we're referencing the same file for both the controller and agent
                     // which will lead to an access violation. prefix the destination file to avoid this.
-                    destinationFile = Path.Combine(OptionsMonitor.CurrentValue.Directories.Downloads, $"_{filename}");
+                    destinationFile = Path.Combine(OptionsMonitor.CurrentValue.Directories.Downloads, $"{filename}.relayed");
                 }
 
                 await Retry.Do(task: async () =>

--- a/src/slskd/Transfers/Downloads/DownloadService.cs
+++ b/src/slskd/Transfers/Downloads/DownloadService.cs
@@ -226,13 +226,18 @@ namespace slskd.Transfers.Downloads
                                 // this would be the ideal place to hook in a generic post-download task processor for now, we'll
                                 // just carry out hard coded behavior. these carry the risk of failing the transfer, and i could
                                 // argue both ways for that being the correct behavior. revisit this later.
-                                MoveFile(file.Filename, OptionsMonitor.CurrentValue.Directories.Incomplete, OptionsMonitor.CurrentValue.Directories.Downloads);
+                                var finalFilename = MoveFile(file.Filename, OptionsMonitor.CurrentValue.Directories.Incomplete, OptionsMonitor.CurrentValue.Directories.Downloads);
 
-                                Relay.BroadcastFileDownloadCompletedNotification(file.Filename);
+                                Log.Debug("Moved file to {Destination}", finalFilename);
+
+                                if (OptionsMonitor.CurrentValue.Relay.Enabled)
+                                {
+                                    _ = Relay.BroadcastFileDownloadCompletedNotificationAsync(finalFilename);
+                                }
 
                                 if (OptionsMonitor.CurrentValue.Integration.Ftp.Enabled)
                                 {
-                                    _ = FTP.UploadAsync(file.Filename.ToLocalFilename(OptionsMonitor.CurrentValue.Directories.Downloads));
+                                    _ = FTP.UploadAsync(finalFilename);
                                 }
                             }
                             catch (OperationCanceledException ex)

--- a/src/slskd/Transfers/Downloads/DownloadService.cs
+++ b/src/slskd/Transfers/Downloads/DownloadService.cs
@@ -490,7 +490,7 @@ namespace slskd.Transfers.Downloads
             return new FileStream(localFilename, FileMode.Create);
         }
 
-        private static void MoveFile(string filename, string sourceDirectory, string destinationDirectory)
+        private static string MoveFile(string filename, string sourceDirectory, string destinationDirectory)
         {
             var sourceFilename = filename.ToLocalFilename(sourceDirectory);
             var destinationFilename = filename.ToLocalFilename(destinationDirectory);
@@ -520,6 +520,8 @@ namespace slskd.Transfers.Downloads
             {
                 Directory.Delete(Path.GetDirectoryName(sourceFilename));
             }
+
+            return destinationFilename;
         }
     }
 }

--- a/src/slskd/Transfers/Downloads/DownloadService.cs
+++ b/src/slskd/Transfers/Downloads/DownloadService.cs
@@ -504,12 +504,12 @@ namespace slskd.Transfers.Downloads
 
             if (File.Exists(destinationFilename))
             {
-                string extensionlessFilename = Path.GetFileNameWithoutExtension(filename);
+                string extensionlessFilename = Path.Combine(Path.GetDirectoryName(filename), Path.GetFileNameWithoutExtension(filename));
                 string extension = Path.GetExtension(filename);
 
                 while (File.Exists(destinationFilename))
                 {
-                    string filenameUTC = $"{extensionlessFilename}_{DateTime.UtcNow.Ticks}.{extension}";
+                    string filenameUTC = $"{extensionlessFilename}_{DateTime.UtcNow.Ticks}{extension}";
                     destinationFilename = filenameUTC.ToLocalFilename(destinationDirectory);
                 }
             }


### PR DESCRIPTION
The controller notifies each connected agent when each download is completed.  Agents will, if the `downloads` option is set, download those files from the controller over HTTP/S and store them in their local directory.

Closes #787 