### PR TITLE
Add the ability to run user-defined scripts when application events are raised

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -213,6 +213,16 @@
 #       username: ~
 #       password: ~
 # integration:
+#   scripts:
+#     my_post_download_script:
+#       on:
+#         - DownloadFileComplete
+#         - DownloadDirectoryComplete
+#       run: data/my_script.sh --json-to-process $EVENT
+#     my_logging_script:
+#       on:
+#        - All
+#       run: data/log_slskd_events.sh $EVENT
 #   ftp:
 #     enabled: false
 #     address: ~
@@ -233,13 +243,3 @@
 #     notify_on_room_mention: true
 #     retry_attempts: 3
 #     cooldown_time: 900000
-# scripts:
-#   my_post_download_script:
-#     on:
-#       - DownloadFileComplete
-#       - DownloadDirectoryComplete
-#     run: data/my_script.sh --json-to-process $EVENT
-#   my_logging_script:
-#     on:
-#      - All
-#     run: data/log_slskd_events.sh $EVENT

--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -233,3 +233,13 @@
 #     notify_on_room_mention: true
 #     retry_attempts: 3
 #     cooldown_time: 900000
+# scripts:
+#   my_post_download_script:
+#     on:
+#       - DownloadFileComplete
+#       - DownloadDirectoryComplete
+#     run: data/my_script.sh --json-to-process $EVENT
+#   my_logging_script:
+#     on:
+#      - All
+#     run: data/log_slskd_events.sh $EVENT

--- a/docs/config.md
+++ b/docs/config.md
@@ -923,7 +923,7 @@ retention:
 
 User-defined scripts can be configured to run when application events are raised.  Scripts are given a name (useful for troubleshooting!), a list of triggering events, and a `run` command that's used to execute the script.
 
-The `run` command must be at least two words, with the first word identifying the executable to run and the rest of the string being the command and arguments that will be passed to the executable when the script is run.  The executable needs to be on the system's PATH, otherwise it must be the fully qualified path to the file on disk.
+The `run` command must be at least one word, with the first word identifying the executable to run and the rest of the string being the command and arguments that will be passed to the executable when the script is run.  The executable needs to be on the system's PATH, otherwise it must be the fully qualified path to the file on disk.
 
 A reserved placeholder value `$DATA` is replaced with the stringified JSON data associated with the event that caused the script to run.  It's the responsibility of the script to parse and handle this JSON.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -919,6 +919,29 @@ retention:
 
 # Integrations
 
+## User-Defined Scripts
+
+User-defined scripts can be configured to run when application events are raised.  Scripts are given a name (useful for troubleshooting!), a list of triggering events, and a `run` command that's used to execute the script.
+
+The `run` command must be at least two words, with the first word identifying the executable to run and the rest of the string being the command and arguments that will be passed to the executable when the script is run.  The executable needs to be on the system's PATH, otherwise it must be the fully qualified path to the file on disk.
+
+A reserved placeholder value `$DATA` is replaced with the stringified JSON data associated with the event that caused the script to run.  It's the responsibility of the script to parse and handle this JSON.
+
+#### **YAML**
+```yaml
+integration:
+  scripts:
+    my_post_download_script:
+      on:
+        - DownloadFileComplete
+        - DownloadDirectoryComplete
+      run: /bin/sh data/my_script.sh --json-to-process "$DATA" # Linux/macOS
+    my_logging_script:
+      on:
+       - All
+      run: cmd.exe echo $DATA >> event_log.txt # Windows
+```
+
 ## FTP
 
 Files can be uploaded to a remote FTP server upon completion. Files are uploaded to the server and remote path specified using the directory and filename with which they were downloaded; the FTP will match the layout of the local disk.

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -32,6 +32,7 @@ namespace slskd
     using NetTools;
     using slskd.Authentication;
     using slskd.Configuration;
+    using slskd.Events;
     using slskd.Relay;
     using slskd.Shares;
     using slskd.Validation;
