### PR TITLE
Add 'NoConfigWatch' flag to suppress config file watching

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -13,6 +13,7 @@
 #   log_sql: false
 #   experimental: false
 #   volatile: false
+#   case_sensitive_reg_ex: false
 # relay:
 #   enabled: false
 #   mode: controller # controller (default), agent, or debug (for local development)

--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -5,6 +5,7 @@
 # flags:
 #   no_logo: false
 #   no_start: false
+#   no_config_watch: false
 #   no_connect: false
 #   no_share_scan: false
 #   force_share_scan: false

--- a/docs/config.md
+++ b/docs/config.md
@@ -963,6 +963,7 @@ Several additional feature flags are provided to change the application's runtim
 | `--experimental`         | `SLSKD_EXPERIMENTAL`         | Run the application in experimental mode.  YMMV.                 |
 | `-n\|--no-logo`          | `SLSKD_NO_LOGO`              | Don't show the application logo on startup                       |
 | `-x\|--no-start`         | `SLSKD_NO_START`             | Bootstrap the application, but don't start                       |
+| `--no-config-watch`      | `SLSKD_NO_CONFIG_WATCH`      | Don't watch the configuration file for changes                   |
 | `--no-connect`           | `SLSKD_NO_CONNECT`           | Start the application, but don't connect to the server           |
 | `--no-share-scan`        | `SLSKD_NO_SHARE_SCAN`        | Don't perform a scan of shared directories on startup            |
 | `--force-share-scan`     | `SLSKD_FORCE_SHARE_SCAN`     | Force a scan of shared directories on startup                    |
@@ -977,12 +978,15 @@ debug: false
 flags:
   no_logo: false
   no_start: false
+  no_config_watch: false
   no_connect: false
   no_share_scan: false
+  force_share_scan: false
   no_version_check: false
   log_sql: false
+  experimental: false
   volatile: false
-  case_sensitive_regex: false
+  case_sensitive_reg_ex: false
 ```
 
 # Commands

--- a/src/slskd/Core/API/Controllers/OptionsController.cs
+++ b/src/slskd/Core/API/Controllers/OptionsController.cs
@@ -198,6 +198,8 @@ namespace slskd.Core.API
             }
             catch (Exception ex)
             {
+                Logger.Warning(ex, "Configuration validation failed");
+
                 error = ex.Message;
 
                 if (ex.InnerException != null)

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -333,6 +333,15 @@ namespace slskd
             public bool NoStart { get; init; } = false;
 
             /// <summary>
+            ///     Gets a value indicating whether the application should watch the configuration file for changes.
+            /// </summary>
+            [Argument(default, "no-config-watch")]
+            [EnvironmentVariable("NO_CONFIG_WATCH")]
+            [Description("do not watch the config file for changes")]
+            [RequiresRestart]
+            public bool NoConfigWatch { get; init; } = false;
+
+            /// <summary>
             ///     Gets a value indicating whether the application should connect to the Soulseek network on startup.
             /// </summary>
             [Argument(default, "no-connect")]

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -412,6 +412,12 @@ namespace slskd
 
             Log.Information("Using application directory {AppDirectory}", AppDirectory);
             Log.Information("Using configuration file {ConfigurationFile}", ConfigurationFile);
+
+            if (OptionsAtStartup.Flags.NoConfigWatch)
+            {
+                Log.Warning("Configuration watch DISABLED; all configuration changes will require a restart to take effect");
+            }
+
             Log.Information("Storing application data in {DataDirectory}", DataDirectory);
 
             if (OptionsAtStartup.Logger.Disk)

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -350,7 +350,7 @@ namespace slskd
             try
             {
                 Configuration = new ConfigurationBuilder()
-                    .AddConfigurationProviders(EnvironmentVariablePrefix, ConfigurationFile)
+                    .AddConfigurationProviders(EnvironmentVariablePrefix, ConfigurationFile, reloadOnChange: !OptionsAtStartup.Flags.NoConfigWatch)
                     .Build();
 
                 Configuration.GetSection(AppName)
@@ -436,7 +436,7 @@ namespace slskd
                 var builder = WebApplication.CreateBuilder(args);
 
                 builder.Configuration
-                    .AddConfigurationProviders(EnvironmentVariablePrefix, ConfigurationFile);
+                    .AddConfigurationProviders(EnvironmentVariablePrefix, ConfigurationFile, reloadOnChange: !OptionsAtStartup.Flags.NoConfigWatch);
 
                 builder.Host
                     .UseSerilog();
@@ -1019,7 +1019,7 @@ namespace slskd
                 .CreateLogger();
         }
 
-        private static IConfigurationBuilder AddConfigurationProviders(this IConfigurationBuilder builder, string environmentVariablePrefix, string configurationFile)
+        private static IConfigurationBuilder AddConfigurationProviders(this IConfigurationBuilder builder, string environmentVariablePrefix, string configurationFile, bool reloadOnChange)
         {
             configurationFile = Path.GetFullPath(configurationFile);
 
@@ -1045,7 +1045,7 @@ namespace slskd
                     path: Path.GetFileName(configurationFile),
                     targetType: typeof(Options),
                     optional: true,
-                    reloadOnChange: true,
+                    reloadOnChange: reloadOnChange,
                     provider: new PhysicalFileProvider(Path.GetDirectoryName(configurationFile), ExclusionFilters.None)) // required for locations outside of the app directory
                 .AddCommandLine(
                     targetType: typeof(Options),


### PR DESCRIPTION
Setting this option to `true` will prevent the application from reacting to changes in the configuration file.  The remote configuration feature relies on this functionality, so with this enabled the configuration can be changed remotely but no changes will take effect until the application is restarted.

Related to #1050 