### PR TITLE
Add a configurable limit for number of daily and weekly failed transfers

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -69,6 +69,7 @@
 #       weekly:
 #         files: 1500
 #         megabytes: 15000
+#         failures: 150
 #   leechers:
 #     thresholds:
 #       files: 1
@@ -85,9 +86,11 @@
 #       daily:
 #         files: 30
 #         megabytes: 300
+#         failures: 10
 #       weekly:
 #         files: 150
 #         megabytes: 1500
+#         failures: 30
 #   blacklisted:
 #     members:
 #       - <username to blacklist>

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1068,6 +1068,12 @@ namespace slskd
                 /// </summary>
                 [Range(1, int.MaxValue)]
                 public int? Megabytes { get; init; } = null;
+
+                /// <summary>
+                ///     Gets the limit for number of failures.
+                /// </summary>
+                [Range(1, int.MaxValue)]
+                public int? Failures { get; init; } = null;
             }
         }
 


### PR DESCRIPTION
Sometimes users repeatedly try and fail to download files, and at some point it just isn't going to work and they need to stop trying.

This limit helps users get the hint; when the configured number of failures is reached, users can no longer enqueue files, and are given a response like 'Too many failed transfers today'.

Extension of #1035 
Part of of #388 