### PR TITLE
Fix a bunch of typos throughout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs
+.vscode
 .DS_Store
 /src/slskd/bin/
 /src/slskd/obj/

--- a/docs/build.md
+++ b/docs/build.md
@@ -29,7 +29,7 @@ options:
 
 The `runtime` parameter is required, and must be a valid .NET [RID](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog).  For most users this will be either `linux-x64` or `win-x64`, which will produce a 64 bit executable for Linux or Windows, respectively.
 
-The `platform` parameter is designed to support multiarchitecture Docker builds; if you'd like to author your own Dockerfile, refer to the one in the root of this repo for usage.
+The `platform` parameter is designed to support multi-architecture Docker builds; if you'd like to author your own Dockerfile, refer to the one in the root of this repo for usage.
 
 Output files will go to the `/dist` directory unless you specify a different location.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -13,7 +13,7 @@ The application supports several different configuration sources to make it easy
 The configuration options used by the application derive from the values specified by each of the sources, with sources higher in the hierarchy overwriting or expanding the configuration set earlier. The hierarchy is:
 
 ```
-Default Values < Environment Variables < YAML Configuraiton File < Command Line Arguments
+Default Values < Environment Variables < YAML Configuration File < Command Line Arguments
 ```
 
 Some options can be specified as lists. In these cases, when combining configurations from multiple sources, care should be taken. .NET framework not only appends but also overwrites values. If a list of `one;two;three` is defined in an environment variable for an option, and the YAML configuration specifies a list of `foo` and `bar`, the resulting configuration will be a list containing `foo, bar, three`.
@@ -532,7 +532,7 @@ groups:
 
 ## Managed Blacklist
 
-A managed blacklist (also called a blocklist) can be specified to disallow interaction with known undesireable actors.  Users whose IP address metches an entry on this list are functionally the same as users added to the [User Blacklist](#user-blacklist) described above and are disallowed any interactions with shares or files.
+A managed blacklist (also called a blocklist) can be specified to disallow interaction with known undesirable actors.  Users whose IP address matches an entry on this list are functionally the same as users added to the [User Blacklist](#user-blacklist) described above and are disallowed any interactions with shares or files.
 
 Blacklists/blocklists designed for use with other P2P applications (such as BitTorrent) are supported; specifically the P2P, DAT, and CIDR formats.
 
@@ -641,7 +641,7 @@ soulseek:
 
 ## Listen IP Address Port
 
-The locak IP address and port on which the application listens for incoming connections.
+The local IP address and port on which the application listens for incoming connections.
 
 As with any other Soulseek client, configuring the listen port and port forwarding ensures full connectivity with other clients, including those without a correctly configured a listening port.  
 
@@ -1023,7 +1023,7 @@ logger:
 
 ## Metrics
 
-The application captures metrics internally and can optionally expose these metrics to be consumed by an instance of Prometheus.  This is a good option for those wanting to tune performance characterisics of the application.
+The application captures metrics internally and can optionally expose these metrics to be consumed by an instance of Prometheus.  This is a good option for those wanting to tune performance characteristics of the application.
 
 Metrics are disabled by default, and enabling them will make them available at `/metrics`.  Authentication is enabled by default, and the credentials are the same defaults as the web UI (`slskd`:`slskd`).
 

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -164,7 +164,7 @@ namespace slskd
 
             Client.BrowseProgressUpdated += Client_BrowseProgressUpdated;
             Client.UserStatusChanged += Client_UserStatusChanged;
-            Client.PrivateMessageReceived += Client_PrivateMessageRecieved;
+            Client.PrivateMessageReceived += Client_PrivateMessageReceived;
 
             Client.PrivateRoomMembershipAdded += (e, room) => Log.Information("Added to private room {Room}", room);
             Client.PrivateRoomMembershipRemoved += (e, room) => Log.Information("Removed from private room {Room}", room);
@@ -863,13 +863,13 @@ namespace slskd
                 // we previously saved a list of all of the download ids that were active at the previous shutdown; fetch the latest
                 // record for those transfers from the db and ensure they haven't been removed from the UI while the application was offline
                 // the user doesn't want those transfers anymore and we don't want to add them back.
-                var resumeableDownloads = Transfers.Downloads.List(t => !t.Removed && ActiveDownloadIdsAtPreviousShutdown.Contains(t.Id));
+                var resumableDownloads = Transfers.Downloads.List(t => !t.Removed && ActiveDownloadIdsAtPreviousShutdown.Contains(t.Id));
 
-                if (resumeableDownloads.Any())
+                if (resumableDownloads.Any())
                 {
                     Log.Information("Attempting to re-enqueue previously active downloads...");
 
-                    var groups = resumeableDownloads.GroupBy(d => d.Username);
+                    var groups = resumableDownloads.GroupBy(d => d.Username);
 
                     // re-request downloads. we use a try/catch here because there's a very good chance that the other user is offline.
                     foreach (var group in groups)
@@ -897,7 +897,7 @@ namespace slskd
             }
         }
 
-        private void Client_PrivateMessageRecieved(object sender, PrivateMessageReceivedEventArgs args)
+        private void Client_PrivateMessageReceived(object sender, PrivateMessageReceivedEventArgs args)
         {
             Messaging.Conversations.HandleMessageAsync(args.Username, PrivateMessage.FromEventArgs(args));
 

--- a/src/slskd/Common/CommonExtensions.cs
+++ b/src/slskd/Common/CommonExtensions.cs
@@ -209,7 +209,7 @@ namespace slskd
         }
 
         /// <summary>
-        ///     Replaces the first occurance of <paramref name="phrase"/> in the string with <paramref name="replacement"/>.
+        ///     Replaces the first occurrence of <paramref name="phrase"/> in the string with <paramref name="replacement"/>.
         /// </summary>
         /// <param name="str">The string on which to perform the replacement.</param>
         /// <param name="phrase">The phrase or substring to replace.</param>
@@ -307,7 +307,7 @@ namespace slskd
         /// </summary>
         /// <typeparam name="T">The type to which to deserialize the string.</typeparam>
         /// <param name="str">The string to deserialize.</param>
-        /// <returns>The new object deserialzied from the string.</returns>
+        /// <returns>The new object deserialized from the string.</returns>
         public static T FromYaml<T>(this string str) => new DeserializerBuilder()
             .WithNamingConvention(UnderscoredNamingConvention.Instance)
             .Build()
@@ -401,7 +401,7 @@ namespace slskd
         }
 
         /// <summary>
