### PR TITLE
Re-enable ARMv7 Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: docker/build-push-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           build-args: |
             VERSION=${{ env.APP_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build static web content
-FROM node:lts-alpine3.18 AS web
+FROM node:18-alpine3.18 AS web
 ARG VERSION=0.0.1.65534-local
 
 WORKDIR /slskd
@@ -43,10 +43,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   tini \
   && \
   rm -rf \
-    /tmp/* \
-    /var/lib/apt/lists/* \
-    /var/cache/apt/* \
-    /var/tmp/*
+  /tmp/* \
+  /var/lib/apt/lists/* \
+  /var/cache/apt/* \
+  /var/tmp/*
 
 RUN bash -c 'mkdir -p /app/{incomplete,downloads} \ 
   && chmod -R 777 /app \


### PR DESCRIPTION
It seems like several other people have solved the hanging issue by pinning the node docker image to v18, so I'll try it, too.

Closes #987 