### PR TITLE
Add speed limit units to code, docs

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -51,7 +51,7 @@
 # global:
 #   upload:
 #     slots: 20
-#     speed_limit: 1000
+#     speed_limit: 1000 # in kibibytes
 #   limits:
 #     queued:
 #       files: 500

--- a/docs/config.md
+++ b/docs/config.md
@@ -283,16 +283,16 @@ A change to slot limits requires an application restart to take effect, while sp
 | Command-Line             | Environment Variable         | Description                                      |
 | ------------------------ | ---------------------------- | ------------------------------------------------ |
 | `--upload-slots`         | `SLSKD_UPLOAD_SLOTS`         | The limit for the total number of upload slots   |
-| `--upload-speed-limit`   | `SLSKD_UPLOAD_SPEED_LIMIT`   | The total upload speed limit                     |
+| `--upload-speed-limit`   | `SLSKD_UPLOAD_SPEED_LIMIT`   | The total upload speed limit, in kibibytes       |
 | `--download-slots`       | `SLSKD_DOWNLOAD_SLOTS`       | The limit for the total number of download slots |
-| `--download-speed-limit` | `SLSKD_DOWNLOAD_SPEED_LIMIT` | The total download speed limit                   |
+| `--download-speed-limit` | `SLSKD_DOWNLOAD_SPEED_LIMIT` | The total download speed limit, in kibibytes     |
 
 #### **YAML**
 ```yaml
 global:
   upload:
     slots: 20
-    speed_limit: 1000
+    speed_limit: 1000 # kibibytes
   limits:
     queued:
       files: 500
@@ -392,7 +392,7 @@ groups:
       priority: 1
       strategy: roundrobin
       slots: 10
-      speed_limit: 50000
+      speed_limit: 50000 # kibibytes
   limits:
     queued:
       files: 150

--- a/src/slskd/Common/TokenBucket.cs
+++ b/src/slskd/Common/TokenBucket.cs
@@ -83,7 +83,7 @@ namespace slskd
         ///     Initializes a new instance of the <see cref="TokenBucket"/> class.
         /// </summary>
         /// <param name="capacity">The bucket capacity.</param>
-        /// <param name="interval">The interval at which tokens are replenished.</param>
+        /// <param name="interval">The interval at which tokens are replenished, in milliseconds.</param>
         public TokenBucket(long capacity, int interval)
         {
             if (capacity < 1)

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -814,7 +814,7 @@ namespace slskd
                 public int Slots { get; init; } = 10;
 
                 /// <summary>
-                ///     Gets the total upload speed limit.
+                ///     Gets the total upload speed limit, in kibibytes.
                 /// </summary>
                 [Argument(default, "upload-speed-limit")]
                 [EnvironmentVariable("UPLOAD_SPEED_LIMIT")]
@@ -839,7 +839,7 @@ namespace slskd
                 public int Slots { get; init; } = int.MaxValue;
 
                 /// <summary>
-                ///     Gets the total download speed limit.
+                ///     Gets the total download speed limit, in kibibytes.
                 /// </summary>
                 [Argument(default, "download-speed-limit")]
                 [EnvironmentVariable("DOWNLOAD_SPEED_LIMIT")]
@@ -1076,7 +1076,7 @@ namespace slskd
                 public int Slots { get; init; } = int.MaxValue;
 
                 /// <summary>
-                ///     Gets the total upload speed limit for the group.
+                ///     Gets the total upload speed limit for the group, in kibibytes.
                 /// </summary>
                 [Range(1, int.MaxValue)]
                 public int SpeedLimit { get; init; } = int.MaxValue;


### PR DESCRIPTION
Speed limits are all expressed in kibibytes.  It took me some investigation to validate this, so I've left indicators in the code as well as added a few to the docs.

Closes #1078 