### PR TITLE
Increase security of config-related API endpoints

### DIFF
--- a/src/slskd/Core/API/Controllers/OptionsController.cs
+++ b/src/slskd/Core/API/Controllers/OptionsController.cs
@@ -86,6 +86,11 @@ namespace slskd.Core.API
         [ProducesResponseType(typeof(string), 200)]
         public IActionResult Debug()
         {
+            if (!OptionsAtStartup.Debug || !OptionsSnapshot.Value.RemoteConfiguration)
+            {
+                return Forbid();
+            }
+
             // retrieve the IConfigurationRoot instance with reflection to avoid
             // exposing it as a public member of Program.
             var property = typeof(Program).GetProperty("Configuration", BindingFlags.NonPublic | BindingFlags.Static);
@@ -99,6 +104,11 @@ namespace slskd.Core.API
         [Route("yaml/location")]
         public IActionResult GetYamlFileLocation()
         {
+            if (!OptionsSnapshot.Value.RemoteConfiguration)
+            {
+                return Forbid();
+            }
+
             return Ok(Program.ConfigurationFile);
         }
 
@@ -148,6 +158,11 @@ namespace slskd.Core.API
         [Route("yaml/validate")]
         public IActionResult ValidateYamlFile([FromBody] string yaml)
         {
+            if (!OptionsSnapshot.Value.RemoteConfiguration)
+            {
+                return Forbid();
+            }
+
             if (!TryValidateYaml(yaml, out var error))
             {
                 return Ok(error);

--- a/src/web/src/components/System/Options/index.js
+++ b/src/web/src/components/System/Options/index.js
@@ -26,7 +26,7 @@ const Index = ({ options }) => {
   const { remoteConfiguration, debug } = options;
 
   const DebugButton = ({ ...props }) => {
-    if (!debug) return <></>;
+    if (!remoteConfiguration || !debug) return <></>;
     
     return <ShrinkableButton
       icon='bug'


### PR DESCRIPTION
Currently the debug view of config could be retrieved if remote config is disabled and the application isn't run in debug mode.  This PR forbids this endpoint if either of those is true.  Additionally, the UI button is not shown if remote config is disabled.

Note that this endpoint still requires a valid JWT, so the endpoint isn't completely unauthorized.

Additionally this change forbids retrieval of the yaml location and validation of yaml if remote config is disabled.  Neither of these endpoints changes or exposes config, but there's no reason they need to be functional if remote config isn't enabled.