### PR TITLE
Use `instance_name` from Relay Agent config instead of map key

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -26,6 +26,7 @@
 #   # this specifies all of the agents capable of connecting
 #   agents:
 #     my_agent:
+#       instance_name: my_agent # make sure the top-level instance_name of the agent matches!
 #       secret: <a 16-255 character string unique to this agent>
 #       cidr: 0.0.0.0/0,::/0
 # directories:

--- a/docs/config.md
+++ b/docs/config.md
@@ -198,7 +198,7 @@ Controllers must have at least one API key configured.  For increased security i
 
 The relay mode for the controller must be set to `controller`, and the relay must be enabled.
 
-For each agent, the agent's name (corresponding to the configured instance name of the agent) must be specified in the agent map, and a different secret value between 16-255 characters should be specified for each agent.
+For each agent, the agent must be specified in the `agents` map, including an `instance_name` that corresponds to the top-level `instance_name` configured for the agent, and a different secret value between 16-255 characters should be specified for each agent.
 
 It is strongly suggested that controllers be configured to force HTTPS.  This makes the traffic between the controller and agents completely private, and prevents API keys and agent secrets from being exposed.
 
@@ -208,8 +208,10 @@ relay:
   mode: controller
   agents:
     some_instance:
+      instance_name: some_instance
       secret: <a secret value between 16 and 255 characters>
     a_different_instance:
+      instance_name: different_instance
       secret: <a different secret value between 16 and 255 characters>
 ```
 
@@ -220,7 +222,7 @@ relay:
 
 ## Agents
 
-The relay mode for agents must be set to `agent`, the relay must be enabled, and each agent must have a unique instance name that corresponds to an agent configured in the controller.
+The relay mode for agents must be set to `agent`, the relay must be enabled, and each agent must have a unique instance name that corresponds to the `instance_name` of an agent configured in the controller.
 
 Agents need to specify the HTTP or HTTPS address of their controller, the API key for the controller, and the secret that corresponds to the value configured in the controller for the agent.
 

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -72,7 +72,7 @@ For this example we'll use `9tWy5c3NrmekKVWLQXBztz0hY7rNGlj1tGMfvHKmU1q` for the
 
 ### Controller
 
-Next, we'll configure the controller.  We'll enable the Relay, set this instance's mode to `controller`, and configure a single agent named `example`.  We'll accept connections from within our home network, which uses IP addresses in the 192.168.1.x range.
+Next, we'll configure the controller.  We'll enable the Relay, set this instance's mode to `controller`, and configure a single agent named `example_agent`.  We'll accept connections from within our home network, which uses IP addresses in the 192.168.1.x range.
 
 We'll also need to create an API key, which we'll allow to be used from anywhere.  We'll give the key the role `readwrite`, which is required for agents.
 
@@ -152,14 +152,14 @@ The controller should show logs similar to the following:
 
 ```
 [19:09:30 INF] Agent connection GyBMnXHfdomNzR2FEzT68Q from 192.168.1.250 established. Sending authentication challenge GU7pSFTG60skUtqM24FfB2WiUnWsC1LxYagBsz7edcp...
-[19:09:30 INF] Agent connection GyBMnXHfdomNzR2FEzT68Q from 192.168.1.250 authenticated as agent example
-[19:09:31 INF] Agent example (connection GyBMnXHfdomNzR2FEzT68Q) from 192.168.1.250 requested share upload token f81eb299-1a86-4f72-a77c-922d3f73106f
-[19:09:31 INF] Handling share upload (f81eb299-1a86-4f72-a77c-922d3f73106f) from a caller claiming to be agent example
-[19:09:31 INF] Agent example authenticated for token f81eb299-1a86-4f72-a77c-922d3f73106f. Beginning download of shares to /tmp/slskd/share_example_h0ycner1.svm.db
-[19:09:31 INF] Download of shares from example (f81eb299-1a86-4f72-a77c-922d3f73106f) complete (48.0 KB in 2ms)
-[19:09:31 INF] Loading shares from agent example
+[19:09:30 INF] Agent connection GyBMnXHfdomNzR2FEzT68Q from 192.168.1.250 authenticated as agent example_agent
+[19:09:31 INF] Agent example_agent (connection GyBMnXHfdomNzR2FEzT68Q) from 192.168.1.250 requested share upload token f81eb299-1a86-4f72-a77c-922d3f73106f
+[19:09:31 INF] Handling share upload (f81eb299-1a86-4f72-a77c-922d3f73106f) from a caller claiming to be agent example_agent
+[19:09:31 INF] Agent example_agent authenticated for token f81eb299-1a86-4f72-a77c-922d3f73106f. Beginning download of shares to /tmp/slskd/share_example_h0ycner1.svm.db
+[19:09:31 INF] Download of shares from example_agent (f81eb299-1a86-4f72-a77c-922d3f73106f) complete (48.0 KB in 2ms)
+[19:09:31 INF] Loading shares from agent example_agent
 [19:09:31 INF] Warming browse response cache...
-[19:09:31 INF] Shares from agent example ready.
+[19:09:31 INF] Shares from agent example_agent ready.
 [19:09:31 INF] Browse response cached successfully in 25ms
 ```
 
@@ -170,12 +170,12 @@ We're now ready to relay files!
 From another machine running a different Soulseek client, download the `foo.txt` file we shared as a test.  The controller should show logs similar to the following:
 
 ```
