### PR TITLE
Move dotnet bundle location within the Docker container to /slskd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ VOLUME /app
 
 HEALTHCHECK --interval=60s --timeout=3s --start-period=5s --retries=3 CMD wget -q -O - http://localhost:${SLSKD_HTTP_PORT}/health
 
-ENV DOTNET_BUNDLE_EXTRACT_BASE_DIR=/var/tmp/.net \
+ENV DOTNET_BUNDLE_EXTRACT_BASE_DIR=/slskd/.net \
   DOTNET_gcServer=0 \
   DOTNET_gcConcurrent=1 \
   DOTNET_GCHeapHardLimit=1F400000	\


### PR DESCRIPTION
Per a Discord conversation with a user experiencing a crash when running the container with `podman kube play`, the `/var/tmp` mount negatively interacts with the .NET bundle that gets extracted to the same place, leading to a crash following a failure to access binaries related to SQLite3.

This PR moves the extraction location to `/slskd`, which will reside next to the rest of the application.  This may cause issues for other .NET apps that might run inside of the same container, but I'm comfortable saying that this use case is 1) weird, and 2) not supported.