### PR TITLE
Bump Soulseek.NET to 6.1.1

### DIFF
--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -66,7 +66,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="7.1.1" />
     <PackageReference Include="Serilog.Sinks.Http" Version="8.0.0" />
-    <PackageReference Include="Soulseek" Version="6.1.0" />
+    <PackageReference Include="Soulseek" Version="6.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This will stop the `Warning` logs related to text encoding.