### PR TITLE
Stop building arm/v7 Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: docker/build-push-action@v3
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             VERSION=${{ env.APP_VERSION }}


### PR DESCRIPTION
The 0.19.0 release build keeps hanging, and I'm not sure why.  It seems the last couple of logs before it times out are always related to the arm/v7 image, so I'm temporarily removing it from the build matrix to see if that's the cause.

It takes a long time to build this image because of the emulation required, and I think it has dubious value now that the Raspberry Pi 3 has been out over 5 years; this image is intended for RPI 2 users, and those with a 32 bit OS on an RPI 3.