### PR TITLE
Add the ability to specify a local IP address to listen on

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -142,6 +142,7 @@
 #   password: ~
 #   description: |
 #     A slskd user. https://github.com/slskd/slskd
+#   listen_ip_address: 0.0.0.0
 #   listen_port: 50300
 #   diagnostic_level: Info
 #   distributed_network:

--- a/docs/config.md
+++ b/docs/config.md
@@ -518,17 +518,21 @@ soulseek:
     child_limit: 25
 ```
 
-## Listen Port
+## Listen IP Address Port
 
-The port on which the application listens for incoming connections.
+The locak IP address and port on which the application listens for incoming connections.
 
 As with any other Soulseek client, configuring the listen port and port forwarding ensures full connectivity with other clients, including those without a correctly configured a listening port.  
 
 Symptoms of a misconfigured listen port include poor search results and the inability to browse or retrieve user information for some users.
 
-| Command-Line         | Environment Variable       | Description                                          |
-| -------------------- | -------------------------- | ---------------------------------------------------- |
-| `--slsk-listen-port` | `SLSKD_SLSK_LISTEN_PORT`   | The port on which to listen for incoming connections |
+The local IP address defaults to 0.0.0.0, and this should be correct for most people.  If you have multiple network adapters or are using a VPN you may want to set this value to ensure
+incoming traffic is properly routed.
+
+| Command-Line                | Environment Variable           | Description                                                      |
+| --------------------------- | ------------------------------ | ---------------------------------------------------------------- |
+| `--slsk-listen-ip-address`  | `SLSKD_SLSK_LISTEN_IP_ADDRESS` | The local IP address on which to listen for incoming connections |
+| `--slsk-listen-port`        | `SLSKD_SLSK_LISTEN_PORT`       | The port on which to listen for incoming connections             |
 
 #### **YAML**
 ```yaml

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -361,7 +361,7 @@ namespace slskd
                 writeBufferSize: OptionsAtStartup.Soulseek.Connection.Buffer.Transfer);
 
             var patch = new SoulseekClientOptionsPatch(
-                listenIPAddress: IPAddress.Parse(OptionsAtStartup.Soulseek.ListenIPAddress),
+                listenIPAddress: IPAddress.Parse(OptionsAtStartup.Soulseek.ListenIpAddress),
                 listenPort: OptionsAtStartup.Soulseek.ListenPort,
                 enableListener: true,
                 userEndPointCache: new UserEndPointCache(),
@@ -387,7 +387,7 @@ namespace slskd
             await Client.ReconfigureOptionsAsync(patch);
 
             Log.Debug("Client configured");
-            Log.Information("Listening for incoming connections on {IP:Port}", OptionsAtStartup.Soulseek.ListenIPAddress, OptionsAtStartup.Soulseek.ListenPort);
+            Log.Information("Listening for incoming connections son {IP}:{Port}", OptionsAtStartup.Soulseek.ListenIpAddress, OptionsAtStartup.Soulseek.ListenPort);
 
             if (OptionsAtStartup.Soulseek.Connection.Proxy.Enabled)
             {
@@ -1050,7 +1050,7 @@ namespace slskd
                     }
 
                     var patch = new SoulseekClientOptionsPatch(
-                        listenIPAddress: old.ListenIPAddress == update.ListenIPAddress ? null : IPAddress.Parse(update.ListenIPAddress),
+                        listenIPAddress: old.ListenIpAddress == update.ListenIpAddress ? null : IPAddress.Parse(update.ListenIpAddress),
                         listenPort: old.ListenPort == update.ListenPort ? null : update.ListenPort,
                         enableDistributedNetwork: old.DistributedNetwork.Disabled == update.DistributedNetwork.Disabled ? null : !update.DistributedNetwork.Disabled,
                         distributedChildLimit: old.DistributedNetwork.ChildLimit == update.DistributedNetwork.ChildLimit ? null : update.DistributedNetwork.ChildLimit,

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -361,6 +361,7 @@ namespace slskd
                 writeBufferSize: OptionsAtStartup.Soulseek.Connection.Buffer.Transfer);
 
             var patch = new SoulseekClientOptionsPatch(
+                listenIPAddress: IPAddress.Parse(OptionsAtStartup.Soulseek.ListenIPAddress),
                 listenPort: OptionsAtStartup.Soulseek.ListenPort,
                 enableListener: true,
                 userEndPointCache: new UserEndPointCache(),
@@ -386,7 +387,7 @@ namespace slskd
             await Client.ReconfigureOptionsAsync(patch);
 
             Log.Debug("Client configured");
-            Log.Information("Listening for incoming connections on port {Port}", OptionsAtStartup.Soulseek.ListenPort);
+            Log.Information("Listening for incoming connections on {IP:Port}", OptionsAtStartup.Soulseek.ListenIPAddress, OptionsAtStartup.Soulseek.ListenPort);
 
             if (OptionsAtStartup.Soulseek.Connection.Proxy.Enabled)
             {
@@ -1049,6 +1050,7 @@ namespace slskd
                     }
 
                     var patch = new SoulseekClientOptionsPatch(
+                        listenIPAddress: old.ListenIPAddress == update.ListenIPAddress ? null : IPAddress.Parse(update.ListenIPAddress),
                         listenPort: old.ListenPort == update.ListenPort ? null : update.ListenPort,
                         enableDistributedNetwork: old.DistributedNetwork.Disabled == update.DistributedNetwork.Disabled ? null : !update.DistributedNetwork.Disabled,
                         distributedChildLimit: old.DistributedNetwork.ChildLimit == update.DistributedNetwork.ChildLimit ? null : update.DistributedNetwork.ChildLimit,

--- a/src/slskd/Common/Validation/IPAddressAttribute.cs
+++ b/src/slskd/Common/Validation/IPAddressAttribute.cs
@@ -1,0 +1,48 @@
+﻿// <copyright file="IPAddressAttribute.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd.Validation
+{
+    using System.ComponentModel.DataAnnotations;
+    using System.Net;
+
+    /// <summary>
+    ///     Validates that the string is a valid IPv4 or IPv6 IP address.
+    /// </summary>
+    public class IPAddressAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            if (value != null)
+            {
+                var fail = new ValidationResult($"The {validationContext.DisplayName} field specifies an invalid IPv4 or IPv6 IP address.");
+
+                if (value is not string valueAsString)
+                {
+                    return fail;
+                }
+
+                if (!IPAddress.TryParse(valueAsString, out _))
+                {
+                    return fail;
+                }
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1295,6 +1295,15 @@ namespace slskd
             public string Description { get; init; } = "A slskd user. https://github.com/slskd/slskd";
 
             /// <summary>
+            ///     Gets the local IP address on which to listen for incoming connections.
+            /// </summary>
+            [Argument(default, "slsk-listen-address")]
+            [EnvironmentVariable("SLSK_LISTEN_ADDRESS")]
+            [Description("local IP address on which to listen for incoming connections")]
+            [IPAddress]
+            public string ListenAddress { get; init; } = "0.0.0.0";
+
+            /// <summary>
             ///     Gets the port on which to listen for incoming connections.
             /// </summary>
             [Argument(default, "slsk-listen-port")]

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1297,11 +1297,11 @@ namespace slskd
             /// <summary>
             ///     Gets the local IP address on which to listen for incoming connections.
             /// </summary>
-            [Argument(default, "slsk-listen-address")]
-            [EnvironmentVariable("SLSK_LISTEN_ADDRESS")]
+            [Argument(default, "slsk-listen-ip-address")]
+            [EnvironmentVariable("SLSK_LISTEN_IP_ADDRESS")]
             [Description("local IP address on which to listen for incoming connections")]
             [IPAddress]
-            public string ListenAddress { get; init; } = "0.0.0.0";
+            public string ListenIPAddress { get; init; } = "0.0.0.0";
 
             /// <summary>
             ///     Gets the port on which to listen for incoming connections.

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1301,7 +1301,7 @@ namespace slskd
             [EnvironmentVariable("SLSK_LISTEN_IP_ADDRESS")]
             [Description("local IP address on which to listen for incoming connections")]
             [IPAddress]
-            public string ListenIPAddress { get; init; } = "0.0.0.0";
+            public string ListenIpAddress { get; init; } = "0.0.0.0";
 
             /// <summary>
             ///     Gets the port on which to listen for incoming connections.


### PR DESCRIPTION
Functional tests still required:

* [x] IP validated at startup, when changing config, and on the UI
* [x] Listens on the configured IP 
* [x] Switches listening IP when updated

~~There's a slight chance that the logic Soulseek.NET isn't working, as I didn't test that thoroughly.~~ Works fine!