### PR TITLE
Fix 32 bit integer overflow when computing byte limits

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -575,11 +575,11 @@ namespace slskd
             {
                 var files = false;
                 var megabytes = false;
-                var byteLimit = options?.Megabytes ?? defaults?.Megabytes;
+                var byteLimitInMegabytes = options?.Megabytes ?? defaults?.Megabytes;
 
-                if (byteLimit is not null && (stats.Bytes + size) > (byteLimit * 1000 * 1000))
+                if (byteLimitInMegabytes is not null && (stats.Bytes + size) > (byteLimitInMegabytes * 1000L * 1000L))
                 {
-                    Log.Debug("Projected bytes {Bytes} exceeds limit {Limit}", stats.Bytes + size, byteLimit * 1000 * 1000);
+                    Log.Debug("Projected bytes {Bytes} exceeds limit {Limit}", stats.Bytes + size, byteLimitInMegabytes * 1000L * 1000L);
                     megabytes = true;
                 }
 


### PR DESCRIPTION
A cast from 32 bit to 64 bit integers when computing bytes from a configuration value specified in megabytes would result in an overflow for higher values.  This PR converts the operands of that megabyte conversion to 64 bit integers, which yields a 64 bit integer when multiplied with a 32 bit value.

Closes #1174 