### PR TITLE
Add support for CIDR blacklist files

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -93,6 +93,7 @@
 #       - <username to blacklist>
 #     cidrs:
 #       - <CIDR to blacklist, e.g. 255.255.255.255/32>
+#     blacklistfile: <path to file containing CIDRs to blacklist>
 #   user_defined:
 #     my_buddies:
 #       upload:

--- a/docs/config.md
+++ b/docs/config.md
@@ -359,7 +359,7 @@ Blacklisted users are prevented from:
 - Retrieving directory contents
 - Enqueueing downloads
 
-Users can be blacklisted by adding their username to the `members` list.  Additionally, users can be blacklisted by IP address, or range of addresses by adding a CIDR entry to the `cidrs` list.
+Users can be blacklisted by adding their username to the `members` list.  Users can also be blacklisted by IP address, or range of addresses by adding a CIDR entry to the `cidrs` list. In addition, an external blacklist file containing CIDRs can be specified using `blacklistfile`, with each CIDR on its own line. Empty lines and lines starting with `#` are ignored.
 
 Users added to the blacklist will be blocked from enqueueing any new files.  Any existing active or queued transfers will need to be cancelled manually.
 
@@ -371,6 +371,7 @@ groups:
       - <username to blacklist>
     cidrs:
       - <CIDR to blacklist, e.g. 255.255.255.255/32>
+    blacklistfile: 'D:\blacklist.txt'
 ```
 
 ## User Defined Groups

--- a/src/slskd/Users/UserService.cs
+++ b/src/slskd/Users/UserService.cs
@@ -273,7 +273,7 @@ namespace slskd.Users
                 return true;
             }
 
-            if (ipAddress is not null && blacklist.Cidrs.Select(c => IPAddressRange.Parse(c)).Any(range => range.Contains(ipAddress)))
+            if (ipAddress is not null && blacklist.GetBlacklistedCIDRs().Any(range => range.Contains(ipAddress)))
             {
                 return true;
             }


### PR DESCRIPTION
Many P2P tools offer support for loading IP range blocklist files, such as those from [i-blocklist](https://www.iblocklist.com/lists). These contain lots of entries, so putting all the CIDRs from one of the lists into the main configuration file quickly becomes unwieldy, and also makes it hard to update the list later.

This PR adds support for loading an external blacklist file, whose entries are merged with any manual entries in the `cidrs` configuration section. Since many blacklist files are quite large (250k+ entries) this PR also introduces a cache for the `IPAddressRange` objects, to prevent having to re-load the file and re-parse every single CIDR string every time a call to `IsBlacklisted` is made. This cache is currently updated at validation time (within the `Validate` function). This works, for now, but a future improvement could be made to detect changes to the blacklist file and invalidate the cache when that occurs, to allow for external updates (e.g. automated blacklist updates) to be reflected at runtime.

I've done my best to follow the style of existing code, but please let me know if there's something that needs tweaking.