### PR TITLE
Move transfer retention options

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -108,14 +108,15 @@
 #         role: readonly # readonly, readwrite, administrator
 #         cidr: 0.0.0.0/0,::/0
 # retention:
-#   upload:
-#     succeeded: 1440 # 1 day
-#     errored: 30
-#     cancelled: 5
-#   download:
-#     succeeded: 1440 # 1 day
-#     errored: 20160 # 2 weeks 
-#     cancelled: 5
+#   transfers:
+#     upload:
+#       succeeded: 1440 # 1 day
+#       errored: 30
+#       cancelled: 5
+#     download:
+#       succeeded: 1440 # 1 day
+#       errored: 20160 # 2 weeks 
+#       cancelled: 5
 #   files:
 #     complete: 20160 # 2 weeks
 #     incomplete: 43200 # 30 days

--- a/docs/config.md
+++ b/docs/config.md
@@ -734,14 +734,15 @@ All retention periods are specified in minutes.
 #### **YAML**
 ```yaml
 retention:
-  upload:
-    succeeded: 1440 # 1 day
-    errored: 30
-    cancelled: 5
-  download:
-    succeeded: 1440 # 1 day
-    errored: 20160 # 2 weeks 
-    cancelled: 5
+  transfers:
+    upload:
+      succeeded: 1440 # 1 day
+      errored: 30
+      cancelled: 5
+    download:
+      succeeded: 1440 # 1 day
+      errored: 20160 # 2 weeks 
+      cancelled: 5
   files:
     complete: 20160 # 2 weeks
     incomplete: 43200 # 30 days

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -821,13 +821,13 @@ namespace slskd
 
             try
             {
-                PruneUpload(options.Upload.Succeeded, TransferStates.Succeeded);
-                PruneUpload(options.Upload.Cancelled, TransferStates.Cancelled);
-                PruneUpload(options.Upload.Errored, TransferStates.Errored);
+                PruneUpload(options.Transfers.Upload.Succeeded, TransferStates.Succeeded);
+                PruneUpload(options.Transfers.Upload.Cancelled, TransferStates.Cancelled);
+                PruneUpload(options.Transfers.Upload.Errored, TransferStates.Errored);
 
-                PruneDownload(options.Download.Succeeded, TransferStates.Succeeded);
-                PruneDownload(options.Download.Cancelled, TransferStates.Cancelled);
-                PruneDownload(options.Download.Errored, TransferStates.Errored);
+                PruneDownload(options.Transfers.Download.Succeeded, TransferStates.Succeeded);
+                PruneDownload(options.Transfers.Download.Cancelled, TransferStates.Cancelled);
+                PruneDownload(options.Transfers.Download.Errored, TransferStates.Errored);
             }
             catch
             {

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1060,28 +1060,64 @@ namespace slskd
         public class RetentionOptions
         {
             /// <summary>
+            ///     Gets transfer retention options.
+            /// </summary>
+            [Validate]
+            public TransferRetentionOptions Transfers { get; init; } = new TransferRetentionOptions();
+
+            /// <summary>
             ///     Gets file retention options.
             /// </summary>
             [Validate]
             public FileRetentionOptions Files { get; init; } = new FileRetentionOptions();
 
             /// <summary>
-            ///     Gets upload retention options.
-            /// </summary>
-            [Validate]
-            public TransferRetentionOptions Upload { get; init; } = new TransferRetentionOptions();
-
-            /// <summary>
-            ///     Gets download retention options.
-            /// </summary>
-            [Validate]
-            public TransferRetentionOptions Download { get; init; } = new TransferRetentionOptions();
-
-            /// <summary>
             ///     Gets the time to retain logs, in days.
             /// </summary>
             [Range(1, maximum: int.MaxValue)]
             public int Logs { get; init; } = 180;
+
+            /// <summary>
+            ///     Transfer retention options.
+            /// </summary>
+            public class TransferRetentionOptions
+            {
+                /// <summary>
+                ///     Gets upload retention options.
+                /// </summary>
+                [Validate]
+                public TransferTypeRetentionOptions Upload { get; init; } = new TransferTypeRetentionOptions();
+
+                /// <summary>
+                ///     Gets download retention options.
+                /// </summary>
+                [Validate]
+                public TransferTypeRetentionOptions Download { get; init; } = new TransferTypeRetentionOptions();
+
+                /// <summary>
+                ///     Transfer retention options.
+                /// </summary>
+                public class TransferTypeRetentionOptions
+                {
+                    /// <summary>
+                    ///     Gets the time to retain successful transfers, in minutes.
+                    /// </summary>
+                    [Range(5, maximum: int.MaxValue)]
+                    public int? Succeeded { get; init; } = null;
+
+                    /// <summary>
+                    ///     Gets the time to retain errored transfers, in minutes.
+                    /// </summary>
+                    [Range(5, maximum: int.MaxValue)]
+                    public int? Errored { get; init; } = null;
+
+                    /// <summary>
+                    ///     Gets the time to retain cancelled transfers, in minutes.
+                    /// </summary>
+                    [Range(5, maximum: int.MaxValue)]
+                    public int? Cancelled { get; init; } = null;
+                }
+            }
 
             /// <summary>
             ///     File retention options.
@@ -1099,30 +1135,6 @@ namespace slskd
                 /// </summary>
                 [Range(30, maximum: int.MaxValue)]
                 public int? Incomplete { get; init; } = null;
-            }
-
-            /// <summary>
-            ///     Transfer retention options.
-            /// </summary>
-            public class TransferRetentionOptions
-            {
-                /// <summary>
-                ///     Gets the time to retain successful transfers, in minutes.
-                /// </summary>
-                [Range(5, maximum: int.MaxValue)]
-                public int? Succeeded { get; init; } = null;
-
-                /// <summary>
-                ///     Gets the time to retain errored transfers, in minutes.
-                /// </summary>
-                [Range(5, maximum: int.MaxValue)]
-                public int? Errored { get; init; } = null;
-
-                /// <summary>
-                ///     Gets the time to retain cancelled transfers, in minutes.
-                /// </summary>
-                [Range(5, maximum: int.MaxValue)]
-                public int? Cancelled { get; init; } = null;
             }
         }
 


### PR DESCRIPTION
With the addition of file and log retention options in #979, the transfer retention options would create confusion in users regarding the difference between 'upload', 'download' and 'files' retention options.  This move should clear things up.

This will be a breaking change for anyone that has added retention options for transfers.