### PR TITLE
Add compliance with server code 160/ExcludedSearchPhrases

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -181,7 +181,7 @@ namespace slskd
             Client.DownloadDenied += (e, args) => Log.Information("Download of {Filename} from {Username} was denied: {Message}", args.Filename, args.Username, args.Message);
             Client.DownloadFailed += (e, args) => Log.Information("Download of {Filename} from {Username} failed", args.Filename, args.Username);
 
-            Client.ExcludedSearchPhrasesReceived += (e, args) => ExcludedSearchPhrases = args;
+            Client.ExcludedSearchPhrasesReceived += Client_ExcludedSearchPhrasesReceived;
 
             ConnectionWatchdog = connectionWatchdog;
 
@@ -1096,6 +1096,12 @@ namespace slskd
             }
         }
 
+        private void Client_ExcludedSearchPhrasesReceived(object sender, IReadOnlyCollection<string> e)
+        {
+            Log.Debug("Excluded search phrases: {Phrases}", string.Join(", ", e));
+            ExcludedSearchPhrases = e;
+        }
+
         private void Client_TransferProgressUpdated(object sender, TransferProgressUpdatedEventArgs args)
         {
             // no-op. this is really verbose, use for troubleshooting.
@@ -1369,7 +1375,7 @@ namespace slskd
 
             // sometimes clients send search queries consisting only of exclusions; drop them.
             // no other clients send search results for these, even though it is technically possible.
-            if (!query.Terms.Any())
+            if (query.Terms.Count == 0)
             {
                 return null;
             }

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -1374,6 +1374,10 @@ namespace slskd
                 return null;
             }
 
+            // append the list of excluded search phrases supplied by the server
+            // see https://github.com/jpdillingham/Soulseek.NET/issues/803
+            query = new SearchQuery(terms: query.Terms, exclusions: query.Exclusions.Concat(ExcludedSearchPhrases).Distinct());
+
             try
             {
                 var sw = new Stopwatch();

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -181,6 +181,8 @@ namespace slskd
             Client.DownloadDenied += (e, args) => Log.Information("Download of {Filename} from {Username} was denied: {Message}", args.Filename, args.Username, args.Message);
             Client.DownloadFailed += (e, args) => Log.Information("Download of {Filename} from {Username} failed", args.Filename, args.Username);
 
+            Client.ExcludedSearchPhrasesReceived += (e, args) => ExcludedSearchPhrases = args;
+
             ConnectionWatchdog = connectionWatchdog;
 
             Clock.EveryMinute += Clock_EveryMinute;
@@ -221,6 +223,7 @@ namespace slskd
         private IEnumerable<Regex> CompiledSearchResponseFilters { get; set; }
         private IEnumerable<Guid> ActiveDownloadIdsAtPreviousShutdown { get; set; } = Enumerable.Empty<Guid>();
         private Options.FlagsOptions Flags { get; set; }
+        private IReadOnlyCollection<string> ExcludedSearchPhrases { get; set; } = Enumerable.Empty<string>().ToList();
 
         public void CollectGarbage()
         {


### PR DESCRIPTION
Starting earlier this year and prompted by an increase in copyright trolling, the server began to send a list of "excluded search terms" which is intended to be used by clients to perform filtering on outgoing search results.  This PR implements that functionality.

This may be objectionable to some but it's for the good of the network, and we all need to be prioritizing that if we want it to stick around.

See also: https://github.com/jpdillingham/Soulseek.NET/issues/803