### PR TITLE
Add support for file symlinks

### DIFF
--- a/src/slskd/Files/FileExtensions.cs
+++ b/src/slskd/Files/FileExtensions.cs
@@ -59,25 +59,4 @@ public static class FileExtensions
 
         return (UnixFileMode)mode;
     }
-
-#nullable enable
-    public static FileInfo? TryFollowSymlink(this FileInfo fileInfo)
-    {
-        try
-        {
-            return fileInfo.FollowSymlink();
-        }
-        catch (IOException)
-        {
-            return null;
-        }
-    }
-
-    public static FileInfo FollowSymlink(this FileInfo fileInfo)
-    {
-        FileSystemInfo fileSystemInfo = fileInfo;
-        fileSystemInfo = fileSystemInfo.ResolveLinkTarget(returnFinalTarget: true) ?? fileSystemInfo;
-        return (FileInfo)fileSystemInfo;
-    }
-#nullable restore
 }

--- a/src/slskd/Files/FileService.cs
+++ b/src/slskd/Files/FileService.cs
@@ -104,7 +104,7 @@ namespace slskd.Files
             }
             catch (Exception ex) when (ex is UnauthorizedAccessException || ex is SecurityException)
             {
-                throw new UnauthorizedException($"Access to the linked file target '{info.LinkTarget}' was denied: {ex.Message}", ex);
+                throw new UnauthorizedException($"Access to the linked file '{filename}->{info.LinkTarget}' was denied: {ex.Message}", ex);
             }
             catch (Exception ex)
             {

--- a/src/slskd/Files/FileService.cs
+++ b/src/slskd/Files/FileService.cs
@@ -23,6 +23,7 @@ namespace slskd.Files
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Security;
     using System.Threading.Tasks;
     using OneOf;
     using Serilog;
@@ -49,6 +50,57 @@ namespace slskd.Files
 
         private ILogger Log { get; } = Serilog.Log.ForContext<FileService>();
         private IOptionsMonitor<Options> OptionsMonitor { get; }
+
+        /// <summary>
+        ///     Resolves an instance of <see cref="FileInfo"/> for the specified <paramref name="filename"/>, following
+        ///     any symlinks that may be present to their final target.
+        /// </summary>
+        /// <param name="filename">The fully qualified filename for which to resolve the FileInfo instance.</param>
+        /// <returns>The resolved FileInfo instance.</returns>
+        /// <exception cref="ArgumentException">Thrown if the specified filename is null or contains only whitespace.</exception>
+        /// <exception cref="UnauthorizedException">Thrown if the specified or linked file is restricted.</exception>
+        /// <exception cref="IOException">Thrown if the specified or linked file can't be accessed for some reason.</exception>
+        public virtual FileInfo ResolveFileInfo(string filename)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(filename, nameof(filename));
+
+            FileInfo info;
+
+            try
+            {
+                info = new FileInfo(filename);
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException || ex is SecurityException)
+            {
+                throw new UnauthorizedException($"Access to the file '{filename}' was denied: {ex.Message}", ex);
+            }
+            catch (Exception ex)
+            {
+                throw new IOException($"Failed to access file '{filename}': {ex.Message}", ex);
+            }
+
+            // if the above didn't throw we are guaranteed a valid instance of FileInfo regardless of whether
+            // the file exists or if it is a symlink. if it doesn't exist it can't be a symlink, so just return it
+            if (!info.Exists)
+            {
+                return info;
+            }
+
+            // LinkTarget is guaranteed to be null if the file isn't a symlink. docs:
+            //  > Gets the target path of the link located in FullName, or null if this FileSystemInfo instance doesn't represent a link.
+            if (info.LinkTarget is null)
+            {
+                return info;
+            }
+
+            // ResolveLinkTarget returns an instance of FileSystemInfo (which is being cast to FileInfo here) as long as
+            // the link itself exists (which we've checked), and regardless of whether the link target itself exists.
+            // we should only get this far if:
+            //   1) the given file exists and
+            //   2) it is a symlink, meaning
+            // this line _SHOULD_ be guaranteed to return an instance of FileInfo.
+            return (FileInfo)info.ResolveLinkTarget(returnFinalTarget: true);
+        }
 
         /// <summary>
         ///     Deletes the specified <paramref name="directories"/>.

