### PR TITLE
Handle file symlinks in shares correctly

### DIFF
--- a/src/slskd/Files/FileExtensions.cs
+++ b/src/slskd/Files/FileExtensions.cs
@@ -59,4 +59,25 @@ public static class FileExtensions
 
         return (UnixFileMode)mode;
     }
+
+#nullable enable
+    public static FileInfo? TryFollowSymlink(this FileInfo fileInfo)
+    {
+        try
+        {
+            return fileInfo.FollowSymlink();
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+    }
+
+    public static FileInfo FollowSymlink(this FileInfo fileInfo)
+    {
+        FileSystemInfo fileSystemInfo = fileInfo;
+        fileSystemInfo = fileSystemInfo.ResolveLinkTarget(returnFinalTarget: true) ?? fileSystemInfo;
+        return (FileInfo)fileSystemInfo;
+    }
+#nullable restore
 }

--- a/src/slskd/Relay/RelayClient.cs
+++ b/src/slskd/Relay/RelayClient.cs
@@ -16,6 +16,7 @@
 // </copyright>
 
 using Microsoft.Extensions.Options;
+using slskd.Files;
 
 namespace slskd.Relay
 {
@@ -360,7 +361,7 @@ namespace slskd.Relay
             {
                 var (_, localFilename, _) = await Shares.ResolveFileAsync(filename);
 
-                var localFileInfo = new FileInfo(localFilename);
+                var localFileInfo = new FileInfo(localFilename).FollowSymlink();
 
                 await HubConnection.InvokeAsync(nameof(RelayHub.ReturnFileInfo), id, localFileInfo.Exists, localFileInfo.Length);
             }

--- a/src/slskd/Shares/SoulseekFileFactory.cs
+++ b/src/slskd/Shares/SoulseekFileFactory.cs
@@ -16,6 +16,7 @@
 // </copyright>
 
 using System.IO;
+using slskd.Files;
 
 namespace slskd.Shares
 {
@@ -59,7 +60,7 @@ namespace slskd.Shares
         public File Create(string filename, string maskedFilename)
         {
             var code = 1;
-            var size = new FileInfo(filename).Length;
+            var size = new FileInfo(filename).FollowSymlink().Length;
             var extension = Path.GetExtension(filename).TrimStart('.').ToLowerInvariant();
             List<FileAttribute> attributeList = default;
 

--- a/src/slskd/Transfers/Uploads/UploadService.cs
+++ b/src/slskd/Transfers/Uploads/UploadService.cs
@@ -16,6 +16,7 @@
 // </copyright>
 
 using Microsoft.Extensions.Options;
+using slskd.Files;
 using Soulseek;
 
 namespace slskd.Transfers.Uploads
@@ -212,9 +213,9 @@ namespace slskd.Transfers.Uploads
                 {
                     // if it's local, do a quick check to see if it exists to spare the caller from queueing up if the transfer is
                     // doomed to fail. for remote files, take a leap of faith.
-                    var info = new FileInfo(localFilename);
+                    var info = new FileInfo(localFilename).TryFollowSymlink();
 
-                    if (!info.Exists)
+                    if (info?.Exists is null or false)
                     {
                         Shares.RequestScan();
                         throw new NotFoundException($"The file '{localFilename}' could not be located on disk. A share scan should be performed.");


### PR DESCRIPTION
#320 

`new FileInfo(fileName).Length` reports the filesystem length of a symlink itself, which is a nonsensical value.

If a file happens to be shorter than that value, the download never finishes and client disconnects through a timeout.

If a file happens to be longer than that value, the downloaded file is truncated to the length equal to that value.

This pull requests adds code that resolves the symlink first (if it's a symlink).

I have tested the code on my Linux machine.