### PR TITLE
fix: unable to remove completed searches

### DIFF
--- a/src/slskd/Search/API/Controllers/SearchesController.cs
+++ b/src/slskd/Search/API/Controllers/SearchesController.cs
@@ -188,7 +188,14 @@ namespace slskd.Search.API
                 return NotFound();
             }
 
-            Searches.TryCancel(id);
+            var tokenCancellation = Searches.TryCancel(id);
+
+            if (!tokenCancellation && search.State == Soulseek.SearchStates.Requested
+                && DateTime.Now.Subtract(search.StartedAt).TotalMilliseconds > OptionsSnapshot.Value.Soulseek.Connection.Timeout.Inactivity)
+            {
+                Searches.ForceCancel(search);
+            }
+
             return Ok();
         }
 

--- a/src/slskd/Search/ISearchService.cs
+++ b/src/slskd/Search/ISearchService.cs
@@ -67,5 +67,12 @@ namespace slskd.Search
         /// <param name="id">The unique identifier for the search.</param>
         /// <returns>A value indicating whether the search was sucessfully cancelled.</returns>
         bool TryCancel(Guid id);
+
+        /// <summary>
+        ///     Forces a cancel on the specified search.
+        /// </summary>
+        /// <param name="search">The search to force cancel.</param>
+        /// <returns>The operation context.</returns>
+        Task ForceCancel(Search search);
     }
 }

--- a/src/slskd/Search/SearchService.cs
+++ b/src/slskd/Search/SearchService.cs
@@ -170,13 +170,6 @@ namespace slskd.Search
 
             List<SearchResponse> responses = new();
 
-            void UpdateAndSaveChanges(Search search)
-            {
-                using var context = ContextFactory.CreateDbContext();
-                context.Update(search);
-                context.SaveChanges();
-            }
-
             options ??= new SearchOptions();
             options = options.WithActions(
                 stateChanged: (args) =>
@@ -267,6 +260,31 @@ namespace slskd.Search
             }
 
             return false;
+        }
+
+        /// <summary>
+        ///     Forces a cancel on the specified search.
+        /// </summary>
+        /// <param name="search">The search to force cancel.</param>
+        /// <returns>The operation context.</returns>
+        public async Task ForceCancel(Search search)
+        {
+            if (search == default)
+            {
+                throw new ArgumentNullException(nameof(search));
+            }
+
+            search.EndedAt = DateTime.UtcNow;
+            search.State = SearchStates.Cancelled;
+            UpdateAndSaveChanges(search);
+            await SearchHub.BroadcastUpdateAsync(search);
+        }
+
+        private void UpdateAndSaveChanges(Search search)
+        {
+            using var context = ContextFactory.CreateDbContext();
+            context.Update(search);
+            context.SaveChanges();
         }
     }
 }

--- a/src/slskd/Search/Types/Search.cs
+++ b/src/slskd/Search/Types/Search.cs
@@ -34,7 +34,13 @@ namespace slskd.Search
         public Guid Id { get; init; }
 
         [NotMapped]
-        public bool IsComplete => State.HasFlag(SearchStates.Completed);
+        public bool IsComplete =>
+            State.HasFlag(SearchStates.Completed)
+            || State.HasFlag(SearchStates.Cancelled)
+            || State.HasFlag(SearchStates.TimedOut)
+            || State.HasFlag(SearchStates.ResponseLimitReached)
+            || State.HasFlag(SearchStates.FileLimitReached)
+            || State.HasFlag(SearchStates.Errored);
 
         public int LockedFileCount { get; set; }
         public int ResponseCount { get; set; }

--- a/src/web/src/components/Search/List/SearchActionIcon.js
+++ b/src/web/src/components/Search/List/SearchActionIcon.js
@@ -7,7 +7,12 @@ const SearchActionIcon = ({ search, loading, onRemove, onStop,...props }) => {
     return (<Icon name='spinner' loading {...props}/>);
   }
 
-  if (search.state.includes('Completed')) {
+  if (search.state.includes('Completed')
+    || search.state.includes('Cancelled')
+    || search.state.includes('TimedOut')
+    || search.state.includes('ResponseLimitReached')
+    || search.state.includes('FileLimitReached')
+    || search.state.includes('Errored')) {
     return (<Icon
       name="trash alternate"
       color='red' 


### PR DESCRIPTION
This PR aims to fix issue #898.

Changes:
A search is now considered completed if search state is either one of these:
- Completed
- Cancelled
- TimedOut
- ResponseLimitReached
- FileLimitReached
- Errored

Added a try-catch around Client.SearchAsync to disallow bad requests to be eternally at search state 'Requested'.

~~We may need to find a way to clean-off requests that are already stuck at state 'Requested'.
Maybe we could periodically put searches that are at state 'Requested' with a 'DateTime.Now' - 'StartedAt' exceeding a configured timeout value?~~

Edit: I added a 'ForceCancel' on Searches that allows to cancel searches that are at state 'Requested' with a 'DateTime.Now' - 'StartedAt' exceeding the configured Soulseek.Connection.Timeout.Inactivity option when TryCancel returns false.
Meaning that users that have stucks requests will be able to cancel them then remove them manually.