--- a/src/slskd/Files/FileService.cs
+++ b/src/slskd/Files/FileService.cs
@@ -102,16 +102,20 @@ namespace slskd.Files
             {
                 info = (FileInfo)info.ResolveLinkTarget(returnFinalTarget: true);
             }
+            catch (Exception ex) when (ex is UnauthorizedAccessException || ex is SecurityException)
+            {
+                throw new UnauthorizedException($"Access to the linked file target '{info.LinkTarget}' was denied: {ex.Message}", ex);
+            }
             catch (Exception ex)
             {
-                Log.Error(ex, "Failed to resolve FileInfo for file '{File}': {Message}", filename, ex.Message);
-                throw new IOException($"Failed to resolve FileInfo for file '{filename}': {ex.Message}", ex);
+                Log.Error(ex, "Failed to resolve FileInfo for linked file '{File}->{Link}': {Message}", filename, info.LinkTarget, ex.Message);
+                throw new IOException($"Failed to resolve FileInfo for linked file '{filename}->{info.LinkTarget}': {ex.Message}", ex);
             }
 
             if (info is null)
             {
-                Log.Error("Resolved FileInfo for file '{File}' was unexpectedly null", filename);
-                throw new IOException($"An unexpected error was encountered while resolving FileInfo for '{filename}'");
+                Log.Error("Resolved FileInfo for linked file '{File}->{Link}' was unexpectedly null", filename, info.LinkTarget);
+                throw new IOException($"An unexpected error was encountered while resolving FileInfo for linked file '{filename}->{info.LinkTarget}'");
             }
 
             return info;

--- a/src/slskd/Files/FileService.cs
+++ b/src/slskd/Files/FileService.cs
@@ -97,8 +97,7 @@ namespace slskd.Files
             // the link itself exists (which we've checked), and regardless of whether the link target itself exists.
             // we should only get this far if:
             //   1) the given file exists and
