### PR TITLE
Always show file size when downloads are cancelled or pending

### DIFF
--- a/src/web/src/components/Transfers/TransferList.js
+++ b/src/web/src/components/Transfers/TransferList.js
@@ -143,9 +143,7 @@ class TransferList extends Component {
                           </Button>}
                       </Table.Cell>
                       <Table.Cell className='transferlist-size'>
-                        {f.bytesTransferred > 0
-                          ? formatBytesTransferred({ transferred: f.bytesTransferred, size: f.size })
-                          : ''}
+                        {formatBytesTransferred({ transferred: f.bytesTransferred, size: f.size })}
                       </Table.Cell>
                     </Table.Row>
                   )}


### PR DESCRIPTION
Instead of only showing the file size when some bytes have been downloaded always show it. That way a user knows the size of pending downloads too.

Fixes #600