### PR TITLE
fix: transfer size column is too narrow

### DIFF
--- a/src/web/src/components/Transfers/TransferList.js
+++ b/src/web/src/components/Transfers/TransferList.js
@@ -4,7 +4,7 @@ import {
   Checkbox,
 } from 'semantic-ui-react';
 
-import { formatBytes, getFileName } from '../../lib/util';
+import { formatBytes, formatBytesAsUnit, getFileName } from '../../lib/util';
 
 import { 
   Header, 
@@ -37,23 +37,10 @@ const isRetryableState = (state) => getColor(state).color === 'red';
 const isQueuedState = (state) => state.includes('Queued');
 
 const formatBytesTransferred = ({ transferred, size }) => {
-  const [t, tExt] = formatBytes(transferred).split(' ');
-  const [s, sExt] = formatBytes(size).split(' ');
+  const [s, sExt] = formatBytes(size, 1).split(' ');
+  const t = formatBytesAsUnit(transferred, 1, sExt);
 
-  const fmt = (n) => parseFloat(n).toFixed(2);
-
-  // if less than 1 MB has been transferred, don't include decimals
-  if (tExt === 'KB') {
-    return `${t} KB/${fmt(s)} ${sExt}`;
-  }
-
-  // if the suffix for size and transferred doesn't match, include
-  // the suffix for each
-  if (tExt !== sExt) {
-    return `${fmt(t)} ${tExt}/${fmt(s)} ${sExt}`;
-  }
-
-  return `${fmt(t)}/${fmt(s)} ${sExt}`;
+  return `${t}/${s} ${sExt}`;
 };
 
 class TransferList extends Component {

--- a/src/web/src/lib/util.js
+++ b/src/web/src/lib/util.js
@@ -9,12 +9,22 @@ export const formatSeconds = (seconds) =>
   return date.toTimeString().replace(/.*(\d{2}:\d{2}).*/, '$1');
 };
 
-export const formatBytes = (bytes, decimals = 2) => {
-  if (bytes === 0) return '0 Bytes';
+export const formatBytesAsUnit = (bytes, decimals = 2, unit) => {
+  if (unit === 'B') return bytes + ' ' + unit;
 
   const k = 1024;
   const dm = decimals < 0 ? 0 : decimals;
-  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const sizes = {'KB': 1, 'MB': 2, 'GB': 3, 'TB': 4, 'PB': 5, 'EB': 6, 'ZB': 7, 'YB': 8};
+
+  return parseFloat((bytes / Math.pow(k, sizes[unit])).toFixed(dm));
+}
+
+export const formatBytes = (bytes, decimals = 2) => {
+  if (bytes === 0) return '0 B';
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
   const i = Math.floor(Math.log(bytes) / Math.log(k));
 

--- a/src/web/src/lib/util.test.js
+++ b/src/web/src/lib/util.test.js
@@ -1,0 +1,5 @@
+import * as utils from './util';
+
+it('converts bytes to specified unit', () => {
+    expect(utils.formatBytesAsUnit(1234567, 2, 'MB')).toBe(1.18);
+});


### PR DESCRIPTION
This PR aims to resolve issue #505.

- Transfer and Size numbers reduced to 1 decimal.
- Bytes replaced with B
- Transfer number always matches the unit of the size number.
