### PR TITLE
Replace deprecated versioning package

### DIFF
--- a/src/slskd/Core/API/Controllers/ApplicationController.cs
+++ b/src/slskd/Core/API/Controllers/ApplicationController.cs
@@ -22,6 +22,7 @@ namespace slskd.Core.API
     using System;
     using System.Diagnostics;
     using System.Threading.Tasks;
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Hosting;

--- a/src/slskd/Core/API/Controllers/LogsController.cs
+++ b/src/slskd/Core/API/Controllers/LogsController.cs
@@ -17,6 +17,7 @@
 
 namespace slskd.Core.API
 {
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 

--- a/src/slskd/Core/API/Controllers/MetricsController.cs
+++ b/src/slskd/Core/API/Controllers/MetricsController.cs
@@ -18,6 +18,7 @@
 namespace slskd.Core.API
 {
     using System.Threading.Tasks;
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 

--- a/src/slskd/Core/API/Controllers/OptionsController.cs
+++ b/src/slskd/Core/API/Controllers/OptionsController.cs
@@ -22,6 +22,7 @@ namespace slskd.Core.API
     using System;
     using System.IO;
     using System.Reflection;
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;

--- a/src/slskd/Core/API/Controllers/ServerController.cs
+++ b/src/slskd/Core/API/Controllers/ServerController.cs
@@ -20,9 +20,9 @@ using Microsoft.Extensions.Options;
 namespace slskd.Core.API
 {
     using System.Threading.Tasks;
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
-    using slskd.Relay;
     using Soulseek;
 
     /// <summary>

--- a/src/slskd/Core/API/Controllers/SessionController.cs
+++ b/src/slskd/Core/API/Controllers/SessionController.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.Options;
 
 namespace slskd.Core.API
 {
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using slskd.Authentication;

--- a/src/slskd/Files/API/FilesController.cs
+++ b/src/slskd/Files/API/FilesController.cs
@@ -23,6 +23,7 @@ namespace slskd.Files.API
     using System.IO;
     using System.Security;
     using System.Threading.Tasks;
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Serilog;

--- a/src/slskd/Messaging/API/Controllers/ConversationsController.cs
+++ b/src/slskd/Messaging/API/Controllers/ConversationsController.cs
@@ -22,6 +22,7 @@ namespace slskd.Messaging.API
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 

--- a/src/slskd/Messaging/API/Controllers/PublicChatController.cs
+++ b/src/slskd/Messaging/API/Controllers/PublicChatController.cs
@@ -20,10 +20,10 @@ using Microsoft.Extensions.Options;
 namespace slskd.Messaging.API
 {
     using System.Threading.Tasks;
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
-    using slskd.Relay;
     using Soulseek;
 
     /// <summary>

--- a/src/slskd/Messaging/API/Controllers/RoomsController.cs
+++ b/src/slskd/Messaging/API/Controllers/RoomsController.cs
@@ -23,10 +23,10 @@ namespace slskd.Messaging.API
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
-    using slskd.Relay;
     using Soulseek;
 
     /// <summary>

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -32,6 +32,7 @@ namespace slskd
     using System.Text.Json.Serialization;
     using System.Threading;
     using System.Threading.Tasks;
+    using Asp.Versioning.ApiExplorer;
     using Microsoft.AspNetCore.Authentication.JwtBearer;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.DataProtection;
@@ -782,12 +783,12 @@ namespace slskd
 
             services.AddHealthChecks();
 
-            services.AddApiVersioning(options => options.ReportApiVersions = true);
-            services.AddVersionedApiExplorer(options =>
-            {
-                options.GroupNameFormat = "'v'VVV";
-                options.SubstituteApiVersionInUrl = true;
-            });
+            services.AddApiVersioning(options => options.ReportApiVersions = true)
+                .AddApiExplorer(options =>
+                {
+                    options.GroupNameFormat = "'v'VVV";
+                    options.SubstituteApiVersionInUrl = true;
+                });
 
             if (OptionsAtStartup.Feature.Swagger)
             {
@@ -802,7 +803,7 @@ namespace slskd
                             Version = "v0",
                         });
 
-                    if (System.IO.File.Exists(XmlDocumentationFile))
+                    if (IOFile.Exists(XmlDocumentationFile))
                     {
                         options.IncludeXmlComments(XmlDocumentationFile);
                     }

--- a/src/slskd/Relay/API/Controllers/RelayController.cs
+++ b/src/slskd/Relay/API/Controllers/RelayController.cs
@@ -25,6 +25,7 @@ namespace slskd.Relay
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;

--- a/src/slskd/Search/API/Controllers/SearchesController.cs
+++ b/src/slskd/Search/API/Controllers/SearchesController.cs
@@ -21,9 +21,9 @@ namespace slskd.Search.API
 {
     using System;
     using System.Threading.Tasks;
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
-    using slskd.Relay;
     using SearchQuery = Soulseek.SearchQuery;
     using SearchScope = Soulseek.SearchScope;
 

--- a/src/slskd/Shares/API/Controllers/SharesController.cs
+++ b/src/slskd/Shares/API/Controllers/SharesController.cs
@@ -20,6 +20,7 @@ namespace slskd.Shares.API
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Soulseek;

--- a/src/slskd/Transfers/API/Controllers/TransfersController.cs
+++ b/src/slskd/Transfers/API/Controllers/TransfersController.cs
@@ -24,9 +24,9 @@ namespace slskd.Transfers.API
     using System.ComponentModel.DataAnnotations;
     using System.Linq;
     using System.Threading.Tasks;
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
-    using slskd.Relay;
 
     /// <summary>
     ///     Transfers.

--- a/src/slskd/Users/API/Controllers/UsersController.cs
+++ b/src/slskd/Users/API/Controllers/UsersController.cs
@@ -23,6 +23,7 @@ namespace slskd.Users.API
     using System.ComponentModel.DataAnnotations;
     using System.Net;
     using System.Threading.Tasks;
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Soulseek;

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -42,10 +42,10 @@
   </Target>
 
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.0.0" />
     <PackageReference Include="FluentFTP" Version="49.0.1" />
     <PackageReference Include="IPAddressRange" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
I diffed the generated openapi spec against the canary and it's the same.