### PR TITLE
Document remote file management option, remove delete icons from UI when option is disabled

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -103,6 +103,20 @@ directories:
   downloads: ~
 ```
 
+## Remote File Management
+
+The application offers APIs for listing and deleting files within the 'Incomplete' and 'Downloads' directories.  Listing is always allowed, while the ability
+to delete is disabled by default.  Deletions can be enabled by enabling the remote file management option.
+
+| Command-Line               | Environment Variable           | Description                                                                               |
+| -------------------------- | ------------------------------ | ----------------------------------------------------------------------------------------- |
+| `--remote-file-management` | `SLSKD_REMOTE_FILE_MANAGEMENT` | Determines whether the remote management of 'Incomplete' and 'Downloads' files is allowed |
+
+#### **YAML**
+```yaml
+remote_file_management: false
+```
+
 # Shares
 
 ## Directories

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -652,17 +652,19 @@ namespace slskd
             {
                 var results = new List<ValidationResult>();
 
+                var directories = Directories ?? Enumerable.Empty<string>();
+
                 bool IsBlankPath(string share) => Regex.IsMatch(share.LocalizePath(), @"^(!|-){0,1}(\[.*\])$");
-                Directories.Where(share => IsBlankPath(share)).ToList()
+                directories?.Where(share => IsBlankPath(share)).ToList()
                     .ForEach(blank => results.Add(new ValidationResult($"Share {blank} doees not specify a path")));
 
                 bool IsRootMount(string share) => Regex.IsMatch(share.LocalizePath(), @"^(!|-){0,1}(\[.*\])/$");
-                Directories.Where(share => IsRootMount(share)).ToList()
+                directories?.Where(share => IsRootMount(share)).ToList()
                     .ForEach(blank => results.Add(new ValidationResult($"Share {blank} specifies a root mount, which is not supported.")));
 
                 // starts with '/', 'X:', or '\\'
                 bool IsAbsolutePath(string share) => Regex.IsMatch(share.LocalizePath(), @"^(!|-){0,1}(\[.*\])?(\/|[a-zA-Z]:|\\\\).*$");
-                Directories.Where(share => !IsAbsolutePath(share)).ToList()
+                directories?.Where(share => !IsAbsolutePath(share)).ToList()
                     .ForEach(relativePath => results.Add(new ValidationResult($"Share {relativePath} contains a relative path; only absolute paths are supported.")));
 
                 (string Raw, string Alias, string Path) Digest(string share)
@@ -677,7 +679,7 @@ namespace slskd
                     return (share, share.Split(new[] { '/', '\\' }).Last(), share);
                 }
 
-                var digestedShared = Directories
+                var digestedShared = directories
                     .Select(share => Digest(share.TrimEnd('/', '\\')))
                     .ToHashSet();
 

--- a/src/web/src/components/System/Files/Explorer.js
+++ b/src/web/src/components/System/Files/Explorer.js
@@ -11,7 +11,7 @@ import { list, deleteDirectory, deleteFile } from '../../../lib/files';
 import { formatBytes, formatDate } from '../../../lib/util';
 import { LoaderSegment } from '../../Shared';
 
-const Explorer = ({ root }) => {
+const Explorer = ({ root, remoteFileManagement }) => {
   const [directory, setDirectory] = useState({ files: [], directories: [] });
   const [subdirectory, setSubdirectory] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -46,27 +46,28 @@ const Explorer = ({ root }) => {
     <Table.Cell>{modifiedAt ? formatDate(modifiedAt) : ''}</Table.Cell>
     <Table.Cell>{length ? formatBytes(length) : ''}</Table.Cell>
     <Table.Cell>
-      <Modal
-        trigger={
-          <Icon name="trash alternate" color="red" style={{ cursor: 'pointer' }}/>
-        }
-        centered
-        size='small'
-        header={<Header icon='trash alternate' content='Confirm File Delete' />}
-        content={`Are you sure you want to delete file '${fullName}'?`}
-        actions={[
-          'Cancel',
-          {
-            key: 'done',
-            content: 'Delete',
-            negative: true,
-            onClick: async () => {
-              await deleteFile({ root, path: `${subdirectory.join('/')}/${fullName}`});
-              fetch();
+      {remoteFileManagement 
+        ? <Modal
+          trigger={
+            <Icon name="trash alternate" color="red" style={{ cursor: 'pointer' }}/>
+          }
+          centered
+          size='small'
+          header={<Header icon='trash alternate' content='Confirm File Delete' />}
+          content={`Are you sure you want to delete file '${fullName}'?`}
+          actions={[
+            'Cancel',
+            {
+              key: 'done',
+              content: 'Delete',
+              negative: true,
+              onClick: async () => {
+                await deleteFile({ root, path: `${subdirectory.join('/')}/${fullName}`});
+                fetch();
+              },
             },
-          },
-        ]}
-      />
+          ]}/>
+        : <></>}
     </Table.Cell>
   </Table.Row>;
 
@@ -84,7 +85,7 @@ const Explorer = ({ root }) => {
     <Table.Cell>{modifiedAt ? formatDate(modifiedAt) : ''}</Table.Cell>
     <Table.Cell></Table.Cell>
     <Table.Cell>
-      {deletable
+      {remoteFileManagement && deletable
         ? <Modal
           trigger={
             <Icon name="trash alternate" color="red" style={{ cursor: 'pointer' }}/>

--- a/src/web/src/components/System/Files/index.js
+++ b/src/web/src/components/System/Files/index.js
@@ -4,17 +4,19 @@ import { Tab } from 'semantic-ui-react';
 import './Files.css';
 import Explorer from './Explorer';
 
-const Files = () => {
+const Files = ({ options } = {}) => {
+  const { remoteFileManagement } = options;
+
   const panes = [
     { 
       route: 'downloads',
       menuItem: 'Downloads',
-      render: () => <Tab.Pane><Explorer root={'downloads'}/></Tab.Pane>,
+      render: () => <Tab.Pane><Explorer root={'downloads'} remoteFileManagement={remoteFileManagement}/></Tab.Pane>,
     },
     { 
       route: 'incomplete',
       menuItem: 'Incomplete',
-      render: () => <Tab.Pane><Explorer root={'incomplete'}/></Tab.Pane>,
+      render: () => <Tab.Pane><Explorer root={'incomplete'} remoteFileManagement={remoteFileManagement}/></Tab.Pane>,
     },
   ];
 

--- a/src/web/src/components/System/System.js
+++ b/src/web/src/components/System/System.js
@@ -59,7 +59,7 @@ const System = ({ state = {}, theme, options = {} }) => {
         icon: 'folder open',
         content: 'Files',
       },
-      render: () => <Tab.Pane className='full-height'><Files theme={theme}/></Tab.Pane>,
+      render: () => <Tab.Pane className='full-height'><Files options={options} theme={theme}/></Tab.Pane>,
     },
     {
       route: 'data',


### PR DESCRIPTION
Related to #205 

Also addresses one of the issues reported in #942, specifically a validation failure if no shares are defined. 