### PR TITLE
Add automated removal of downloaded and incomplete files, and application logs

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -118,7 +118,7 @@
 #     cancelled: 5
 #   files:
 #     complete: 20160 # 2 weeks
-#     incomplete: 10080 # 1 week
+#     incomplete: 43200 # 30 days
 #   logs: 259200 # 180 days
 # logger:
 #   loki: ~

--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -116,7 +116,7 @@
 #     succeeded: 1440 # 1 day
 #     errored: 20160 # 2 weeks 
 #     cancelled: 5
-#   file:
+#   files:
 #     complete: 20160 # 2 weeks
 #     incomplete: 10080 # 1 week
 #   logs: 259200 # 180 days

--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -118,7 +118,8 @@
 #     cancelled: 5
 #   file:
 #     complete: 20160 # 2 weeks
-#     incomplete: 10080 # 1 week#
+#     incomplete: 10080 # 1 week
+#   logs: 259200 # 180 days
 # logger:
 #   loki: ~
 # metrics:

--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -116,6 +116,9 @@
 #     succeeded: 1440 # 1 day
 #     errored: 20160 # 2 weeks 
 #     cancelled: 5
+#   file:
+#     complete: 20160 # 2 weeks
+#     incomplete: 10080 # 1 week#
 # logger:
 #   loki: ~
 # metrics:

--- a/docs/config.md
+++ b/docs/config.md
@@ -721,7 +721,13 @@ filters:
 
 # Data Retention
 
-Retention of transfer records on the UI (and in API endpoints) is, by default, indefinite; completed transfers will remain visible until they are manually removed.  Users can optionally configure time-based retention rules for both uploads and downloads, and can specify different settings for different dispositions (succeeded, errored, and cancelled).  Transfers are checked for expiration on a 5 minute interval, and the minimum retention time is 5 minutes.
+By default, most things created by the application are retained indefinitely; they have to be removed manually by the user.  Users can optionally configure certain things to be removed or deleted automatically after a period of time.
+
+Transfers can be configured to be removed from the UI after they are complete.  Users can specify different retention periods for uploads and downloads separately, and by transfer state; succeeded, errored, and cancelled.
+
+Files (on disk) can be configured to be deleted after the age of their last access time exceeds the configured time.  Completed and incomplete files can be configured separately.
+
+Application logs are removed after 180 days by default, but this can be configured as well.
 
 All retention periods are specified in minutes.
 
@@ -736,6 +742,10 @@ retention:
     succeeded: 1440 # 1 day
     errored: 20160 # 2 weeks 
     cancelled: 5
