### PR TITLE
Fix bug parsing semantic version

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -135,7 +135,7 @@ namespace slskd
         /// <summary>
         ///     Gets the semantic application version.
         /// </summary>
-        public static string SemanticVersion { get; } = InformationalVersion.Split('+').First();
+        public static string SemanticVersion { get; } = InformationalVersion.Split('-').First();
 
         /// <summary>
         ///     Gets the full application version, including both assembly and informational versions.


### PR DESCRIPTION
A while ago I tried to use `+` to delimit the semantic version and the SHA it is based on to better conform to semver.  This worked with some things and broke others, so I reverted it.  I neglected to update the logic that parses the semantic version, leaving the `+` in place.  This would periodically break the version check because of .NET's versioning rules.

This PR swaps `+` for `-` and fixes the version check, hopefully for good.

Closes #705 
Related to #763 