### PR TITLE
Improve reverse proxy setup for Nginx

### DIFF
--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -19,7 +19,10 @@ server {
                 proxy_set_header Upgrade $http_upgrade;
                 proxy_set_header Connection "Upgrade";
                 proxy_set_header Host $host;
+                proxy_request_buffering off;
         }
+
+        client_max_body_size 0;
 }
 ```
 
@@ -36,7 +39,10 @@ server {
                 proxy_set_header Upgrade $http_upgrade;
                 proxy_set_header Connection "Upgrade";
                 proxy_set_header Host $host;
+                proxy_request_buffering off;
         }
+
+        client_max_body_size 0;
 }
 ```
 


### PR DESCRIPTION
Fixes the problem I encountered with the reverse proxy setup when I tried out downloading a 5GB file from my slskd setup.

By default Nginx has its own limit of body size of 1MB, and also its own proxy buffering. These two settings disable them.