### PR TITLE
Fix a bunch of linter warnings, include share upload in agent connection retry loop

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -753,6 +753,7 @@ namespace slskd
 
         private void Client_UserStatusChanged(object sender, UserStatus args)
         {
+            // todo: react to watched user status changes
         }
 
         private Task<int?> PlaceInQueueResolver(string username, IPEndPoint endpoint, string filename)

--- a/src/slskd/Common/CommonExtensions.cs
+++ b/src/slskd/Common/CommonExtensions.cs
@@ -302,7 +302,7 @@ namespace slskd
         }
 
         /// <summary>
-        ///     <see cref="Path.GetDirectoryName"/>, but for paths normalized to use backslashes.
+        ///     <see cref="Path.GetDirectoryName(string)"/>, but for paths normalized to use backslashes.
         /// </summary>
         /// <param name="path"></param>
         /// <returns></returns>
@@ -312,7 +312,7 @@ namespace slskd
         }
 
         /// <summary>
-        ///     <see cref="Path.GetFileName"/>, but for paths normalized to use backslashes.
+        ///     <see cref="Path.GetFileName(string)"/>, but for paths normalized to use backslashes.
         /// </summary>
         /// <param name="path"></param>
         /// <returns></returns>

--- a/src/slskd/Core/API/DTO/TokenResponse.cs
+++ b/src/slskd/Core/API/DTO/TokenResponse.cs
@@ -49,7 +49,7 @@ namespace slskd.Core.API
         /// <summary>
         ///     Gets the value of the Not Before claim from the Access Token.
         /// </summary>
-        public long NotBefore => long.Parse(JwtSecurityToken.Claims.SingleOrDefault(c => c.Type == "nbf").Value);
+        public long NotBefore => long.Parse(JwtSecurityToken.Claims.SingleOrDefault(c => c.Type == "nbf")?.Value ?? long.MaxValue.ToString());
 
         /// <summary>
         ///     Gets the Access Token string.

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -687,7 +687,7 @@ namespace slskd
                                         }
                                         catch
                                         {
-                                            // the token either isn't a valid API key. use the provided value and let the 
+                                            // the token either isn't a valid API key. use the provided value and let the
                                             // rest of the auth middleware figure out whether it is valid
                                             context.Token = token;
                                         }

--- a/src/slskd/Relay/DummyRelayClient.cs
+++ b/src/slskd/Relay/DummyRelayClient.cs
@@ -24,12 +24,26 @@ namespace slskd.Relay
     {
         public IStateMonitor<RelayClientState> StateMonitor => new ManagedState<RelayClientState>();
 
-        public void Dispose() { }
+        private bool Disposed { get; set; }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            System.GC.SuppressFinalize(this);
+        }
 
         public Task StartAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         public Task StopAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         public Task SynchronizeAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!Disposed)
+            {
+                Disposed = true;
+            }
+        }
     }
 }

--- a/src/slskd/Shares/API/Controllers/SharesController.cs
+++ b/src/slskd/Shares/API/Controllers/SharesController.cs
@@ -74,7 +74,7 @@ namespace slskd.Shares.API
         [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(Share), 200)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> Get(string id)
+        public IActionResult Get(string id)
         {
             var share = Shares.Hosts.SelectMany(host => host.Shares).FirstOrDefault(share => share.Id == id);
 

--- a/src/slskd/Shares/SqliteShareRepository.cs
+++ b/src/slskd/Shares/SqliteShareRepository.cs
@@ -672,7 +672,7 @@ namespace slskd.Shares
                 var msg = "The internal share database has been corrupted or lost, and the application cannot continue to run. Please report this in a GitHub issue here: https://github.com/slskd/slskd/issues";
                 Log.Fatal(msg);
                 Environment.Exit(1);
-                throw new ApplicationException(msg);
+                throw new DataMisalignedException(msg);
             }
         }
     }

--- a/src/slskd/Transfers/API/Controllers/TransfersController.cs
+++ b/src/slskd/Transfers/API/Controllers/TransfersController.cs
@@ -41,6 +41,7 @@ namespace slskd.Transfers.API
         /// <summary>
         ///     Initializes a new instance of the <see cref="TransfersController"/> class.
         /// </summary>
+        /// <param name="optionsSnapshot"></param>
         /// <param name="transferService"></param>
         public TransfersController(
             ITransferService transferService,

--- a/src/slskd/Users/API/Controllers/UsersController.cs
+++ b/src/slskd/Users/API/Controllers/UsersController.cs
@@ -25,7 +25,6 @@ namespace slskd.Users.API
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
-    using slskd.Relay;
     using Soulseek;
 
     /// <summary>
@@ -44,6 +43,7 @@ namespace slskd.Users.API
         /// <param name="soulseekClient"></param>
         /// <param name="browseTracker"></param>
         /// <param name="userService"></param>
+        /// <param name="optionsSnapshot"></param>
         public UsersController(ISoulseekClient soulseekClient, IBrowseTracker browseTracker, IUserService userService, IOptionsSnapshot<Options> optionsSnapshot)
         {
             Client = soulseekClient;

--- a/tests/slskd.Tests.Unit/Transfers/Uploads/UploadQueueTests.cs
+++ b/tests/slskd.Tests.Unit/Transfers/Uploads/UploadQueueTests.cs
@@ -625,7 +625,7 @@
 
                 queue.SetProperty("Uploads", uploads);
 
-                var result = queue.InvokeMethod<Upload>("Process");
+                _ = queue.InvokeMethod<Upload>("Process");
 
                 var groups = queue.GetProperty<Dictionary<string, UploadGroup>>("Groups");
 


### PR DESCRIPTION
I saw a remote agent log in and try to upload shares and it was rejected with an unauthorized message.  This was a race condition, but one that spanned a network.  I added a 500ms delay prior to uploading shares that should help with this.