### PR TITLE
Fix search filter config docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -867,17 +867,15 @@ web:
         cidr: 0.0.0.0/0,::/0
 ```
 
-# Filters
+# Search Filters
 
-A number of filters can be configured to control various aspects of how the application interacts with the Soulseek network.
-
-Share filters can be used to prevent certain types of files from being shared.  This option is an array that can take any number of filters.  Filters must be a valid regular expression; a few examples are included below and in the example configuration included with the application, but the list is empty by default.
+Search filters can be used to prevent certain types of search requests from being performed against your shares.  This option is an array that can take any number of filters.  Filters must be a valid regular expression; a few examples are included below and in the example configuration included with the application, but the list is empty by default.
 
 Filter expressions are case insensitive by default.
 
 | Command Line              | Environment Variable    | Description                                                           |
 | ------------------------- | ----------------------- | --------------------------------------------------------------------- |
-| `--share-filter`          | `SLSKD_SHARE_FILTER`          | A list of regular expressions used to filter files from shares        |
+| `--search-request-filter` | `SEARCH_REQUEST_FILTER` | A list of regular expressions used to filter incoming search requests |
 
 #### **YAML**
 ```yaml


### PR DESCRIPTION
Preivously the config docs for search filters used the same text from share filters (possibly due to a copy and paste mistake?). This PR fixes that and makes clear what the search filters config actually does.