### PR TITLE
Remember theme setting between page loads

### DIFF
--- a/src/web/src/components/App.jsx
+++ b/src/web/src/components/App.jsx
@@ -149,8 +149,8 @@ class App extends Component {
           'change',
           (event) => event.matches && this.setState({ theme: 'light' }),
         );
-
     }
+
     this.init();
   }
 
@@ -188,9 +188,9 @@ class App extends Component {
           await appHub.start();
         }
 
-        let savedTheme = this.getSavedTheme();
+        const savedTheme = this.getSavedTheme();
         if (savedTheme != null) {
-          this.setState({theme: savedTheme});
+          this.setState({ theme: savedTheme });
         }
 
         this.setState({
@@ -206,15 +206,15 @@ class App extends Component {
   };
 
   getSavedTheme = () => {
-    return localStorage.getItem("slskd-theme");
+    return localStorage.getItem('slskd-theme');
   };
 
   toggleTheme = () => {
     this.setState((state) => {
-      let newTheme = state.theme === 'dark' ? 'light' : 'dark';
-      localStorage.setItem("slskd-theme", newTheme);
-      return {theme: newTheme}
-    })
+      const newTheme = state.theme === 'dark' ? 'light' : 'dark';
+      localStorage.setItem('slskd-theme', newTheme);
+      return { theme: newTheme };
+    });
   };
 
   handleLogin = (username, password, rememberMe) => {
@@ -258,9 +258,10 @@ class App extends Component {
       initialized,
       login,
       retriesExhausted,
-      theme = this.getSavedTheme() || (window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light'),
+      theme = this.getSavedTheme() ||
+        (window.matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'dark'
+          : 'light'),
     } = this.state;
     const {
       pendingReconnect,
@@ -403,9 +404,7 @@ class App extends Component {
               className="right"
               inverted
             >
-              <Menu.Item
-                onClick={() => this.toggleTheme()}
-              >
+              <Menu.Item onClick={() => this.toggleTheme()}>
                 <Icon name="theme" />
                 Theme
               </Menu.Item>

--- a/src/web/src/components/App.jsx
+++ b/src/web/src/components/App.jsx
@@ -136,18 +136,21 @@ class App extends Component {
   }
 
   componentDidMount() {
-    window
-      .matchMedia('(prefers-color-scheme: dark)')
-      .addEventListener(
-        'change',
-        (event) => event.matches && this.setState({ theme: 'dark' }),
-      );
-    window
-      .matchMedia('(prefers-color-scheme: light)')
-      .addEventListener(
-        'change',
-        (event) => event.matches && this.setState({ theme: 'light' }),
-      );
+    if (this.getSavedTheme() == null) {
+      window
+        .matchMedia('(prefers-color-scheme: dark)')
+        .addEventListener(
+          'change',
+          (event) => event.matches && this.setState({ theme: 'dark' }),
+        );
+      window
+        .matchMedia('(prefers-color-scheme: light)')
+        .addEventListener(
+          'change',
+          (event) => event.matches && this.setState({ theme: 'light' }),
+        );
+
+    }
     this.init();
   }
 
@@ -185,6 +188,11 @@ class App extends Component {
           await appHub.start();
         }
 
+        let savedTheme = this.getSavedTheme();
+        if (savedTheme != null) {
+          this.setState({theme: savedTheme});
+        }
+
         this.setState({
           error: false,
         });
@@ -195,6 +203,18 @@ class App extends Component {
         this.setState({ initialized: true });
       }
     });
+  };
+
+  getSavedTheme = () => {
+    return localStorage.getItem("slskd-theme");
+  };
+
+  toggleTheme = () => {
+    this.setState((state) => {
+      let newTheme = state.theme === 'dark' ? 'light' : 'dark';
+      localStorage.setItem("slskd-theme", newTheme);
+      return {theme: newTheme}
+    })
   };
 
   handleLogin = (username, password, rememberMe) => {
@@ -238,9 +258,9 @@ class App extends Component {
       initialized,
       login,
       retriesExhausted,
-      theme = window.matchMedia('(prefers-color-scheme: dark)').matches
+      theme = this.getSavedTheme() || (window.matchMedia('(prefers-color-scheme: dark)').matches
         ? 'dark'
-        : 'light',
+        : 'light'),
     } = this.state;
     const {
       pendingReconnect,
@@ -384,9 +404,7 @@ class App extends Component {
               inverted
             >
               <Menu.Item
-                onClick={() =>
-                  this.setState({ theme: theme === 'dark' ? 'light' : 'dark' })
-                }
+                onClick={() => this.toggleTheme()}
               >
                 <Icon name="theme" />
                 Theme


### PR DESCRIPTION
Previously, the theme setting would default to the device preference on each load. So, if a user preferred light theme for slskd despite having a dark device theme, they would need to toggle the theme on each page load. By saving the theme preference in localStorage, we can override the device default with the user's manual preference.

Addresses my main concern in issue #1198.

This is a re-implementaiton of the (abandoned?) PR #1065 but implements the feature using `localStorage` per the suggestion in [the comment on that PR](https://github.com/slskd/slskd/pull/1065#issuecomment-1913637361). 
