### PR TITLE
Simplify docker caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,27 +112,19 @@ jobs:
           echo "BUILD_DATE=$(date --iso-8601=s)" >> $GITHUB_ENV
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USERNAME }}
@@ -140,7 +132,7 @@ jobs:
 
       - name: Build and push Canary
         if: "!startsWith(github.ref, 'refs/tags/')"
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           platforms: linux/amd64
           push: true
@@ -154,12 +146,12 @@ jobs:
             slskd/slskd:canary
             ghcr.io/slskd/slskd:${{ env.VERSION }}
             ghcr.io/slskd/slskd:canary
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build and push Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
@@ -174,17 +166,8 @@ jobs:
             ghcr.io/slskd/slskd:${{ env.TAG }}
             ghcr.io/slskd/slskd:canary
             ghcr.io/slskd/slskd:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        if: 
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   release:
     name: Create Release


### PR DESCRIPTION
A number of `docker` GitHub actions have been updated, and the `build-push` action now natively supports GitHub as a layer cache.  This PR updates the actions and deprecates the manual caching in favor of native.