### PR TITLE
Fix a copy/paste mistake in search filter documentation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -867,7 +867,9 @@ web:
         cidr: 0.0.0.0/0,::/0
 ```
 
-# Search Filters
+# Filters
+
+## Search Filters
 
 Search filters can be used to prevent certain types of search requests from being performed against your shares.  This option is an array that can take any number of filters.  Filters must be a valid regular expression; a few examples are included below and in the example configuration included with the application, but the list is empty by default.
 
@@ -882,7 +884,7 @@ Filter expressions are case insensitive by default.
 filters:
   search:
     request:
-      - ^.{1,2}$
+      - ^.{1,2}$ # discard any requests shorter than 3 characters
 ```
 
 # Data Retention

--- a/docs/config.md
+++ b/docs/config.md
@@ -887,6 +887,7 @@ filters:
   search:
     request:
       - ^.{1,2}$ # discard any requests shorter than 3 characters
+      - ^(\.?pdf|\.?docx|\.?xlsx)$ # discard any requests that might be looking for sensitive documents
 ```
 
 # Data Retention

--- a/docs/config.md
+++ b/docs/config.md
@@ -869,6 +869,8 @@ web:
 
 # Filters
 
+A number of filters can be configured to control various aspects of how the application interacts with the Soulseek network.
+
 ## Search Filters
 
 Search filters can be used to prevent certain types of search requests from being performed against your shares.  This option is an array that can take any number of filters.  Filters must be a valid regular expression; a few examples are included below and in the example configuration included with the application, but the list is empty by default.


### PR DESCRIPTION
Follow up to #1224 that tweaks the headings and adds more examples (with an explanation of what they are!)

Thanks again @nhawke 