### PR TITLE
Disable disk logging by default

### DIFF
--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1289,11 +1289,11 @@ namespace slskd
             /// <summary>
             ///     Gets a value indicating whether to write logs to disk.
             /// </summary>
-            [Argument(default, "no-disk-logger")]
-            [EnvironmentVariable("NO_DISK_LOGGER")]
-            [Description("disable logging to disk")]
+            [Argument(default, "disk-logger")]
+            [EnvironmentVariable("DISK_LOGGER")]
+            [Description("ensable logging to disk")]
             [RequiresRestart]
-            public bool Disk { get; init; } = true;
+            public bool Disk { get; init; } = false;
         }
 
         /// <summary>

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -430,10 +430,6 @@ namespace slskd
             {
                 Log.Information("Saving application logs to {LogDirectory}", LogDirectory);
             }
-            else
-            {
-                Log.Information("Logging to disk is disabled");
-            }
 
             RecreateConfigurationFileIfMissing(ConfigurationFile);
 


### PR DESCRIPTION
Currently the behavior of the environment variable `NO_DISK_LOGGER` is inverted, and it's not possible to disable disk logging via the command line because I made a mistake when originally implementing the `Disk` option.

Correcting this would involve changing the backing property from `Disk` to `NoDisk` to properly reflect the behavior, but that would be a breaking change for anyone that had set the value of the `disk` property in their config.

This PR fixes the problem by disabling disk logging by default, and renaming the environment variable and command line argument to drop the `no`.

Closes #1115 