### PR TITLE
Rssume remote filenames use a backslash, unless forward slashes are present

### DIFF
--- a/src/slskd/Common/CommonExtensions.cs
+++ b/src/slskd/Common/CommonExtensions.cs
@@ -133,15 +133,46 @@ namespace slskd
         }
 
         /// <summary>
+        ///     Makes a best-guess determination of the directory separator character used by a remote system,
+        ///     based on the characters present in the specified <paramref name="remoteFilename"/>.
+        /// </summary>
+        /// <param name="remoteFilename">The fully qualified remote filename to inspect.</param>
+        /// <returns>The guessed directory separator.</returns>
+        public static char GuessDirectorySeparator(this string remoteFilename)
+        {
+            // forward slash is a forbidden character on all operating systems; if the specified string contains it,
+            // then it is coming from the OS's directory separator
+            if (remoteFilename.Contains('/'))
+            {
+                return '/';
+            }
+
+            // if the given string doesn't contain any forward slashes, it either lacks a directory separator at all
+            // (potentially impossible?) or it is using backspaces. backspaces are used by all major clients, so
+            // this should be a safe assumption.
+            return '\\';
+        }
+
+        /// <summary>
+        ///     Returns the directory name of the given <paramref name="path"/>, using the specified <paramref name="directorySeparator"/>
+        ///     to split and join directories and filename.
+        /// </summary>
+        /// <param name="path">The path for which to return the directory name.</param>
+        /// <param name="directorySeparator">The directory separator character.</param>
+        /// <returns>The specified path, less the last segment.</returns>
+        public static string GetDirectoryName(this string path, char directorySeparator)
+        {
+            return string.Join(directorySeparator, path.Split(directorySeparator).SkipLast(1));
+        }
+
+        /// <summary>
         ///     Returns the directory from the given path, regardless of separator format.
         /// </summary>
         /// <param name="path">The path.</param>
         /// <returns>The directory.</returns>
         public static string DirectoryName(this string path)
         {
-            var separator = path.Contains('\\') ? '\\' : '/';
-            var parts = path.Split(separator);
-            return string.Join(separator, parts.Take(parts.Length - 1));
+            return path.GetDirectoryName(path.GuessDirectorySeparator());
         }
 
         /// <summary>


### PR DESCRIPTION
This change was made in #1215 but has the potential to screw everything up, so I'm going to deploy it alone and do some testing in the canary to limit the blast radius.