-        ///     Replaces any occurance of an invalid filename character with the specified <see paramref="replacement"/>.
+        ///     Replaces any occurrence of an invalid filename character with the specified <see paramref="replacement"/>.
         /// </summary>
         /// <param name="path">The path to sanitize.</param>
         /// <param name="replacement">The character with which to replace invalid characters.</param>
@@ -451,7 +451,7 @@ namespace slskd
         /// </summary>
         /// <typeparam name="T">The type to which to deserialize the string.</typeparam>
         /// <param name="str">The string to deserialize.</param>
-        /// <returns>The new object deserialzied from the string.</returns>
+        /// <returns>The new object deserialized from the string.</returns>
         public static T FromJson<T>(this string str) => JsonSerializer.Deserialize<T>(str, GetJsonSerializerOptions());
 
         private static JsonSerializerOptions GetJsonSerializerOptions()

--- a/src/slskd/Common/Configuration/CommandLineConfigurationSource.cs
+++ b/src/slskd/Common/Configuration/CommandLineConfigurationSource.cs
@@ -30,7 +30,7 @@ namespace slskd.Configuration
     public static class CommandLineConfigurationExtensions
     {
         /// <summary>
-        ///     Adds a command line argument configuration soruce to <paramref name="builder"/>.
+        ///     Adds a command line argument configuration source to <paramref name="builder"/>.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to which to add.</param>
         /// <param name="targetType">The type from which to map properties.</param>

--- a/src/slskd/Common/Configuration/EnvironmentVariableConfigurationSource.cs
+++ b/src/slskd/Common/Configuration/EnvironmentVariableConfigurationSource.cs
@@ -55,7 +55,7 @@ namespace slskd.Configuration
         }
 
         /// <summary>
-        ///     Adds an enviroment variable configuration source to <paramref name="builder"/>.
+        ///     Adds an environment variable configuration source to <paramref name="builder"/>.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to which to add.</param>
         /// <param name="configureSource">Configures the source.</param>
@@ -65,7 +65,7 @@ namespace slskd.Configuration
     }
 
     /// <summary>