+  files:
+    complete: 20160 # 2 weeks
+    incomplete: 43200 # 30 days
+  logs: 259200 # 180 days
 ```
 
 # Integrations

--- a/docs/config.md
+++ b/docs/config.md
@@ -723,7 +723,7 @@ filters:
 
 By default, most things created by the application are retained indefinitely; they have to be removed manually by the user.  Users can optionally configure certain things to be removed or deleted automatically after a period of time.
 
-Transfers can be configured to be removed from the UI after they are complete.  Users can specify different retention periods for uploads and downloads separately, and by transfer state; succeeded, errored, and cancelled.
+Transfers can be configured to be removed from the UI after they are complete by specifying retention periods for uploads and downloads separately, and by transfer state; succeeded, errored, and cancelled.
 
 Files (on disk) can be configured to be deleted after the age of their last access time exceeds the configured time.  Completed and incomplete files can be configured separately.
 

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -742,12 +742,13 @@ namespace slskd
 
         private void PruneFiles()
         {
-
+            // todo: incomplete
+            // todo: complete
         }
 
         private void PruneLogs()
         {
-
+            // todo: delete files matching pattern slskd-20230216.log
         }
 
         private void PruneTransfers()

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -446,6 +446,9 @@ namespace slskd
         {
             ShuttingDown = true;
             Log.Warning("Application is shutting down");
+
+            Clock.Stop();
+
             Client.Disconnect("Shutting down", new ApplicationShutdownException("Shutting down"));
             Client.Dispose();
             Log.Information("Client stopped");

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -750,46 +750,53 @@ namespace slskd
         {
             void PruneDirectory(int? age, string directory)
             {
-                if (!age.HasValue)
+                try
                 {
-                    return;
-                }
-
-                Log.Debug("Pruning files older than {Age} minutes from {Directory}", age, directory);
-
-                var options = new EnumerationOptions
-                {
-                    IgnoreInaccessible = true,
-                    AttributesToSkip = FileAttributes.Hidden | FileAttributes.System,
-                    RecurseSubdirectories = true,
-                };
-
-                var files = System.IO.Directory.GetFiles(directory, "*", options)
-                    .Select(filename => new FileInfo(filename))
-                    .Where(file => file.LastAccessTimeUtc <= DateTime.UtcNow.AddMinutes(-age.Value));
-
-                Log.Debug("Found {Count} files of need of pruning", files.Count());
-
-                int errors = 0;
-
-                foreach (var file in files)
-                {
-                    try
+                    if (!age.HasValue)
                     {
-                        file.Delete();
+                        return;
                     }
-                    catch (Exception ex)
-                    {
-                        errors++;
-                        Log.Warning(ex, "Failed to prune file {File}: {Message}", file, ex.Message);
-                    }
-                }
 
-                Log.Debug("Pruning complete. Deleted: {Deleted}, Errors: {Errors}", files.Count() - errors, errors);
+                    Log.Debug("Pruning files older than {Age} minutes from {Directory}", age, directory);
+
+                    var options = new EnumerationOptions
+                    {
+                        IgnoreInaccessible = true,
+                        AttributesToSkip = FileAttributes.Hidden | FileAttributes.System,
+                        RecurseSubdirectories = true,
+                    };
+
+                    var files = System.IO.Directory.GetFiles(directory, "*", options)
+                        .Select(filename => new FileInfo(filename))
+                        .Where(file => file.LastAccessTimeUtc <= DateTime.UtcNow.AddMinutes(-age.Value));
+
+                    Log.Debug("Found {Count} files of need of pruning", files.Count());
+
+                    int errors = 0;
+
+                    foreach (var file in files)
+                    {
+                        try
+                        {
+                            file.Delete();
+                        }
+                        catch (Exception ex)
+                        {
+                            errors++;
+                            Log.Warning(ex, "Failed to prune file {File}: {Message}", file, ex.Message);
+                        }
+                    }
+
+                    Log.Debug("Pruning complete. Deleted: {Deleted}, Errors: {Errors}", files.Count() - errors, errors);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error("Failed to prune files in directory {Directory}: {Message}", directory, ex.Message);
+                }
             }
 
-            PruneDirectory(age: Options.Retention.File.Incomplete, directory: Options.Directories.Incomplete);
-            PruneDirectory(age: Options.Retention.File.Complete, directory: Options.Directories.Downloads);
+            PruneDirectory(age: Options.Retention.Files.Incomplete, directory: Options.Directories.Incomplete);
+            PruneDirectory(age: Options.Retention.Files.Complete, directory: Options.Directories.Downloads);
         }
 
         private void PruneTransfers()

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -286,7 +286,7 @@ namespace slskd
             Log.Information("Application started");
 
             Log.Debug("Starting clock");
-            Clock.Start();
+            await Clock.StartAsync();
             Log.Debug("Clock started");
 
             // if the application shut down "uncleanly", transfers may need to be cleaned up. we deliberately don't allow these

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -727,15 +727,27 @@ namespace slskd
 
         private void Clock_EveryFiveMinutes(object sender, EventArgs e)
         {
-            PruneTransfers();
+            _ = Task.Run(() => PruneTransfers());
         }
 
         private void Clock_EveryThirtyMinutes(object sender, EventArgs e)
         {
+            _ = Task.Run(() => PruneFiles());
         }
 
         private void Clock_EveryHour(object sender, EventArgs e)
         {
+            _ = Task.Run(() => PruneLogs());
+        }
+
+        private void PruneFiles()
+        {
+
+        }
+
+        private void PruneLogs()
+        {
+
         }
 
         private void PruneTransfers()

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -285,6 +285,10 @@ namespace slskd
         {
             Log.Information("Application started");
 
+            Log.Debug("Starting clock");
+            Clock.Start();
+            Log.Debug("Clock started");
+
             // if the application shut down "uncleanly", transfers may need to be cleaned up. we deliberately don't allow these
             // records to be updated if the application has started to shut down so that we can do this cleanup and properly
             // disposition them as having failed due to an application shutdown, instead of some random exception thrown while

--- a/src/slskd/Core/Clock.cs
+++ b/src/slskd/Core/Clock.cs
@@ -18,6 +18,7 @@
 namespace slskd
 {
     using System;
+    using System.Threading.Tasks;
     using System.Timers;
 
     /// <summary>
@@ -27,10 +28,15 @@ namespace slskd
     {
         static Clock()
         {
-            EveryMinuteTimer.Elapsed += (_, _) => EveryMinute?.Invoke(null, EventArgs.Empty);
-            EveryFiveMinutesTimer.Elapsed += (_, _) => EveryFiveMinutes?.Invoke(null, EventArgs.Empty);
-            EveryThirtyMinutesTimer.Elapsed += (_, _) => EveryThirtyMinutes?.Invoke(null, EventArgs.Empty);
-            EveryHourTimer.Elapsed += (_, _) => EveryHour?.Invoke(null, EventArgs.Empty);
+            EveryMinuteTimer.Elapsed += (_, _) => EveryMinute?.Fire();
+            EveryFiveMinutesTimer.Elapsed += (_, _) => EveryFiveMinutes?.Fire();
+            EveryThirtyMinutesTimer.Elapsed += (_, _) => EveryThirtyMinutes?.Fire();
+            EveryHourTimer.Elapsed += (_, _) => EveryHour?.Fire();
+
+            _ = Task.Run(() => EveryMinute?.Fire());
+            _ = Task.Run(() => EveryFiveMinutes?.Fire());
+            _ = Task.Run(() => EveryThirtyMinutes?.Fire());
+            _ = Task.Run(() => EveryHour?.Fire());
         }
 
         /// <summary>
@@ -53,11 +59,18 @@ namespace slskd
         /// </summary>
         public static event EventHandler EveryHour;
 
+        /// <summary>
+        ///     Invokes the EventHandler <paramref name="e"/> with a null sender and <see cref="EventArgs.Empty"/>.
+        /// </summary>
+        /// <param name="e">The EventHandler to invoke.</param>
+        public static void Fire(this EventHandler e) => e?.Invoke(null, EventArgs.Empty);
+
         private static Timer EveryMinuteTimer { get; } = CreateTimer(interval: 1000 * 60);
         private static Timer EveryFiveMinutesTimer { get; } = CreateTimer(interval: 1000 * 60 * 5);
         private static Timer EveryThirtyMinutesTimer { get; } = CreateTimer(interval: 1000 * 60 * 30);
         private static Timer EveryHourTimer { get; } = CreateTimer(interval: 1000 * 60 * 60);
 
         private static Timer CreateTimer(double interval) => new() { AutoReset = true, Interval = interval, Enabled = true };
+
     }
 }

--- a/src/slskd/Core/Clock.cs
+++ b/src/slskd/Core/Clock.cs
@@ -28,15 +28,10 @@ namespace slskd
     {
         static Clock()
         {
-            EveryMinuteTimer.Elapsed += (_, _) => EveryMinute?.Fire();
-            EveryFiveMinutesTimer.Elapsed += (_, _) => EveryFiveMinutes?.Fire();
-            EveryThirtyMinutesTimer.Elapsed += (_, _) => EveryThirtyMinutes?.Fire();
-            EveryHourTimer.Elapsed += (_, _) => EveryHour?.Fire();
-
-            _ = Task.Run(() => EveryMinute?.Fire());
-            _ = Task.Run(() => EveryFiveMinutes?.Fire());
-            _ = Task.Run(() => EveryThirtyMinutes?.Fire());
-            _ = Task.Run(() => EveryHour?.Fire());
+            EveryMinuteTimer.Elapsed += (_, _) => Fire(EveryMinute);
+            EveryFiveMinutesTimer.Elapsed += (_, _) => Fire(EveryFiveMinutes);
+            EveryThirtyMinutesTimer.Elapsed += (_, _) => Fire(EveryThirtyMinutes);
+            EveryHourTimer.Elapsed += (_, _) => Fire(EveryHour);
         }
 
         /// <summary>
@@ -59,18 +54,25 @@ namespace slskd
         /// </summary>
         public static event EventHandler EveryHour;
 
-        /// <summary>
-        ///     Invokes the EventHandler <paramref name="e"/> with a null sender and <see cref="EventArgs.Empty"/>.
-        /// </summary>
-        /// <param name="e">The EventHandler to invoke.</param>
-        public static void Fire(this EventHandler e) => e?.Invoke(null, EventArgs.Empty);
+        public static void Start()
+        {
+            EveryMinuteTimer.Enabled = true;
+            EveryFiveMinutesTimer.Enabled = true;
+            EveryThirtyMinutesTimer.Enabled = true;
+            EveryHourTimer.Enabled = true;
+
+            _ = Task.Run(() => Fire(EveryMinute));
+            _ = Task.Run(() => Fire(EveryFiveMinutes));
+            _ = Task.Run(() => Fire(EveryThirtyMinutes));
+            _ = Task.Run(() => Fire(EveryHour));
+        }
 
         private static Timer EveryMinuteTimer { get; } = CreateTimer(interval: 1000 * 60);
         private static Timer EveryFiveMinutesTimer { get; } = CreateTimer(interval: 1000 * 60 * 5);
         private static Timer EveryThirtyMinutesTimer { get; } = CreateTimer(interval: 1000 * 60 * 30);
         private static Timer EveryHourTimer { get; } = CreateTimer(interval: 1000 * 60 * 60);
 
-        private static Timer CreateTimer(double interval) => new() { AutoReset = true, Interval = interval, Enabled = true };
-
+        private static Timer CreateTimer(double interval) => new() { AutoReset = true, Interval = interval, Enabled = false };
+        private static void Fire(EventHandler e) => e?.Invoke(null, EventArgs.Empty);
     }
 }

--- a/src/slskd/Core/Clock.cs
+++ b/src/slskd/Core/Clock.cs
@@ -54,17 +54,22 @@ namespace slskd
         /// </summary>
         public static event EventHandler EveryHour;
 
-        public static void Start()
+        /// <summary>
+        ///     Starts the clock.
+        /// </summary>
+        /// <returns>A Task that completes when all startup events have finished processing.</returns>
+        public static Task StartAsync()
         {
             EveryMinuteTimer.Enabled = true;
             EveryFiveMinutesTimer.Enabled = true;
             EveryThirtyMinutesTimer.Enabled = true;
             EveryHourTimer.Enabled = true;
 
-            _ = Task.Run(() => Fire(EveryMinute));
-            _ = Task.Run(() => Fire(EveryFiveMinutes));
-            _ = Task.Run(() => Fire(EveryThirtyMinutes));
-            _ = Task.Run(() => Fire(EveryHour));
+            return Task.WhenAll(
+                Task.Run(() => Fire(EveryMinute)),
+                Task.Run(() => Fire(EveryFiveMinutes)),
+                Task.Run(() => Fire(EveryThirtyMinutes)),
+                Task.Run(() => Fire(EveryHour)));
         }
 
         private static Timer EveryMinuteTimer { get; } = CreateTimer(interval: 1000 * 60);

--- a/src/slskd/Core/Clock.cs
+++ b/src/slskd/Core/Clock.cs
@@ -72,6 +72,17 @@ namespace slskd
                 Task.Run(() => Fire(EveryHour)));
         }
 
+        /// <summary>
+        ///     Stops the clock.
+        /// </summary>
+        public static void Stop()
+        {
+            EveryMinuteTimer.Stop();
+            EveryFiveMinutesTimer.Stop();
+            EveryThirtyMinutesTimer.Stop();
+            EveryHourTimer.Stop();
+        }
+
         private static Timer EveryMinuteTimer { get; } = CreateTimer(interval: 1000 * 60);
         private static Timer EveryFiveMinutesTimer { get; } = CreateTimer(interval: 1000 * 60 * 5);
         private static Timer EveryThirtyMinutesTimer { get; } = CreateTimer(interval: 1000 * 60 * 30);

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1078,6 +1078,11 @@ namespace slskd
             public TransferRetentionOptions Download { get; init; } = new TransferRetentionOptions();
 
             /// <summary>
+            ///     Gets log retention options.
+            /// </summary>
+            public int? Logs { get; init; } = 259200; // 180 days
+
+            /// <summary>
             ///     File retention options.
             /// </summary>
             public class FileRetentionOptions

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1080,7 +1080,7 @@ namespace slskd
             /// <summary>
             ///     Gets log retention options.
             /// </summary>
-            public int? Logs { get; init; } = 259200; // 180 days
+            public int Logs { get; init; } = 259200; // 180 days
 
             /// <summary>
             ///     File retention options.

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1060,6 +1060,12 @@ namespace slskd
         public class RetentionOptions
         {
             /// <summary>
+            ///     Gets file retention options.
+            /// </summary>
+            [Validate]
+            public FileRetentionOptions File { get; init; } = new FileRetentionOptions();
+
+            /// <summary>
             ///     Gets upload retention options.
             /// </summary>
             [Validate]
@@ -1070,6 +1076,22 @@ namespace slskd
             /// </summary>
             [Validate]
             public TransferRetentionOptions Download { get; init; } = new TransferRetentionOptions();
+
+            /// <summary>
+            ///     File retention options.
+            /// </summary>
+            public class FileRetentionOptions
+            {
+                /// <summary>
+                ///     Gets the time to retain completed files, in minutes.
+                /// </summary>
+                public int? Complete { get; init; } = null;
+
+                /// <summary>
+                ///     Gets the time to retain incomplete files, in minutes.
+                /// </summary>
+                public int? Incomplete { get; init; } = null;
+            }
 
             /// <summary>
             ///     Transfer retention options.

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1078,9 +1078,10 @@ namespace slskd
             public TransferRetentionOptions Download { get; init; } = new TransferRetentionOptions();
 
             /// <summary>
-            ///     Gets log retention options.
+            ///     Gets the time to retain logs, in days.
             /// </summary>
-            public int Logs { get; init; } = 259200; // 180 days
+            [Range(1, maximum: int.MaxValue)]
+            public int Logs { get; init; } = 180;
 
             /// <summary>
             ///     File retention options.

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1091,11 +1091,13 @@ namespace slskd
                 /// <summary>
                 ///     Gets the time to retain completed files, in minutes.
                 /// </summary>
+                [Range(30, maximum: int.MaxValue)]
                 public int? Complete { get; init; } = null;
 
                 /// <summary>
                 ///     Gets the time to retain incomplete files, in minutes.
                 /// </summary>
+                [Range(30, maximum: int.MaxValue)]
                 public int? Incomplete { get; init; } = null;
             }
 

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1063,7 +1063,7 @@ namespace slskd
             ///     Gets file retention options.
             /// </summary>
             [Validate]
-            public FileRetentionOptions File { get; init; } = new FileRetentionOptions();
+            public FileRetentionOptions Files { get; init; } = new FileRetentionOptions();
 
             /// <summary>
             ///     Gets upload retention options.

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -953,7 +953,7 @@ namespace slskd
                         Path.Combine(AppDirectory, "logs", $"{AppName}-.log"),
                         outputTemplate: (OptionsAtStartup.Debug ? "[{SourceContext}] " : string.Empty) + "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
                         rollingInterval: RollingInterval.Day,
-                        retainedFileTimeLimit: TimeSpan.FromMinutes(OptionsAtStartup.Retention.Logs)))
+                        retainedFileTimeLimit: TimeSpan.FromDays(OptionsAtStartup.Retention.Logs)))
                 .WriteTo.Conditional(
                     e => !string.IsNullOrEmpty(OptionsAtStartup.Logger.Loki),
                     config => config.GrafanaLoki(

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -952,7 +952,8 @@ namespace slskd
                     config.File(
                         Path.Combine(AppDirectory, "logs", $"{AppName}-.log"),
                         outputTemplate: (OptionsAtStartup.Debug ? "[{SourceContext}] " : string.Empty) + "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
-                        rollingInterval: RollingInterval.Day))
+                        rollingInterval: RollingInterval.Day,
+                        retainedFileTimeLimit: TimeSpan.FromMinutes(OptionsAtStartup.Retention.Logs)))
                 .WriteTo.Conditional(
                     e => !string.IsNullOrEmpty(OptionsAtStartup.Logger.Loki),
                     config => config.GrafanaLoki(


### PR DESCRIPTION
#972 added the ability to configure the application to remove transfers from the UI automatically after a configurable amount of time.  This PR adds similar settings for files on disk (both downloaded and incomplete) and application logs.