### PR TITLE
Revert "add x86 and freebsd runtime targets"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,22 +50,17 @@ jobs:
     strategy:
       matrix:
         runtime:
-          - "win-x86"
           - "win-x64"
           - "win-arm"
           - "win-arm64"
-          - "linux-x86"
           - "linux-x64"
           - "linux-arm"
           - "linux-arm64"
-          - "linux-musl-x86"
           - "linux-musl-x64"
           - "linux-musl-arm"
           - "linux-musl-arm64"
           - "osx-x64"
           - "osx-arm64"
-          - "freebsd-x64"
-          - "freebsd-arm64"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -185,22 +180,17 @@ jobs:
     strategy:
       matrix:
         runtime:
-          - "win-x86"
           - "win-x64"
           - "win-arm"
           - "win-arm64"
-          - "linux-x86"
           - "linux-x64"
           - "linux-arm"
           - "linux-arm64"
-          - "linux-musl-x86"
           - "linux-musl-x64"
           - "linux-musl-arm"
           - "linux-musl-arm64"
           - "osx-x64"
           - "osx-arm64"
-          - "freebsd-x64"
-          - "freebsd-arm64"
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Unfortunately these runtime targets aren't fully supported.  The [release build](https://github.com/slskd/slskd/actions/runs/4963214686) failed with:

```bash
There is no application host available for the specified RuntimeIdentifier 'linux-musl-x86'.
There is no application host available for the specified RuntimeIdentifier 'linux-x86'.
The specified RuntimeIdentifier 'freebsd-arm64' is not recognized.
There is no application host available for the specified RuntimeIdentifier 'freebsd-x64'.
```

The `win-x86` RID didn't raise any issues, but there's dubious value in including that (I think the last 32 bit Windows OS is XP?).