### PR TITLE
Use current username when refreshing stats

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -576,7 +576,7 @@ namespace slskd
         {
             if (force || !Cache.TryGetValue(CacheKeys.UserStatisticsToken, out _))
             {
-                var stats = await Client.GetUserStatisticsAsync(OptionsAtStartup.Soulseek.Username);
+                var stats = await Client.GetUserStatisticsAsync(Client.Username);
                 var privileges = await Client.GetPrivilegesAsync();
 
                 State.SetValue(state => state with


### PR DESCRIPTION
The logic to refresh a user's own statistics after login was incorrectly using the username at the time the application was started, which can change without needing a restart.  This PR updates this logic to use the username from the `Client`, which will always reflect the name of the logged in user.

Closes #954 