### PR TITLE
Improve chat colours

### DIFF
--- a/src/web/src/components/Chat/Chat.css
+++ b/src/web/src/components/Chat/Chat.css
@@ -1,3 +1,13 @@
+:root {
+  --slskd-chat-color: #0e6eb8;
+  --slskd-self-message-background-color: rgba(0, 0, 0, 0.03);
+}
+
+:root.dark {
+  --slskd-chat-color: #cce2ff;
+  --slskd-self-message-background-color: rgba(255, 255, 255, 0.03);
+}
+
 .chat {
   display: flex;
   margin-top: 1rem;
@@ -76,14 +86,15 @@
 
 .chat-message-time {
   float:right;
-  opacity: .5;
+  opacity: .65;
   font-size: smaller;
   font-variant: small-caps;
   font-style: italic;
 }
 
 .chat-message-self {
-  color: blue;
+  color: var(--slskd-chat-color);
+  background-color: var(--slskd-self-message-background-color);
 }
 
 .chat-input {


### PR DESCRIPTION
Various improvements to the colours in chats:

- Increase contrast of text in dark theme.
- Make the text colour in the light theme a little nicer.
- Improve the contrast of message timestamps.
- Add a subtle background to messages sent by the local user, in both themes, to help distingish message boundaries.

Screenshot of the changes:

![image](https://github.com/slskd/slskd/assets/6430604/0ea81e76-02fc-4954-a2b2-77bb99e790e2)

These colours have been confirmed to meet APCA contrast guidance.

This should largely resolve #1017.