### PR TITLE
Return proper message when exceeding queued limits

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -585,7 +585,10 @@ namespace slskd
                 if (over.Files || over.Megabytes)
                 {
                     Log.Information("Rejected enqueue request for user {Username}: Queued limits exceeded", username);
-                    throw new DownloadEnqueueException($"Too many {(over.Files ? "files" : "megabytes")} queued");
+
+                    // note: return exactly 'Too many files' or 'Too many megabytes' to ensure interop with other clients.
+                    // these messages are retryable, while anything else is not
+                    throw new DownloadEnqueueException($"Too many {(over.Files ? "files" : "megabytes")}");
                 }
             }
 


### PR DESCRIPTION
I had forgotten that the standard [transfer rejection messages](https://nicotine-plus.org/doc/SLSKPROTOCOL.html#in-use) are used by other clients to determine whether to retry a transfer.  This PR adjusts the message returned when exceeding queue limits so that other clients will retry.

If daily or weekly limits have been exceeded, different messages will be sent and those transfers will not be automatically retried.