-[19:19:34 INF] Resolved Music\test\foo.txt to physical file /home/kubuntu/Music/test/foo.txt on host 'example'
-[19:19:35 INF] Requested file Music\test\foo.txt from Agent example with ID 09e76dde-c4fa-4c50-8c25-d92a26b52102. Waiting for incoming connection.
-[19:19:35 INF] Handling file upload of Music\test\foo.txt (09e76dde-c4fa-4c50-8c25-d92a26b52102) from a caller claiming to be agent example
-[19:19:35 INF] Agent example authenticated for token 09e76dde-c4fa-4c50-8c25-d92a26b52102. Forwarding file stream for Music\test\foo.txt
-[19:19:35 INF] Agent example provided file stream for file Music\test\foo.txt with ID 09e76dde-c4fa-4c50-8c25-d92a26b52102
-[19:19:35 INF] File upload of Music\test\foo.txt (09e76dde-c4fa-4c50-8c25-d92a26b52102) from agent example complete
+[19:19:34 INF] Resolved Music\test\foo.txt to physical file /home/kubuntu/Music/test/foo.txt on host 'example_agent'
+[19:19:35 INF] Requested file Music\test\foo.txt from Agent example_agent with ID 09e76dde-c4fa-4c50-8c25-d92a26b52102. Waiting for incoming connection.
+[19:19:35 INF] Handling file upload of Music\test\foo.txt (09e76dde-c4fa-4c50-8c25-d92a26b52102) from a caller claiming to be agent example_agent
+[19:19:35 INF] Agent example_agent authenticated for token 09e76dde-c4fa-4c50-8c25-d92a26b52102. Forwarding file stream for Music\test\foo.txt
+[19:19:35 INF] Agent example_agent provided file stream for file Music\test\foo.txt with ID 09e76dde-c4fa-4c50-8c25-d92a26b52102
+[19:19:35 INF] File upload of Music\test\foo.txt (09e76dde-c4fa-4c50-8c25-d92a26b52102) from agent example_agent complete
 ```
 
 And the agent should show:

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -85,6 +85,7 @@ relay:
   mode: controller
   agents:
     example:
+      instance_name: example_agent
       secret: BgI04SuVtsAYipxPHDpdxJsnVoPEeq4tKJeorWxr3Pj
       cidr: 192.168.1.0/24
 web:
@@ -120,7 +121,7 @@ To demonstrate how file relays work, I've created a file `foo.txt` in `~/Music/t
 The entire `slskd.yml` file is below if you'd like to copy/paste it. Be sure to update the controller's address to the IP address of the machine the controller is working on.
 
 ```yaml
-instance_name: example
+instance_name: example_agent
 relay:
   enabled: true
   mode: agent

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -438,6 +438,14 @@ namespace slskd
                 }
                 else
                 {
+                    // determine whether any InstanceName is used more than once
+                    var instanceNames = Agents.Values.Select(a => a.InstanceName);
+
+                    if (instanceNames.Count() != instanceNames.Distinct().Count())
+                    {
+                        modeResults.Add(new ValidationResult("One or more Agent instance names are duplicated.  Ensure instance names are unique."));
+                    }
+
                     foreach (var (name, agent) in Agents)
                     {
                         var res = new List<ValidationResult>();
@@ -515,6 +523,15 @@ namespace slskd
             /// </summary>
             public class RelayAgentConfigurationOptions : IValidatableObject
             {
+                /// <summary>
+                ///     Gets the agent instance name.
+                /// </summary>
+                [Description("the name for this agent")]
+                [StringLength(255, MinimumLength = 1)]
+                [NotNullOrWhiteSpace]
+                [Secret]
+                public string InstanceName { get; init; }
+
                 /// <summary>
                 ///     Gets the agent secret.
                 /// </summary>

--- a/src/slskd/Relay/API/Hubs/RelayHub.cs
+++ b/src/slskd/Relay/API/Hubs/RelayHub.cs
@@ -89,7 +89,7 @@ namespace slskd.Relay
             OptionsAtStartup = optionsAtStartup;
         }
 
-        private ILogger Log { get; } = Serilog.Log.ForContext<RelayService>();
+        private ILogger Log { get; } = Serilog.Log.ForContext<RelayHub>();
         private IRelayService Relay { get; }
         private IOptionsMonitor<Options> OptionsMonitor { get; }
         private OptionsAtStartup OptionsAtStartup { get; }


### PR DESCRIPTION
🚨 BREAKING CHANGE FOR RELAY USERS 🚨 

As reported in #891, currently agent names within the configuration map containing an underscore are converted to pascal case (e.g. `foo_bar` becomes `fooBar`).  This leads to an inability of the agent to log in to the controller because the controller is expecting the pascal-cased name.

This PR adds an additional field to the agent configuration, `instance_name`, and modifies the authentication code to find agent config by this property instead of the map key, which resolves the mismatch.

Furthermore, this property should help guide users while configuring the Relay.  I've updated the YAML example and documentation in a few places

Previously, the configuration key for the agent was used to match the instance name:

```yaml
relay:
  enabled: true
  mode: controller
  agents:
    some_instance:
      secret: <a secret value between 16 and 255 characters>
```

In this example, the intended outcome would be that the agent was configured with a top-level `instance_name` of `"some_instance"`, and that the secret configured for the `some_instance` key in the YAML would be used to authenticate.  This is broken for the reasons explained above.

Here's the new configuration:

```yaml
relay:
  enabled: true
  mode: controller
  agents:
    literally_anything:
      instance_name: some_instance
      secret: <a secret value between 16 and 255 characters>
```

With the changes in this PR, only the instance name defined in the `instance_name` property matters.  This value won't be transformed, and both the agent and controller's values will match (as long as they are configured properly).

🚨 HOW TO UN-BREAK 🚨 

Anyone using the Relay feature will need to update their controller configuration to add the `instance_name` property for each of their agents.  The application will fail to start until you do.

Closes #891