### PR TITLE
Minor fix in the user-defined queue strategy parameter

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -76,7 +76,7 @@
 #     my_buddies:
 #       upload:
 #         priority: 250
-#         queue_strategy: firstinfirstout
+#         strategy: firstinfirstout
 #         slots: 10
 #       members:
 #         - alice


### PR DESCRIPTION
Minor typo in the default slskd config (`queue_strategy` vs `strategy`