### PR TITLE
Add x86 and freebsd runtime targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,17 +50,22 @@ jobs:
     strategy:
       matrix:
         runtime:
+          - "win-x86"
           - "win-x64"
           - "win-arm"
           - "win-arm64"
+          - "linux-x86"
           - "linux-x64"
           - "linux-arm"
           - "linux-arm64"
+          - "linux-musl-x86"
           - "linux-musl-x64"
           - "linux-musl-arm"
           - "linux-musl-arm64"
           - "osx-x64"
           - "osx-arm64"
+          - "freebsd-x64"
+          - "freebsd-arm64"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -180,17 +185,22 @@ jobs:
     strategy:
       matrix:
         runtime:
+          - "win-x86"
           - "win-x64"
           - "win-arm"
           - "win-arm64"
+          - "linux-x86"
           - "linux-x64"
           - "linux-arm"
           - "linux-arm64"
+          - "linux-musl-x86"
           - "linux-musl-x64"
           - "linux-musl-arm"
           - "linux-musl-arm64"
           - "osx-x64"
           - "osx-arm64"
+          - "freebsd-x64"
+          - "freebsd-arm64"
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Closes #904 
Related to #905 

I had been trying to keep this list on the shorter side so that the list of binaries in the GitHub release wouldn't need to be expanded to find the most common platforms.  Prior to this only one of the `arm` binaries was hidden; after this is merged there will be more.