-            //   2) it is a symlink, meaning
-            // this line _SHOULD_ be guaranteed to return an instance of FileInfo.
+            //   2) it is a symlink, meaning this line _SHOULD_ be guaranteed to return an instance of FileInfo.
             try
             {
                 info = (FileInfo)info.ResolveLinkTarget(returnFinalTarget: true);

--- a/src/slskd/Relay/RelayClient.cs
+++ b/src/slskd/Relay/RelayClient.cs
@@ -40,14 +40,17 @@ namespace slskd.Relay
         ///     Initializes a new instance of the <see cref="RelayClient"/> class.
         /// </summary>
         /// <param name="shareService"></param>
+        /// <param name="fileService"></param>
         /// <param name="optionsMonitor"></param>
         /// <param name="httpClientFactory"></param>
         public RelayClient(
             IShareService shareService,
+            FileService fileService,
             IOptionsMonitor<Options> optionsMonitor,
             IHttpClientFactory httpClientFactory)
         {
             Shares = shareService;
+            Files = fileService;
 
             HttpClientFactory = httpClientFactory;
 
@@ -64,6 +67,7 @@ namespace slskd.Relay
         /// </summary>
         public IStateMonitor<RelayClientState> StateMonitor { get; }
 
+        private FileService Files { get; }
         private SemaphoreSlim ConfigurationSyncRoot { get; } = new SemaphoreSlim(1, 1);
         private bool Disposed { get; set; }
         private IHttpClientFactory HttpClientFactory { get; }
@@ -361,7 +365,7 @@ namespace slskd.Relay
             {
                 var (_, localFilename, _) = await Shares.ResolveFileAsync(filename);
 
-                var localFileInfo = new FileInfo(localFilename).FollowSymlink();
+                var localFileInfo = Files.ResolveFileInfo(localFilename);
 
                 await HubConnection.InvokeAsync(nameof(RelayHub.ReturnFileInfo), id, localFileInfo.Exists, localFileInfo.Length);
             }
@@ -382,7 +386,7 @@ namespace slskd.Relay
                 {
                     var (_, localFilename, _) = await Shares.ResolveFileAsync(filename);
 
-                    var localFileInfo = new FileInfo(localFilename);
+                    var localFileInfo = Files.ResolveFileInfo(localFilename);
 
                     if (!localFileInfo.Exists)
                     {

--- a/src/slskd/Relay/RelayService.cs
+++ b/src/slskd/Relay/RelayService.cs
@@ -273,6 +273,7 @@ namespace slskd.Relay
         ///     Initializes a new instance of the <see cref="RelayService"/> class.
         /// </summary>
         /// <param name="waiter"></param>
+        /// <param name="fileService"></param>
         /// <param name="shareService"></param>
         /// <param name="shareRepositoryFactory"></param>
         /// <param name="optionsMonitor"></param>

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -26,6 +26,7 @@ namespace slskd.Shares
     using System.Threading;
     using System.Threading.Tasks;
     using Serilog;
+    using slskd.Files;
     using slskd.Relay;
     using Soulseek;
 
@@ -37,10 +38,12 @@ namespace slskd.Shares
         /// <summary>
         ///     Initializes a new instance of the <see cref="ShareService"/> class.
         /// </summary>
+        /// <param name="fileService"></param>
         /// <param name="shareRepositoryFactory"></param>
         /// <param name="optionsMonitor"></param>
         /// <param name="scanner"></param>
         public ShareService(
+            FileService fileService,
             IShareRepositoryFactory shareRepositoryFactory,
             IOptionsMonitor<Options> optionsMonitor,
             IShareScanner scanner = null)
@@ -58,7 +61,9 @@ namespace slskd.Shares
 
             AllRepositories = new List<IShareRepository>(new[] { repository });
 
-            Scanner = scanner ?? new ShareScanner(workerCount: options.Shares.Cache.Workers);
+            Scanner = scanner ?? new ShareScanner(
+                workerCount: options.Shares.Cache.Workers,
+                fileService: fileService);
 
             Scanner.StateMonitor.OnChange(cacheState =>
             {

--- a/src/slskd/Shares/SoulseekFileFactory.cs
+++ b/src/slskd/Shares/SoulseekFileFactory.cs
@@ -49,6 +49,16 @@ namespace slskd.Shares
         private static readonly string[] VideoExtensions = { "mkv", "ogv", "avi", "wmv", "asf", "mp4", "m4p", "m4v", "mpg", "mpe", "mpv", "mpg", "m2v" };
         private static readonly HashSet<string> SupportedExtensions = AudioExtensions.Concat(VideoExtensions).ToHashSet();
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="SoulseekFileFactory"/> class.
+        /// </summary>
+        /// <param name="fileService"></param>
+        public SoulseekFileFactory(FileService fileService)
+        {
+            Files = fileService;
+        }
+
+        private FileService Files { get; }
         private ILogger Log { get; } = Serilog.Log.ForContext<SoulseekFileFactory>();
 
         /// <summary>
@@ -60,7 +70,7 @@ namespace slskd.Shares
         public File Create(string filename, string maskedFilename)
         {
             var code = 1;
-            var size = new FileInfo(filename).FollowSymlink().Length;
+            var size = Files.ResolveFileInfo(filename).Length;
             var extension = Path.GetExtension(filename).TrimStart('.').ToLowerInvariant();
             List<FileAttribute> attributeList = default;
 


### PR DESCRIPTION
Builds on #1158 by @milleniumbug.

Closes #320 

The logic is encapsulated in the `FileService` class along with the other file I/O, as cross-platform support has been shaky in the past and I don't trust it fully.  Symlink support in .NET is fairly new and I was able to find at least 3 open issues in the dotnet runtime repository related to erroneous results, and I suspect issues will be encountered in the future.

I tested this with both directory (which were working already) and file symlinks, confirming that both browse and search responses return the correct file size, and that downloads of each complete as expected.  I haven't tested with the relay, but there's no reason it should be any different than regular uploads.

Moving forward (and this is more of a note to myself I guess), no application logic should attempt to resolve `FileInfo` the conventional way; `new FileInfo(<path>)`.  Instead it should use the `ResolveFileInfo()` method from the `FileService` class, which navigates symlinks defensively.