### PR TITLE
Fix browser reload to stay on the same page

### DIFF
--- a/src/web/src/components/App.js
+++ b/src/web/src/components/App.js
@@ -356,7 +356,10 @@ class App extends Component {
                         <System {...props} state={applicationState} options={applicationOptions} />
                       )
                     }/>
-                    <Redirect from='*' to={`${urlBase}/searches`}/>
+                    <Route render={(props) => 
+                      /\/(searches\/?|browse|users|chat|rooms|uploads|downloads|system\/)/
+                        .test(props.location.pathname) ?
+                        <></> : <Redirect to={`${urlBase}/searches`}/>} />
                   </>}
               </Switch>
             </AppContext.Provider>

--- a/src/web/src/components/Search/Searches.js
+++ b/src/web/src/components/Search/Searches.js
@@ -42,8 +42,8 @@ const Searches = ({ server }) => {
   const onConnectionError = (error) => { setConnecting(false); setError(error); };
 
   const onUpdate = (update) => {
-    onConnected();
     setSearches(update);
+    onConnected();
   };
 
   useEffect(() => {


### PR DESCRIPTION
There were 2 issues here:

1. The Redirect in App.js seems to be being hit on reload always and would always force a redirect. I tried googling but couldn't find a good answer why and how to workaround it, so I've just excluded our known paths from that redirect.
2. Even after this in Searches.js there's a race condition with the component being connected and starting to process the searchId, but the searches haven't been set yet, so it assumes it's invalid and resets to /searches. So I've swapped the order in onUpdate and that seems to fix it with no side effects.

Fixes #555