@@ -2005,6 +2006,12 @@ namespace slskd
         public class IntegrationOptions
         {
             /// <summary>
+            ///     Gets script configuration.
+            /// </summary>
+            [Validate]
+            public Dictionary<string, ScriptOptions> Scripts { get; init; } = [];
+
+            /// <summary>
             ///     Gets FTP options.
             /// </summary>
             [Validate]
@@ -2015,6 +2022,25 @@ namespace slskd
             /// </summary>
             [Validate]
             public PushbulletOptions Pushbullet { get; init; } = new PushbulletOptions();
+
+            /// <summary>
+            ///     Script configuration.
+            /// </summary>
+            public class ScriptOptions
+            {
+                /// <summary>
+                ///     Gets the list of Event types that trigger the script.
+                /// </summary>
+                [Enum(typeof(EventType))]
+                public string[] On { get; init; } = Array.Empty<string>();
+
+                /// <summary>
+                ///     Gets the shell script to invoke.
+                /// </summary>
+                [StringLength(int.MaxValue, MinimumLength = 1)]
+                [NotNullOrWhiteSpace]
+                public string Run { get; init; }
+            }
 
             /// <summary>
             ///     FTP options.

--- a/src/slskd/Events/EventBus.cs
+++ b/src/slskd/Events/EventBus.cs
@@ -83,7 +83,7 @@ public class EventBus
         // if something throws it will be logged and the consumer can figure it out
         if (Subscriptions.TryGetValue(typeof(T), out var subscribers))
         {
-            Log.Debug("{Count} subscriber(s) for {Type}: {Names}", subscribers.Count, typeof(T), string.Join(", ", subscribers.Keys));
+            Log.Debug("{Count} subscriber(s) for {Type}: {Names}", subscribers.Count, data.Type, string.Join(", ", subscribers.Keys));
 
             // we don't care about any of these tasks; contractually we are only obligated to invoke them
             _ = Task.WhenAll(subscribers.Select(subscriber =>
@@ -98,7 +98,7 @@ public class EventBus
         // broadcast the event to catch-all subscribers of type Event; listening for all types
         if (Subscriptions.TryGetValue(typeof(Event), out subscribers))
         {
-            Log.Debug("{Count} catch-all subscriber(s) for {Type}: {Names}", subscribers.Count, typeof(Event), string.Join(", ", subscribers.Keys));
+            Log.Debug("{Count} catch-all subscriber(s): {Names}", subscribers.Count, string.Join(", ", subscribers.Keys));
 
             // we don't care about any of these tasks; contractually we are only obligated to invoke them
             _ = Task.WhenAll(subscribers.Select(subscriber =>

--- a/src/slskd/Events/EventsDbContext.cs
+++ b/src/slskd/Events/EventsDbContext.cs
@@ -34,6 +34,11 @@ public class EventsDbContext : DbContext
     {
         modelBuilder
             .Entity<EventRecord>()
+            .Property(e => e.Type)
+            .HasConversion<string>();
+
+        modelBuilder
+            .Entity<EventRecord>()
             .Property(e => e.Timestamp)
             .HasConversion(v => v, v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
     }

--- a/src/slskd/Events/Types/EventRecord.cs
+++ b/src/slskd/Events/Types/EventRecord.cs
@@ -19,7 +19,6 @@ namespace slskd.Events;
 
 using System;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -31,7 +30,7 @@ using Microsoft.EntityFrameworkCore;
 public record EventRecord
 {
     public DateTime Timestamp { get; init; } = DateTime.UtcNow;
-    public string Type { get; private set; }
+    public EventType Type { get; private set; }
     public string Data { get; init; }
     [Key]
     public Guid Id { get; private set; }
@@ -61,10 +60,6 @@ public record EventRecord
     public static EventRecord From<T>(Event e)
         where T : Event
     {
-        // this will be 'slskd.NameOfEvent'; we want to chop off 'slskd.' and 'Event' = 'NameOf'
-        var type = e.GetType().Name.Split('.').TakeLast(1).First();
-        type = type.Substring(0, type.Length - "Event".Length); // chop off "Event" suffix
-
         // construct the data for the record by serializing the event and removing redundant properties
         var json = JsonSerializer.Serialize(e as T, JsonSerializerOptions);
         var data = JsonNode.Parse(json).AsObject();
@@ -76,7 +71,7 @@ public record EventRecord
         return new EventRecord
         {
             Timestamp = e.Timestamp,
-            Type = type,
+            Type = e.Type,
             Id = e.Id,
             Data = data.ToJsonString(JsonSerializerOptions),
         };

--- a/src/slskd/Events/Types/Events.cs
+++ b/src/slskd/Events/Types/Events.cs
@@ -24,10 +24,20 @@ public abstract record Event
 {
     public Guid Id { get; } = Guid.NewGuid();
     public DateTime Timestamp { get; init; } = DateTime.UtcNow;
+    public abstract EventType Type { get; }
+}
+
+public enum EventType
+{
+    None = 0,
+    All = 1,
+    DownloadFileComplete = 2,
+    DownloadDirectoryComplete = 3,
 }
 
 public sealed record DownloadFileCompleteEvent : Event
 {
+    public override EventType Type => EventType.DownloadFileComplete;
     public string LocalFilename { get; init; }
     public string RemoteFilename { get; init; }
     public Transfer Transfer { get; init; }
@@ -35,6 +45,7 @@ public sealed record DownloadFileCompleteEvent : Event
 
 public sealed record DownloadDirectoryCompleteEvent : Event
 {
+    public override EventType Type => EventType.DownloadDirectoryComplete;
     public string LocalDirectoryName { get; init; }
     public string RemoteDirectoryName { get; init; }
     public string Username { get; init; }

--- a/src/slskd/Events/Types/Events.cs
+++ b/src/slskd/Events/Types/Events.cs
@@ -30,7 +30,7 @@ public abstract record Event
 public enum EventType
 {
     None = 0,
-    All = 1,
+    Any = 1,
     DownloadFileComplete = 2,
     DownloadDirectoryComplete = 3,
 }

--- a/src/slskd/Integrations/Scripts/ScriptService.cs
+++ b/src/slskd/Integrations/Scripts/ScriptService.cs
@@ -67,6 +67,7 @@ public class ScriptService
 
                 try
                 {
+                    // todo: update options validation to ensure run strings have at least 2 words
                     var run = script.Value.Run;
                     var executable = run.Split(" ", 2)[0];
                     var args = run.Split(" ", 2)[1].Replace("$DATA", data.ToJson());

--- a/src/slskd/Integrations/Scripts/ScriptService.cs
+++ b/src/slskd/Integrations/Scripts/ScriptService.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Options;
 namespace slskd.Integrations.Scripts;
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Serilog;
 using slskd.Events;
@@ -45,6 +46,18 @@ public class ScriptService
 
     private async Task HandleEvent(Event data)
     {
-        Console.WriteLine($"--------------------{nameof(HandleEvent)}");
+        Log.Debug("Handling event {Event}", data);
+
+        bool EqualsThisEvent(string type) => type.Equals(data.Type.ToString(), StringComparison.OrdinalIgnoreCase);
+        bool EqualsLiterallyAnyEvent(string type) => type.Equals(EventType.Any.ToString(), StringComparison.OrdinalIgnoreCase);
+
+        var options = OptionsMonitor.CurrentValue;
+        var scriptsTriggeredByThisEventType = options.Integration.Scripts
+            .Where(kvp => kvp.Value.On.Any(EqualsThisEvent) || kvp.Value.On.Any(EqualsLiterallyAnyEvent));
+
+        foreach (var script in scriptsTriggeredByThisEventType)
+        {
+            Console.WriteLine($"--------------------{script.Key}");
+        }
     }
 }

--- a/src/slskd/Integrations/Scripts/ScriptService.cs
+++ b/src/slskd/Integrations/Scripts/ScriptService.cs
@@ -1,0 +1,50 @@
+// <copyright file="ScriptService.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+using Microsoft.Extensions.Options;
+
+namespace slskd.Integrations.Scripts;
+
+using System;
+using System.Threading.Tasks;
+using Serilog;
+using slskd.Events;
+
+/// <summary>
+///     Handles the invocation of shell scripts.
+/// </summary>
+public class ScriptService
+{
+    public ScriptService(EventBus eventBus, IOptionsMonitor<Options> optionsMonitor)
+    {
+        Events = eventBus;
+        OptionsMonitor = optionsMonitor;
+
+        Events.Subscribe<Event>(nameof(ScriptService), HandleEvent);
+
+        Log.Debug("{Service} initialized", nameof(ScriptService));
+    }
+
+    private ILogger Log { get; } = Serilog.Log.ForContext<ScriptService>();
+    private IOptionsMonitor<Options> OptionsMonitor { get; }
+    private EventBus Events { get; }
+
+    private async Task HandleEvent(Event data)
+    {
+        Console.WriteLine($"--------------------{nameof(HandleEvent)}");
+    }
+}

--- a/src/slskd/Integrations/Scripts/ScriptService.cs
+++ b/src/slskd/Integrations/Scripts/ScriptService.cs
@@ -67,10 +67,18 @@ public class ScriptService
 
                 try
                 {
-                    // todo: update options validation to ensure run strings have at least 2 words
                     var run = script.Value.Run;
-                    var executable = run.Split(" ", 2)[0];
-                    var args = run.Split(" ", 2)[1].Replace("$DATA", data.ToJson());
+
+                    // split the string into at most 2 parts, leaving part [0] the executable and part [1] the rest of the string, but possibly null
+                    var parts = run.Split(" ", count: 2, options: StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
+
+                    var executable = parts[0];
+                    string args = default;
+
+                    if (parts.Length > 1)
+                    {
+                        args = parts[1].Replace("$DATA", data.ToJson());
+                    }
 
                     Log.Debug("Running script '{Script}': {Run}", script.Key, run);
                     var sw = Stopwatch.StartNew();
@@ -87,7 +95,12 @@ public class ScriptService
                     };
 
                     process.Start();
-                    process.StandardInput.WriteLine($"{args}");
+
+                    if (args is not null)
+                    {
+                        process.StandardInput.WriteLine(args);
+                    }
+
                     process.StandardInput.WriteLine("exit");
 
                     process.WaitForExit();

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -60,6 +60,7 @@ namespace slskd
     using slskd.Files;
     using slskd.Integrations.FTP;
     using slskd.Integrations.Pushbullet;
+    using slskd.Integrations.Scripts;
     using slskd.Messaging;
     using slskd.Relay;
     using slskd.Search;
@@ -484,6 +485,10 @@ namespace slskd
 
                 var app = builder.Build();
 
+                // hack: services that exist only to subscribe to the event bus are not referenced by anything else
+                //       and are thus never instantiated.  force a reference here so they are created.
+                _ = app.Services.GetService<ScriptService>();
+
                 app.ConfigureAspDotNetPipeline();
 
                 if (OptionsAtStartup.Flags.NoStart)
@@ -553,7 +558,6 @@ namespace slskd
             services.AddHostedService(p => p.GetRequiredService<IApplication>());
 
             services.AddSingleton<IWaiter, Waiter>();
-
             services.AddSingleton<IConnectionWatchdog, ConnectionWatchdog>();
 
             if (OptionsAtStartup.Flags.Volatile)
@@ -577,6 +581,8 @@ namespace slskd
 
             services.AddSingleton<EventService>();
             services.AddSingleton<EventBus>();
+
+            services.AddSingleton<ScriptService>();
 
             services.AddSingleton<IBrowseTracker, BrowseTracker>();
             services.AddSingleton<IRoomTracker, RoomTracker>(_ => new RoomTracker(messageLimit: 250));


### PR DESCRIPTION
User-defined scripts can be configured to run when application events are raised.  Scripts are given a name (useful for troubleshooting!), a list of triggering events, and a `run` command that's used to execute the script.

The `run` command must be at least one word, with the first word identifying the executable to run and the rest of the string being the command and arguments that will be passed to the executable when the script is run.  The executable needs to be on the system's PATH, otherwise it must be the fully qualified path to the file on disk.

A reserved placeholder value `$DATA` is replaced with the stringified JSON data associated with the event that caused the script to run.  It's the responsibility of the script to parse and handle this JSON.

Here are a few examples:

```yaml
integration:
  scripts:
    my_post_download_script:
      on:
        - DownloadFileComplete
        - DownloadDirectoryComplete
      run: /bin/sh data/my_script.sh --json-to-process "$DATA" # Linux/macOS
    my_logging_script:
      on:
       - All
      run: cmd.exe echo $DATA >> event_log.txt # Windows
```

In these examples, `my_post_download_script` will run when either the `DownloadFileComplete` or `DownloadDirectoryComplete` events are raised, and will execute a bash script `my_script.sh`, passing the JSON data in the `--json-to-process` argument.

`my_logging_script` is configured to run on the special event `All`, which means each and every event, including future events.  This script will use the `cmd.exe` executable on Windows to append the JSON data to a text file.

I'll go on record now and say that configuring scripts to run on `All` is a _bad idea_ for any case other than general purpose event logging, as additional events will be added in the future, and these may be extremely 'chatty'.  Use at your own risk!