### PR TITLE
fix(docker): Allow container to be ran as read-only filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,8 @@ VOLUME /app
 
 HEALTHCHECK --interval=60s --timeout=3s --start-period=5s --retries=3 CMD wget -q -O - http://localhost:${SLSKD_HTTP_PORT}/health
 
-ENV DOTNET_BUNDLE_EXTRACT_BASE_DIR=/.net \
+ENV COMPlus_EnableDiagnostics="0" \
+  DOTNET_BUNDLE_EXTRACT_BASE_DIR=/.net \
   DOTNET_gcServer=0 \
   DOTNET_gcConcurrent=1 \
   DOTNET_GCHeapHardLimit=1F400000	\


### PR DESCRIPTION
This is env var is required for those that have a strict security policy on running containers. I don't see a downside to enabling this otherwise and it seems like a common issue with dotnet based apps running in containers.

More info here

https://github.com/Radarr/Radarr/issues/7030#issuecomment-1039689518
https://github.com/dotnet/runtime/issues/9336
https://github.com/recyclarr/recyclarr/pull/231