### PR TITLE
Add options for the Soulseek server address and port

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -136,6 +136,8 @@
 # feature:
 #   swagger: false
 # soulseek:
+#   address: vps.slsknet.org
+#   port: 2271
 #   username: ~
 #   password: ~
 #   description: |

--- a/docs/config.md
+++ b/docs/config.md
@@ -433,6 +433,22 @@ groups:
 
 The Soulseek configuration determines how slskd interacts with the Soulseek network and underlying [Soulseek.NET](https://github.com/jpdillingham/Soulseek.NET) library.
 
+## Server Connection
+
+By default the application connects to `vps.slsknet.org` on port `2271`.  This should work for nearly everyone, but it is possible to override both defaults if necessary.
+
+| Command-Line     | Environment Variable | Description                        |
+| ---------------- | ---------------------| -----------------------------------|
+| `--slsk-address` | `SLSKD_SLSK_ADDRESS` | The address of the Soulseek server |
+| `--slsk-port`    | `SLSKD_SLSK_PORT`    | The port of the Soulseek server    |
+
+#### **YAML**
+```yaml
+soulseek:
+  address: vps.slsknet.org
+  port: 2271
+```
+
 ## Username and Password
 
 Credentials to log in to the Soulseek network.

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -438,7 +438,13 @@ namespace slskd
                 }
                 else
                 {
-                    await Client.ConnectAsync(OptionsAtStartup.Soulseek.Username, OptionsAtStartup.Soulseek.Password).ConfigureAwait(false);
+                    var opt = OptionsAtStartup.Soulseek;
+
+                    await Client.ConnectAsync(
+                        address: opt.Address,
+                        port: opt.Port,
+                        username: opt.Username,
+                        password: opt.Password).ConfigureAwait(false);
                 }
             }
         }

--- a/src/slskd/Core/API/Controllers/ServerController.cs
+++ b/src/slskd/Core/API/Controllers/ServerController.cs
@@ -67,7 +67,13 @@ namespace slskd.Core.API
 
             if (!Client.State.HasFlag(SoulseekClientStates.Connected))
             {
-                await Client.ConnectAsync(OptionsSnapshot.Value.Soulseek.Username, OptionsSnapshot.Value.Soulseek.Password);
+                var opt = OptionsSnapshot.Value.Soulseek;
+
+                await Client.ConnectAsync(
+                    address: opt.Address,
+                    port: opt.Port,
+                    username: opt.Username,
+                    password: opt.Password);
             }
 
             return Ok();

--- a/src/slskd/Core/ConnectionWatchdog.cs
+++ b/src/slskd/Core/ConnectionWatchdog.cs
@@ -165,7 +165,14 @@ namespace slskd
                             // reconnect with the latest configuration values we have for username and password, instead of the
                             // options that were captured at startup. if a user has updated these values prior to the disconnect,
                             // the changes will take effect now.
-                            await Client.ConnectAsync(Options.CurrentValue.Soulseek.Username, Options.CurrentValue.Soulseek.Password);
+                            var opt = Options.CurrentValue.Soulseek;
+
+                            await Client.ConnectAsync(
+                                address: opt.Address,
+                                port: opt.Port,
+                                username: opt.Username,
+                                password: opt.Password);
+
                             break;
                         }
                         catch (Exception ex)

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1249,6 +1249,25 @@ namespace slskd
         public class SoulseekOptions
         {
             /// <summary>
+            ///     Gets the address of the Soulseek server.
+            /// </summary>
+            [Argument(default, "slsk-address")]
+            [EnvironmentVariable("SLSK_ADDRESS")]
+            [Description("address of the Soulseek server")]
+            [RequiresReconnect]
+            public string Address { get; init; } = "vps.slsknet.org";
+
+            /// <summary>
+            ///     Gets the port of the Soulseek server.
+            /// </summary>
+            [Argument(default, "slsk-port")]
+            [EnvironmentVariable("SLSK_PORT")]
+            [Description("port of the Soulseek server")]
+            [RequiresReconnect]
+            [Range(1024, 65535)]
+            public int Port { get; init; } = 2271;
+
+            /// <summary>
             ///     Gets the username for the Soulseek network.
             /// </summary>
             [Argument(default, "slsk-username")]


### PR DESCRIPTION
Previously the application used the address and password that were hard-coded in the Soulseek.NET library.  The recent DNS related outage created a need for users to be able to substitute an IP address for the hostname, and this PR adds that ability.

Users can also change the port, but I'm not sure why someone would want to do that.  The official client has a lot of ports to choose from for some reason.

Users generally shouldn't need to set these.