-    ///     An enviroment variable <see cref="ConfigurationProvider"/>.
+    ///     An environment variable <see cref="ConfigurationProvider"/>.
     /// </summary>
     public class EnvironmentVariableConfigurationProvider : ConfigurationProvider
     {

--- a/src/slskd/Common/Configuration/RequiresReconnectAttribute.cs
+++ b/src/slskd/Common/Configuration/RequiresReconnectAttribute.cs
@@ -19,6 +19,9 @@ namespace slskd.Configuration
 {
     using System;
 
+    /// <summary>
+    ///     Indicates that the application must disconnect and reconnect to the Soulseek server for changes to take effect.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public class RequiresReconnectAttribute : Attribute
     {

--- a/src/slskd/Common/Configuration/RequiresRestartAttribute.cs
+++ b/src/slskd/Common/Configuration/RequiresRestartAttribute.cs
@@ -19,6 +19,9 @@ namespace slskd.Configuration
 {
     using System;
 
+    /// <summary>
+    ///     Indicates that the application must be restarted for any changes to take effect.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public class RequiresRestartAttribute : Attribute
     {

--- a/src/slskd/Common/Exceptions/OutOfRangeException.cs
+++ b/src/slskd/Common/Exceptions/OutOfRangeException.cs
@@ -19,7 +19,6 @@ namespace slskd
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using System.Runtime.Serialization;
 
     /// <summary>
     ///     Represents errors that originate when a value falls out of an expected range.

--- a/src/slskd/Common/Exceptions/RetryException.cs
+++ b/src/slskd/Common/Exceptions/RetryException.cs
@@ -21,7 +21,7 @@ namespace slskd
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
-    ///     Represents erorrs that originate while attempting to execute retry logic.
+    ///     Represents errors that originate while attempting to execute retry logic.
     /// </summary>
     [ExcludeFromCodeCoverage]
     public class RetryException : Exception

--- a/src/slskd/Common/Exceptions/SlskdException.cs
+++ b/src/slskd/Common/Exceptions/SlskdException.cs
@@ -21,7 +21,7 @@ namespace slskd
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
-    ///     Represents erorrs that originate from slskd logic.
+    ///     Represents errors that originate from slskd logic.
     /// </summary>
     [ExcludeFromCodeCoverage]
     public class SlskdException : Exception

--- a/src/slskd/Common/ManagedState.cs
+++ b/src/slskd/Common/ManagedState.cs
@@ -35,7 +35,7 @@ namespace slskd
         /// <summary>
         ///     Registers a listener to be called whenever the tracked state changes.
         /// </summary>
-        /// <param name="listener">Registers a listener to be called whenver state changes.</param>
+        /// <param name="listener">Registers a listener to be called whenever state changes.</param>
         /// <returns>An <see cref="IDisposable"/> which should be disposed to stop listening for changes.</returns>
         IDisposable OnChange(Action<(T Previous, T Current)> listener);
     }
@@ -164,9 +164,9 @@ namespace slskd
         private object Lock { get; } = new object();
 
         /// <summary>
-        ///     Registers a listener to be called whenever the stracked state changes.
+        ///     Registers a listener to be called whenever the tracked state changes.
         /// </summary>
-        /// <param name="listener">Registers a listener to be called whenver state changes.</param>
+        /// <param name="listener">Registers a listener to be called whenever state changes.</param>
         /// <returns>An <see cref="IDisposable"/> which should be disposed to stop listening for changes.</returns>
         public IDisposable OnChange(Action<(T Previous, T Current)> listener)
         {

--- a/src/slskd/Common/Middleware/HTMLRewriteMiddleware.cs
+++ b/src/slskd/Common/Middleware/HTMLRewriteMiddleware.cs
@@ -66,7 +66,7 @@ namespace slskd
         private RequestDelegate Next { get; }
 
         /// <summary>
-        ///     Executes this middleware, returning the contents of the requested HTML file with the specified replacesments made.
+        ///     Executes this middleware, returning the contents of the requested HTML file with the specified replacements made.
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>

--- a/src/slskd/Common/Retry.cs
+++ b/src/slskd/Common/Retry.cs
@@ -53,7 +53,7 @@ namespace slskd
         /// <param name="isRetryable">A function returning a value indicating whether the last Exception is retryable.</param>
         /// <param name="onFailure">An action to execute on failure.</param>
         /// <param name="maxAttempts">The maximum number of retry attempts.</param>
-        /// <param name="maxDelayInMilliseconds">The maximum delay in miliseconds.</param>
+        /// <param name="maxDelayInMilliseconds">The maximum delay in milliseconds.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <typeparam name="T">The Type of the logic return value.</typeparam>
         /// <returns>The execution context.</returns>

--- a/src/slskd/Common/Validation/EnumAttribute.cs
+++ b/src/slskd/Common/Validation/EnumAttribute.cs
@@ -21,7 +21,7 @@ namespace slskd.Validation
     using System.ComponentModel.DataAnnotations;
 
     /// <summary>
-    ///     Validates that the value is a valid nember of the specified <see cref="Enum"/>.
+    ///     Validates that the value is a valid member of the specified <see cref="Enum"/>.
     /// </summary>
     public class EnumAttribute : ValidationAttribute
     {

--- a/src/slskd/Common/Validation/ValidationExtensions.cs
+++ b/src/slskd/Common/Validation/ValidationExtensions.cs
@@ -22,7 +22,7 @@ namespace slskd.Validation
     using System.Linq;
 
     /// <summary>
-    ///     Extension methods for types involved with validaiton.
+    ///     Extension methods for types involved with validation.
     /// </summary>
     public static class ValidationExtensions
     {

--- a/src/slskd/Common/Waiter.cs
+++ b/src/slskd/Common/Waiter.cs
@@ -348,7 +348,7 @@ namespace slskd
                         // enqueueing a new wait.
                         if (queue.IsEmpty)
                         {
-                            // enter the write lock to prevent Wait() (which obtains a read lock) from enqueing any more waits
+                            // enter the write lock to prevent Wait() (which obtains a read lock) from enqueuing any more waits
                             // before we can delete the dictionary record. it's ok and expected that Wait() might add this record
                             // back to the dictionary as soon as this unblocks; we're preventing new waits from being discarded if
                             // they are added by another thread just prior to the TryRemove() operation below.
@@ -357,7 +357,7 @@ namespace slskd
                             try
                             {
                                 // check the queue again to ensure Wait() didn't enqueue anything between the last check and when
-                                // we entered the write lock. this is guarateed to be safe since we now have exclusive access to
+                                // we entered the write lock. this is guaranteed to be safe since we now have exclusive access to
                                 // the record and it should be impossible to remove a record containing a non-empty queue
                                 if (queue.IsEmpty)
                                 {

--- a/src/slskd/Core/Blacklist.cs
+++ b/src/slskd/Core/Blacklist.cs
@@ -179,7 +179,7 @@ public class Blacklist
     {
         if (format == BlacklistFormat.AutoDetect)
         {
-            Log.Debug("Attempting to auto-detect blacklist fomat from contents...");
+            Log.Debug("Attempting to auto-detect blacklist format from contents...");
             format = await DetectFormat(filename); // FormatException if unsuccessful
             Log.Debug("Detected blacklist format {Format}", format);
         }
@@ -294,7 +294,7 @@ public class Blacklist
     }
 
     /// <summary>
-    ///     Returns a value indicating whether the specified <paramref name="ip"/> is contained witin the blacklist.
+    ///     Returns a value indicating whether the specified <paramref name="ip"/> is contained within the blacklist.
     /// </summary>
     /// <param name="ip">The IP address to check.</param>
     /// <returns>A value indicating whether the specified IP is contained within the blacklist.</returns>
@@ -310,7 +310,7 @@ public class Blacklist
             return false;
         }
 
-        // conver the entire IP to a uint
+        // convert the entire IP to a uint
         var ipAsUint32 = ToUint32(ip);
 
         // check the list for this octet sequentially until the first match

--- a/src/slskd/Core/Metrics.cs
+++ b/src/slskd/Core/Metrics.cs
@@ -123,7 +123,7 @@ namespace slskd
             public static Gauge BranchLevel { get; } = Prometheus.Metrics.CreateGauge("slskd_dnet_branch_level", "Current distributed branch level");
 
             /// <summary>
-            ///     Gets a gauge representing the most recent average time tekn to broadcast incoming search requests to connected children.
+            ///     Gets a gauge representing the most recent average time taken to broadcast incoming search requests to connected children.
             /// </summary>
             public static Gauge CurrentBroadcastLatency { get; } = Prometheus.Metrics.CreateGauge("slskd_dnet_broadcast_latency_current", "The average time taken to broadcast incoming search requests to connected children");
 

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -744,7 +744,7 @@ namespace slskd
 
                 bool IsBlankPath(string share) => Regex.IsMatch(share.LocalizePath(), @"^(!|-){0,1}(\[.*\])$");
                 directories?.Where(share => IsBlankPath(share)).ToList()
-                    .ForEach(blank => results.Add(new ValidationResult($"Share {blank} doees not specify a path")));
+                    .ForEach(blank => results.Add(new ValidationResult($"Share {blank} does not specify a path")));
 
                 bool IsRootMount(string share) => Regex.IsMatch(share.LocalizePath(), @"^(!|-){0,1}(\[.*\])/$");
                 directories?.Where(share => IsRootMount(share)).ToList()
@@ -1291,7 +1291,7 @@ namespace slskd
             /// </summary>
             [Argument(default, "disk-logger")]
             [EnvironmentVariable("DISK_LOGGER")]
-            [Description("ensable logging to disk")]
+            [Description("enable logging to disk")]
             [RequiresRestart]
             public bool Disk { get; init; } = false;
         }

--- a/src/slskd/Files/FileService.cs
+++ b/src/slskd/Files/FileService.cs
@@ -337,7 +337,7 @@ namespace slskd.Files
 
             if (!overwrite && File.Exists(destinationFilename))
             {
-                Log.Debug("Destination file {Destination} exists, and overwite option is not set; attempting to generate new filename", destinationFilename);
+                Log.Debug("Destination file {Destination} exists, and overwrite option is not set; attempting to generate new filename", destinationFilename);
 
                 string extensionlessFilename = Path.Combine(Path.GetDirectoryName(destinationFilename), Path.GetFileNameWithoutExtension(sourceFilename));
                 string extension = Path.GetExtension(sourceFilename);

--- a/src/slskd/Messaging/API/Controllers/ConversationsController.cs
+++ b/src/slskd/Messaging/API/Controllers/ConversationsController.cs
@@ -39,15 +39,15 @@ namespace slskd.Messaging.API
         /// <summary>
         ///     Initializes a new instance of the <see cref="ConversationsController"/> class.
         /// </summary>
-        /// <param name="applicationStateMonotor"></param>
+        /// <param name="applicationStateMonitor"></param>
         /// <param name="messagingService"></param>
         /// <param name="optionsSnapshot"></param>
         public ConversationsController(
-            IStateMonitor<State> applicationStateMonotor,
+            IStateMonitor<State> applicationStateMonitor,
             IMessagingService messagingService,
             IOptionsSnapshot<Options> optionsSnapshot)
         {
-            ApplicationStateMonitor = applicationStateMonotor;
+            ApplicationStateMonitor = applicationStateMonitor;
             Messages = messagingService;
             OptionsSnapshot = optionsSnapshot;
         }
@@ -70,7 +70,7 @@ namespace slskd.Messaging.API
         [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(200)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> Acknowledge([FromRoute]string username, [FromRoute]int id)
+        public async Task<IActionResult> Acknowledge([FromRoute] string username, [FromRoute] int id)
         {
             if (Program.IsRelayAgent)
             {
@@ -100,7 +100,7 @@ namespace slskd.Messaging.API
         [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(200)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> AcknowledgeAll([FromRoute]string username)
+        public async Task<IActionResult> AcknowledgeAll([FromRoute] string username)
         {
             if (Program.IsRelayAgent)
             {
@@ -129,7 +129,7 @@ namespace slskd.Messaging.API
         [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(404)]
         [ProducesResponseType(204)]
-        public async Task<IActionResult> Close([FromRoute]string username)
+        public async Task<IActionResult> Close([FromRoute] string username)
         {
             if (Program.IsRelayAgent)
             {
@@ -156,7 +156,7 @@ namespace slskd.Messaging.API
         [HttpGet("")]
         [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(List<Conversation>), 200)]
-        public async Task<IActionResult> GetAll([FromQuery] bool includeInactive = false, [FromQuery]bool unAcknowledgedOnly = false)
+        public async Task<IActionResult> GetAll([FromQuery] bool includeInactive = false, [FromQuery] bool unAcknowledgedOnly = false)
         {
             if (Program.IsRelayAgent)
             {
@@ -185,7 +185,7 @@ namespace slskd.Messaging.API
         [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(Conversation), 200)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> GetByUsername([FromRoute]string username, [FromQuery]bool includeMessages = true)
+        public async Task<IActionResult> GetByUsername([FromRoute] string username, [FromQuery] bool includeMessages = true)
         {
             if (Program.IsRelayAgent)
             {
@@ -206,7 +206,7 @@ namespace slskd.Messaging.API
         [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(typeof(List<PrivateMessage>), 200)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> GetMessagesByUsername([FromRoute]string username, [FromQuery]bool unAcknowledgedOnly = false)
+        public async Task<IActionResult> GetMessagesByUsername([FromRoute] string username, [FromQuery] bool unAcknowledgedOnly = false)
         {
             if (Program.IsRelayAgent)
             {
@@ -242,7 +242,7 @@ namespace slskd.Messaging.API
         [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(201)]
         [ProducesResponseType(400)]
-        public async Task<IActionResult> Send([FromRoute]string username, [FromBody]string message)
+        public async Task<IActionResult> Send([FromRoute] string username, [FromBody] string message)
         {
             if (Program.IsRelayAgent)
             {

--- a/src/slskd/Messaging/RoomService.cs
+++ b/src/slskd/Messaging/RoomService.cs
@@ -32,7 +32,7 @@ namespace slskd.Messaging
     public interface IRoomService
     {
         /// <summary>
-        ///     Joins the specfied <paramref name="roomName"/>.
+        ///     Joins the specified <paramref name="roomName"/>.
         /// </summary>
         /// <param name="roomName">The name of the room to join.</param>
         /// <returns>The operation context, including information about the room.</returns>
@@ -95,7 +95,7 @@ namespace slskd.Messaging
         private IRoomTracker RoomTracker { get; set; }
 
         /// <summary>
-        ///     Joins the specfied <paramref name="roomName"/>.
+        ///     Joins the specified <paramref name="roomName"/>.
         /// </summary>
         /// <param name="roomName">The name of the room to join.</param>
         /// <returns>The operation context, including information about the room.</returns>

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -333,7 +333,7 @@ namespace slskd
             DefaultDownloadsDirectory = Path.Combine(AppDirectory, "downloads");
             DefaultIncompleteDirectory = Path.Combine(AppDirectory, "incomplete");
 
-            // the location of the configuration file might have been overriden by command line or envar.
+            // the location of the configuration file might have been overridden by command line or envar.
             // if not, set it to the default.
             ConfigurationFile ??= DefaultConfigurationFile;
 
@@ -487,7 +487,7 @@ namespace slskd
 
                 if (OptionsAtStartup.Flags.NoStart)
                 {
-                    Log.Information("Qutting because 'no-start' option is enabled");
+                    Log.Information("Quitting because 'no-start' option is enabled");
                     return;
                 }
 

--- a/src/slskd/Relay/NullRelayClient.cs
+++ b/src/slskd/Relay/NullRelayClient.cs
@@ -21,7 +21,7 @@ namespace slskd.Relay
     using System.Threading.Tasks;
 
     /// <summary>
-    ///     A non-operarable Relay client.
+    ///     A non-operable Relay client.
     /// </summary>
     public class NullRelayClient : IRelayClient
     {

--- a/src/slskd/Relay/RelayService.cs
+++ b/src/slskd/Relay/RelayService.cs
@@ -87,7 +87,7 @@ namespace slskd.Relay
         ///     Retrieves information about the specified <paramref name="filename"/> from the specified <paramref name="agentName"/>.
         /// </summary>
         /// <remarks>
-        ///     <para>This is the first step in a mult-step workflow. The entire sequence is:</para>
+        ///     <para>This is the first step in a multi-step workflow. The entire sequence is:</para>
         ///     <list type="number">
         ///         <item>
         ///             Upload service calls and awaits <see cref="GetFileInfoAsync"/>, which requests the file info from the
@@ -389,7 +389,7 @@ namespace slskd.Relay
         ///     Retrieves information about the specified <paramref name="filename"/> from the specified <paramref name="agentName"/>.
         /// </summary>
         /// <remarks>
-        ///     <para>This is the first step in a mult-step workflow. The entire sequence is:</para>
+        ///     <para>This is the first step in a multi-step workflow. The entire sequence is:</para>
         ///     <list type="number">
         ///         <item>
         ///             Upload service calls and awaits <see cref="GetFileInfoAsync"/>, which requests the file info from the

--- a/src/slskd/Search/ISearchService.cs
+++ b/src/slskd/Search/ISearchService.cs
@@ -29,7 +29,7 @@ namespace slskd.Search
     public interface ISearchService
     {
         /// <summary>
-        ///     Deletes the specified ssearch.
+        ///     Deletes the specified search.
         /// </summary>
         /// <param name="search">The search to delete.</param>
         /// <returns>The operation context.</returns>
@@ -65,7 +65,7 @@ namespace slskd.Search
         ///     Cancels the search matching the specified <paramref name="id"/>, if it is in progress.
         /// </summary>
         /// <param name="id">The unique identifier for the search.</param>
-        /// <returns>A value indicating whether the search was sucessfully cancelled.</returns>
+        /// <returns>A value indicating whether the search was successfully cancelled.</returns>
         bool TryCancel(Guid id);
     }
 }

--- a/src/slskd/Search/SearchService.cs
+++ b/src/slskd/Search/SearchService.cs
@@ -70,7 +70,7 @@ namespace slskd.Search
         private IHubContext<SearchHub> SearchHub { get; set; }
 
         /// <summary>
-        ///     Deletes the specified ssearch.
+        ///     Deletes the specified search.
         /// </summary>
         /// <param name="search">The search to delete.</param>
         /// <returns>The operation context.</returns>
@@ -245,7 +245,7 @@ namespace slskd.Search
         ///     Cancels the search matching the specified <paramref name="id"/>, if it is in progress.
         /// </summary>
         /// <param name="id">The unique identifier for the search.</param>
-        /// <returns>A value indicating whether the search was sucessfully cancelled.</returns>
+        /// <returns>A value indicating whether the search was successfully cancelled.</returns>
         public bool TryCancel(Guid id)
         {
             if (CancellationTokens.TryGetValue(id, out var cts))

--- a/src/slskd/Shares/IShareRepository.cs
+++ b/src/slskd/Shares/IShareRepository.cs
@@ -87,7 +87,7 @@ namespace slskd.Shares
         Scan FindLatestScan();
 
         /// <summary>
-        ///     Flags the latest scan as suspect, indicating that the cached contents may have divered from physical storage.
+        ///     Flags the latest scan as suspect, indicating that the cached contents may have diverged from physical storage.
         /// </summary>
         void FlagLatestScanAsSuspect();
 

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -486,7 +486,7 @@ namespace slskd.Shares
                 ComputeShareStatistics();
                 Log.Debug("Share statistics updated");
 
-                // one of several thigns happened above before we got here:
+                // one of several things happened above before we got here:
                 //   this method was called with forceRescan = true
                 //   the storage mode is memory, and we loaded the in-memory db from a valid backup
                 //   the storage mode is disk, and the file is there and valid
@@ -510,7 +510,7 @@ namespace slskd.Shares
 
                 if (!forceRescan)
                 {
-                    Log.Warning("Re-attempting initializtion");
+                    Log.Warning("Re-attempting initialization");
                     await InitializeAsync(forceRescan: true);
                 }
                 else

--- a/src/slskd/Shares/SoulseekFileFactory.cs
+++ b/src/slskd/Shares/SoulseekFileFactory.cs
@@ -72,7 +72,7 @@ namespace slskd.Shares
                 {
                     file = TagLib.File.Create(filename, TagLib.ReadStyle.Average | TagLib.ReadStyle.PictureLazy);
 
-                    // try to mimick the behavior of existing clients by providing attributes selectively and in a specific order,
+                    // try to mimic the behavior of existing clients by providing attributes selectively and in a specific order,
                     // depending on whether files use a lossless or lossy codec. lossless files should have BitsPerSample, while lossy
                     // will not. this may not be the best way to determine this.
                     bool isLossless = file.Properties.BitsPerSample > 0;

--- a/src/slskd/Shares/SqliteShareRepository.cs
+++ b/src/slskd/Shares/SqliteShareRepository.cs
@@ -178,7 +178,7 @@ namespace slskd.Shares
         }
 
         /// <summary>
-        ///     Diposes this object.
+        ///     Disposes this object.
         /// </summary>
         public void Dispose()
         {
@@ -258,7 +258,7 @@ namespace slskd.Shares
         }
 
         /// <summary>
-        ///     Flags the latest scan as suspect, indicating that the cached contents may have divered from physical storage.
+        ///     Flags the latest scan as suspect, indicating that the cached contents may have diverged from physical storage.
         /// </summary>
         public void FlagLatestScanAsSuspect()
         {

--- a/src/slskd/Transfers/API/Controllers/TransfersController.cs
+++ b/src/slskd/Transfers/API/Controllers/TransfersController.cs
@@ -67,7 +67,7 @@ namespace slskd.Transfers.API
         [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(204)]
         [ProducesResponseType(404)]
-        public IActionResult CancelDownloadAsync([FromRoute, Required] string username, [FromRoute, Required]string id, [FromQuery]bool remove = false)
+        public IActionResult CancelDownloadAsync([FromRoute, Required] string username, [FromRoute, Required] string id, [FromQuery] bool remove = false)
         {
             if (Program.IsRelayAgent)
             {
@@ -136,7 +136,7 @@ namespace slskd.Transfers.API
         [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(204)]
         [ProducesResponseType(404)]
-        public IActionResult CancelUpload([FromRoute, Required] string username, [FromRoute, Required]string id, [FromQuery]bool remove = false)
+        public IActionResult CancelUpload([FromRoute, Required] string username, [FromRoute, Required] string id, [FromQuery] bool remove = false)
         {
             if (Program.IsRelayAgent)
             {
@@ -207,7 +207,7 @@ namespace slskd.Transfers.API
         [ProducesResponseType(201)]
         [ProducesResponseType(typeof(string), 403)]
         [ProducesResponseType(typeof(string), 500)]
-        public async Task<IActionResult> EnqueueAsync([FromRoute, Required]string username, [FromBody]IEnumerable<QueueDownloadRequest> requests)
+        public async Task<IActionResult> EnqueueAsync([FromRoute, Required] string username, [FromBody] IEnumerable<QueueDownloadRequest> requests)
         {
             if (Program.IsRelayAgent)
             {
@@ -233,7 +233,7 @@ namespace slskd.Transfers.API
         [HttpGet("downloads")]
         [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(200)]
-        public IActionResult GetDownloadsAsync([FromQuery]bool includeRemoved = false)
+        public IActionResult GetDownloadsAsync([FromQuery] bool includeRemoved = false)
         {
             if (Program.IsRelayAgent)
             {
@@ -320,7 +320,7 @@ namespace slskd.Transfers.API
         }
 
         /// <summary>
-        ///     Gets the downlaod for the specified username matching the specified filename, and requests
+        ///     Gets the download for the specified username matching the specified filename, and requests
         ///     the current place in the remote queue of the specified download.
         /// </summary>
         /// <param name="username">The username of the download source.</param>

--- a/src/slskd/Transfers/Uploads/UploadQueue.cs
+++ b/src/slskd/Transfers/Uploads/UploadQueue.cs
@@ -296,7 +296,7 @@ namespace slskd.Transfers
                 // ddddddd
                 //     ^
                 //
-                // if we want the postion of the file over the carat above, first find the position of it
+                // if we want the position of the file over the carat above, first find the position of it
                 // within its own queue (= 5). assume uploads will process top down, left to right until reaching
                 // this one.  that's 5 files from a, 2 from b, 5 from c, and the other 4 from d, putting the file over
                 // the carat at position 16. the actual number will vary due to many factors, including where in the

--- a/src/slskd/Users/UserService.cs
+++ b/src/slskd/Users/UserService.cs
@@ -345,7 +345,7 @@ namespace slskd.Users
             await GetStatisticsAsync(username);
 
             // delay the add until last, so that IsWatched won't return true until stats and status are populated. this may result
-            // in several unecessary calls to WatchAsync (if someone is checking IsWatched() and WatchAsync()ing if false), but we
+            // in several unnecessary calls to WatchAsync (if someone is checking IsWatched() and WatchAsync()ing if false), but we
             // can be sure that if IsWatched() is true, we have valid stats and status. if we can't ensure this, the application
             // will have non-deterministic behavior when it makes decisions about user groups, limits, governance etc.
             WatchedUsernamesDictionary.TryAdd(username, true);
@@ -368,7 +368,7 @@ namespace slskd.Users
 
             if (optionsHash != LastOptionsHash || force)
             {
-                // get a list of tracked names that haven't been explicitly added to any group, including those that were previlously
+                // get a list of tracked names that haven't been explicitly added to any group, including those that were previously
                 // configured but have now been removed
                 var usernamesBeforeUpdate = UserDictionary.Keys.ToList();
                 var usernamesAfterUpdate = options.Groups.UserDefined.SelectMany(g => g.Value.Members);


### PR DESCRIPTION
Spell checked with the [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) VS Code extension and the following overrides:

```
{
  "cSpell.words": [
    "blocklist",
    "blocklists",
    "bootup",
    "BTRFS",
    "bumpless",
    "cooldown",
    "Decryptor",
    "Disambiguates",
    "dispositioned",
    "distros",
    "dnet",
    "Encryptor",
    "envar",
    "envars",
    "extensionless",
    "filesystems",
    "firstinfirstout",
    "flac",
    "HMACSHA",
    "Hsts",
    "IFTP",
    "keepalive",
    "KEEPCNT",
    "KEEPIDLE",
    "KEEPINTVL",
    "kibibytes",
    "leecher",
    "leechers",
    "libc",
    "localappdata",
    "Museek",
    "NETSTANDARD",
    "Pasteable",
    "Pkcs",
    "POSIX",
    "prebuild",
    "proxying",
    "Pushbullet",
    "readwrite",
    "reconfig",
    "Rescan",
    "Retryable",
    "Rewriteable",
    "roundrobin",
    "Serilog",
    "shrinkwrapped",
    "signalr",
    "slsk",
    "slskd",
    "slsknet",
    "snapshotted",
    "Soulseek",
    "Swashbuckle",
    "THREADSAFE",
    "topts",
    "unacked",
    "unscanned",
    "v'VVV",
    "Validatable",
    "VBRI",
    "webserver",
    "websockets",
    "wwwroot",
    "xbarx",
    "xfer"
  ]
}
```

Closes #1136 