### PR TITLE
Raise lower limit for JWT signing key from 16 to 32 characters

### DIFF
--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1725,7 +1725,7 @@ namespace slskd
                     [Argument(default, "jwt-key")]
                     [EnvironmentVariable("JWT_KEY")]
                     [Description("JWT signing key")]
-                    [StringLength(255, MinimumLength = 16)]
+                    [StringLength(255, MinimumLength = 32)]
                     [Secret]
                     [RequiresRestart]
                     public string Key { get; init; } = Cryptography.Random.GetBytes(32).ToBase62();

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -634,16 +634,7 @@ namespace slskd
             services.AddDataProtection()
                 .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(DataDirectory, "misc", ".DataProtection-Keys")));
 
-            var adjustedJwtKey = OptionsAtStartup.Web.Authentication.Jwt.Key;
-
-            // the JWT key must be at least 256 bits in length, due to the HMACSHA256 algorithm being used for signing.
-            if (adjustedJwtKey.Length < 32)
-            {
-                adjustedJwtKey = adjustedJwtKey.PadRight(32, ' ');
-                Log.Warning("The configured JWT signing key is less than the required 32 characters and has been padded with spaces to make up the difference. The minimum length will be raised from 16 to 32 in a future release, and this will become an error.");
-            }
-
-            var jwtSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(adjustedJwtKey));
+            var jwtSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(OptionsAtStartup.Web.Authentication.Jwt.Key));
 
             services.AddSingleton(jwtSigningKey);
             services.AddSingleton<ISecurityService, SecurityService>();


### PR DESCRIPTION
This is a breaking change for anyone that has manually specified a JWT signing key with a length of fewer than 32 characters.  If the app fails to start, extend the length of your signing key to at least 32 characters.

Closes #1022 