### PR TITLE
Add the ability to call HTTP endpoints (webhooks) when application events are raised

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -218,13 +218,18 @@
 #       on:
 #         - DownloadFileComplete
 #       call:
-#         url: http://192.168.1.42:8080/slskd_webhook
+#         url: https://192.168.1.42:8080/slskd_webhook
 #         headers:
-#           - name: x-api-key
+#           - name: X-API-Key
 #             value: foobar1234
-#           - name: user-agent
-#             value: slskd/1.0
-#         ignore_certificate_errors: true
+#           - name: Authorization
+#             value: Bearer eyJ...ssw5c
+#           - name: User-Agent
+#             value: slskd/0.0
+#         ignore_certificate_errors: false
+#       timeout: 5000 # in milliseconds
+#       retry:
+#         attempts: 3
 #   scripts:
 #     my_post_download_script:
 #       on:

--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -234,7 +234,7 @@
 #     my_logging_script:
 #       on:
 #        - All
-#       run: data/log_slskd_events.sh $EVENT
+#       run: data/log_slskd_events.sh $DATA
 #   ftp:
 #     enabled: false
 #     address: ~

--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -213,6 +213,18 @@
 #       username: ~
 #       password: ~
 # integration:
+#   webhooks:
+#     my_webhook:
+#       on:
+#         - DownloadFileComplete
+#       call:
+#         url: http://192.168.1.42:8080/slskd_webhook
+#         headers:
+#           - name: x-api-key
+#             value: foobar1234
+#           - name: user-agent
+#             value: slskd/1.0
+#         ignore_certificate_errors: true
 #   scripts:
 #     my_post_download_script:
 #       on:

--- a/docs/config.md
+++ b/docs/config.md
@@ -922,6 +922,41 @@ retention:
 
 # Integrations
 
+## Webhooks
+
+Webhooks (outbound HTTP requests) can be configured to be called when application events are raised.  Webhooks are given a name (useful for troubleshooting!), a list of triggering events, a `call` configuration that defines the HTTP request to be made, and timeout and retry configuration.
+
+Webhook HTTP requests are always a `POST`, and will always include the event data in the body, serialized as JSON.  Users define a fully-qualified endpoint address, an optional collection of headers, and an optional flag to ignore HTTPS errors caused by invalid (e.g. self signed) certificates.
+
+If unconfigured, the default timeout for requests is 5 seconds, and each request will be attempted only once per event.
+
+#### **YAML**
+```yaml
+integration:
+  webhooks:
+    my_basic_webhook_using_defaults:
+      on:
+        - All
+      call:
+        url: http://localhost:4224
+    my_webhook_using_detailed_config:
+      on:
+        - DownloadFileComplete
+      call:
+        url: https://192.168.1.42:8080/slskd_webhook
+        headers:
+          - name: X-API-Key # if using API key style authentication
+            value: foobar1234
+          - name: Authorization # if using JWT authentication
+            value: Bearer eyJ...ssw5c
+          - name: User-Agent # can be useful!
+            value: slskd/0.0
+        ignore_certificate_errors: true # defaults to false
+      timeout: 5000 # in milliseconds
+      retry:
+        attempts: 3
+```
+
 ## User-Defined Scripts
 
 User-defined scripts can be configured to run when application events are raised.  Scripts are given a name (useful for troubleshooting!), a list of triggering events, and a `run` command that's used to execute the script.

--- a/src/slskd/Core/API/Controllers/ApplicationController.cs
+++ b/src/slskd/Core/API/Controllers/ApplicationController.cs
@@ -26,6 +26,7 @@ namespace slskd.Core.API
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Hosting;
+    using Serilog;
 
     /// <summary>
     ///     Application.
@@ -53,6 +54,7 @@ namespace slskd.Core.API
         private IStateMonitor<State> ApplicationStateMonitor { get; }
         private IOptionsMonitor<Options> OptionsMonitor { get; }
         private IHostApplicationLifetime Lifetime { get; }
+        private ILogger Log { get; } = Serilog.Log.ForContext<ApplicationController>();
 
         /// <summary>
         ///     Gets the current state of the application.
@@ -148,6 +150,14 @@ namespace slskd.Core.API
             var file = await dumper.DumpAsync();
 
             return PhysicalFile(file, "application/octet-stream", "slskd.dmp");
+        }
+
+        [HttpPost("loopback")]
+        [Authorize(Policy = AuthPolicy.Any)]
+        public IActionResult Loopback([FromBody] object body)
+        {
+            Log.Information("Loopback POST: {Body}", body);
+            return Ok();
         }
     }
 }

--- a/src/slskd/Core/Constants.cs
+++ b/src/slskd/Core/Constants.cs
@@ -1,0 +1,23 @@
+// <copyright file="Constants.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd;
+
+public static class Constants
+{
+    public static readonly string IgnoreCertificateErrors = nameof(IgnoreCertificateErrors);
+}

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -2044,13 +2044,25 @@ namespace slskd
                 ///     Gets details about the webhook call.
                 /// </summary>
                 [Validate]
-                public WebhookDetails Call { get; init; } = new WebhookDetails();
+                public WebhookHttpOptions Call { get; init; } = new WebhookHttpOptions();
+
+                /// <summary>
+                ///     Gets the time to wait before timing out, in milliseconds.
+                /// </summary>
+                [Range(500, int.MaxValue)]
+                public int Timeout { get; init; } = 5000;
+
+                /// <summary>
+                ///     Gets the retry configuration.
+                /// </summary>
+                [Validate]
+                public RetryOptions Retry { get; init; } = new RetryOptions();
             }
 
             /// <summary>
-            ///     Webhook details.
+            ///     Webhook HTTP options.
             /// </summary>
-            public class WebhookDetails : IValidatableObject
+            public class WebhookHttpOptions : IValidatableObject
             {
                 /// <summary>
                 ///     Gets the fully qualified URL for the webhook.
@@ -2062,7 +2074,7 @@ namespace slskd
                 ///     Gets the HTTP headers to include with the webhook.
                 /// </summary>
                 [Validate]
-                public WebhookDetailHeader[] Headers { get; init; } = [];
+                public WebhookHttpHeader[] Headers { get; init; } = [];
 
                 /// <summary>
                 ///     Gets a value indicating whether HTTPS certificate errors should be ignored.
@@ -2082,11 +2094,33 @@ namespace slskd
                 }
             }
 
-            public class WebhookDetailHeader
+            /// <summary>
+            ///     Webhook HTTP header configuration.
+            /// </summary>
+            public class WebhookHttpHeader
             {
+                /// <summary>
+                ///     Gets the name of the header.
+                /// </summary>
                 [NotNullOrWhiteSpace]
                 public string Name { get; init; }
+
+                /// <summary>
+                ///     Gets the header's value.
+                /// </summary>
                 public string Value { get; init; }
+            }
+
+            /// <summary>
+            ///     Retry configuration.
+            /// </summary>
+            public class RetryOptions
+            {
+                /// <summary>
+                ///     Gets the number of attempts to make before failing.
+                /// </summary>
+                [Range(1, int.MaxValue)]
+                public int Attempts { get; init; } = 1;
             }
 
             /// <summary>

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -2062,7 +2062,7 @@ namespace slskd
                 ///     Gets the HTTP headers to include with the webhook.
                 /// </summary>
                 [Validate]
-                public IEnumerable<WebhookDetailHeader> Headers { get; init; } = [];
+                public WebhookDetailHeader[] Headers { get; init; } = [];
 
                 /// <summary>
                 ///     Gets a value indicating whether HTTPS certificate errors should be ignored.

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -2006,6 +2006,12 @@ namespace slskd
         public class IntegrationOptions
         {
             /// <summary>
+            ///     Gets webhook configuration.
+            /// </summary>
+            [Validate]
+            public Dictionary<string, WebhookOptions> Webhooks { get; init; } = [];
+
+            /// <summary>
             ///     Gets script configuration.
             /// </summary>
             [Validate]
@@ -2022,6 +2028,66 @@ namespace slskd
             /// </summary>
             [Validate]
             public PushbulletOptions Pushbullet { get; init; } = new PushbulletOptions();
+
+            /// <summary>
+            ///     Webhook configuration.
+            /// </summary>
+            public class WebhookOptions
+            {
+                /// <summary>
+                ///     Gets the list of Event types that trigger the webhook.
+                /// </summary>
+                [Enum(typeof(EventType))]
+                public string[] On { get; init; } = Array.Empty<string>();
+
+                /// <summary>
+                ///     Gets details about the webhook call.
+                /// </summary>
+                [Validate]
+                public WebhookDetails Call { get; init; } = new WebhookDetails();
+            }
+
+            /// <summary>
+            ///     Webhook details.
+            /// </summary>
+            public class WebhookDetails : IValidatableObject
+            {
+                /// <summary>
+                ///     Gets the fully qualified URL for the webhook.
+                /// </summary>
+                [NotNullOrWhiteSpace]
+                public string Url { get; init; }
+
+                /// <summary>
+                ///     Gets the HTTP headers to include with the webhook.
+                /// </summary>
+                [Validate]
+                public IEnumerable<WebhookDetailHeader> Headers { get; init; } = [];
+
+                /// <summary>
+                ///     Gets a value indicating whether HTTPS certificate errors should be ignored.
+                /// </summary>
+                public bool IgnoreCertificateErrors { get; init; } = false;
+
+                public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+                {
+                    var results = new List<ValidationResult>();
+
+                    if (!Url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) && !Url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                    {
+                        results.Add(new ValidationResult($"The {nameof(Url)} field must contain a fully qualified URL, including protocol (e.g. http:// or https://)"));
+                    }
+
+                    return results;
+                }
+            }
+
+            public class WebhookDetailHeader
+            {
+                [NotNullOrWhiteSpace]
+                public string Name { get; init; }
+                public string Value { get; init; }
+            }
 
             /// <summary>
             ///     Script configuration.

--- a/src/slskd/Events/EventBus.cs
+++ b/src/slskd/Events/EventBus.cs
@@ -88,7 +88,9 @@ public class EventBus
             // we don't care about any of these tasks; contractually we are only obligated to invoke them
             _ = Task.WhenAll(subscribers.Select(subscriber =>
                     Task.Run(() => (subscriber.Value as Func<T, Task>)(data))
-                        .ContinueWith(task => Log.Error(task.Exception, "Subscriber {Name} for {Type} encountered an error: {Message}", subscriber.Key, typeof(T), task.Exception.Message))));
+                        .ContinueWith(
+                            task => Log.Error(task.Exception, "Subscriber {Name} for {Type} encountered an error: {Message}", subscriber.Key, typeof(T), task.Exception.Message),
+                            continuationOptions: TaskContinuationOptions.OnlyOnFaulted)));
         }
         else
         {
@@ -104,7 +106,8 @@ public class EventBus
             _ = Task.WhenAll(subscribers.Select(subscriber =>
                     Task.Run(() => (subscriber.Value as Func<Event, Task>)(data))
                         .ContinueWith(
-                            task => Log.Error(task.Exception, "Catch-All Subscriber {Name} for {Type} encountered an error: {Message}", subscriber.Key, typeof(Event), task.Exception.Message), TaskContinuationOptions.OnlyOnFaulted)));
+                            task => Log.Error(task.Exception, "Catch-All Subscriber {Name} for {Type} encountered an error: {Message}", subscriber.Key, typeof(Event), task.Exception.Message),
+                            continuationOptions: TaskContinuationOptions.OnlyOnFaulted)));
         }
     }
 

--- a/src/slskd/Events/EventBus.cs
+++ b/src/slskd/Events/EventBus.cs
@@ -103,7 +103,8 @@ public class EventBus
             // we don't care about any of these tasks; contractually we are only obligated to invoke them
             _ = Task.WhenAll(subscribers.Select(subscriber =>
                     Task.Run(() => (subscriber.Value as Func<Event, Task>)(data))
-                        .ContinueWith(task => Log.Error(task.Exception, "Catch-All Subscriber {Name} for {Type} encountered an error: {Message}", subscriber.Key, typeof(Event), task.Exception.Message))));
+                        .ContinueWith(
+                            task => Log.Error(task.Exception, "Catch-All Subscriber {Name} for {Type} encountered an error: {Message}", subscriber.Key, typeof(Event), task.Exception.Message), TaskContinuationOptions.OnlyOnFaulted)));
         }
     }
 

--- a/src/slskd/Integrations/Pushbullet/PushbulletService.cs
+++ b/src/slskd/Integrations/Pushbullet/PushbulletService.cs
@@ -145,9 +145,13 @@ namespace slskd.Integrations.Pushbullet
                 Log.LogDebug("Sending Pushbullet notification {Title} {Body}", title, body);
 
                 await Retry.Do(
-                    task: () => http.PostAsync(PushUri, content),
+                    task: async () =>
+                    {
+                        using var response = await http.PostAsync(PushUri, content);
+                        response.EnsureSuccessStatusCode();
+                    },
                     isRetryable: (attempts, ex) => true,
-                    onFailure: (attempts, ex) => Log.LogWarning("Failed attempt {Attempts} to send Pushbullet notification {Title} {Body}: {Message}", attempts, title, body, ex.Message),
+                    onFailure: (attempts, ex) => Log.LogWarning("Failed attempt #{Attempts} to send Pushbullet notification {Title} {Body}: {Message}", attempts, title, body, ex.Message),
                     maxAttempts: PushbulletOptions.RetryAttempts,
                     maxDelayInMilliseconds: 30000);
 

--- a/src/slskd/Integrations/Scripts/ScriptService.cs
+++ b/src/slskd/Integrations/Scripts/ScriptService.cs
@@ -120,7 +120,7 @@ public class ScriptService
                 }
                 catch (Exception ex)
                 {
-                    Log.Warning(ex, "Failed to run script '{Script}': {Message}", script.Key, ex.Message);
+                    Log.Warning(ex, "Failed to run script '{Script}' for event type {Event}: {Message}", script.Key, data.Type, ex.Message);
                 }
                 finally
                 {
@@ -130,7 +130,7 @@ public class ScriptService
                     }
                     catch (Exception ex)
                     {
-                        Log.Warning(ex, "Failed to clean up process started from script '{Script}': {Message}", script.Key, ex.Message);
+                        Log.Warning(ex, "Failed to clean up process started from script '{Script}' for event type {Event}: {Message}", script.Key, data.Type, ex.Message);
                     }
                 }
             });

--- a/src/slskd/Integrations/Webhooks/WebhookService.cs
+++ b/src/slskd/Integrations/Webhooks/WebhookService.cs
@@ -26,7 +26,6 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 using slskd.Events;
 
@@ -35,7 +34,7 @@ public class WebhookService
     public WebhookService(
         EventBus eventBus,
         IOptionsMonitor<Options> optionsMonitor,
-        [FromKeyedServices(key: nameof(WebhookService))] IHttpClientFactory httpClientFactory)
+        IHttpClientFactory httpClientFactory)
     {
         Events = eventBus;
         OptionsMonitor = optionsMonitor;

--- a/src/slskd/Integrations/Webhooks/WebhookService.cs
+++ b/src/slskd/Integrations/Webhooks/WebhookService.cs
@@ -1,0 +1,63 @@
+// <copyright file="WebhookService.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+using Microsoft.Extensions.Options;
+
+namespace slskd.Integrations.Webhooks;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Serilog;
+using slskd.Events;
+
+public class WebhookService
+{
+    public WebhookService(EventBus eventBus, IOptionsMonitor<Options> optionsMonitor)
+    {
+        Events = eventBus;
+        OptionsMonitor = optionsMonitor;
+
+        Events.Subscribe<Event>(nameof(WebhookService), HandleEvent);
+
+        Log.Debug("{Service} initialized", nameof(WebhookService));
+        Log.Warning("Webhook config: {Config}", OptionsMonitor.CurrentValue.Integration.Webhooks.ToJson());
+    }
+
+    private ILogger Log { get; } = Serilog.Log.ForContext<WebhookService>();
+    private IOptionsMonitor<Options> OptionsMonitor { get; }
+    private EventBus Events { get; }
+
+    private async Task HandleEvent(Event data)
+    {
+        await Task.Yield();
+
+        Log.Debug("Handling event {Event}", data);
+
+        bool EqualsThisEvent(string type) => type.Equals(data.Type.ToString(), StringComparison.OrdinalIgnoreCase);
+        bool EqualsLiterallyAnyEvent(string type) => type.Equals(EventType.Any.ToString(), StringComparison.OrdinalIgnoreCase);
+
+        var options = OptionsMonitor.CurrentValue;
+        var webhooksTriggeredByThisEventType = options.Integration.Webhooks
+            .Where(kvp => kvp.Value.On.Any(EqualsThisEvent) || kvp.Value.On.Any(EqualsLiterallyAnyEvent));
+
+        foreach (var webhook in webhooksTriggeredByThisEventType)
+        {
+            Log.Information("{Webhook}", webhook);
+        }
+    }
+}

--- a/src/slskd/Integrations/Webhooks/WebhookService.cs
+++ b/src/slskd/Integrations/Webhooks/WebhookService.cs
@@ -68,7 +68,11 @@ public class WebhookService
             _ = Task.Run(async () =>
             {
                 var call = webhook.Value.Call;
-                using var http = HttpClientFactory.CreateClient();
+
+                using var http = call.IgnoreCertificateErrors
+                    ? HttpClientFactory.CreateClient(Constants.IgnoreCertificateErrors)
+                    : HttpClientFactory.CreateClient();
+
                 http.Timeout = TimeSpan.FromMilliseconds(webhook.Value.Timeout);
 
                 foreach (var header in call.Headers)

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -61,6 +61,7 @@ namespace slskd
     using slskd.Integrations.FTP;
     using slskd.Integrations.Pushbullet;
     using slskd.Integrations.Scripts;
+    using slskd.Integrations.Webhooks;
     using slskd.Messaging;
     using slskd.Relay;
     using slskd.Search;
@@ -488,6 +489,7 @@ namespace slskd
                 // hack: services that exist only to subscribe to the event bus are not referenced by anything else
                 //       and are thus never instantiated.  force a reference here so they are created.
                 _ = app.Services.GetService<ScriptService>();
+                _ = app.Services.GetService<WebhookService>();
 
                 app.ConfigureAspDotNetPipeline();
 
@@ -583,6 +585,7 @@ namespace slskd
             services.AddSingleton<EventBus>();
 
             services.AddSingleton<ScriptService>();
+            services.AddSingleton<WebhookService>();
 
             services.AddSingleton<IBrowseTracker, BrowseTracker>();
             services.AddSingleton<IRoomTracker, RoomTracker>(_ => new RoomTracker(messageLimit: 250));

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -839,6 +839,7 @@ namespace slskd
 
         private static WebApplication ConfigureAspDotNetPipeline(this WebApplication app)
         {
+            // stop ASP.NET from sending a full stack trace and ProblemDetails for unhandled exceptions
             app.UseExceptionHandler(a => a.Run(async context =>
             {
                 await context.Response.WriteAsJsonAsync(context.Features.Get<IExceptionHandlerPathFeature>().Error.Message);

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -26,6 +26,7 @@ namespace slskd
     using System.IO;
     using System.Linq;
     using System.Net;
+    using System.Net.Http;
     using System.Reflection;
     using System.Security.Cryptography.X509Certificates;
     using System.Text;
@@ -545,6 +546,15 @@ namespace slskd
             // use through 'using var http = HttpClientFactory.CreateClient()' wherever HTTP calls will be made
             // this is important to prevent memory leaks
             services.AddHttpClient();
+
+            // add a special HttpClientFactory to DI that disables SSL.  access it via:
+            // 'using var http = HttpClientFactory.CreateClient(Constants.IgnoreCertificateErrors)'
+            // thanks Microsoft, makes total sense and surely won't be easy to fuck up later!
+            services.AddHttpClient(Constants.IgnoreCertificateErrors)
+                .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+                {
+                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+                });
 
             // add a partially configured instance of SoulseekClient. the Application instance will
             // complete configuration at startup.


### PR DESCRIPTION
Webhooks (outbound HTTP requests) can be configured to be called when application events are raised.  Webhooks are given a name (useful for troubleshooting!), a list of triggering events, a `call` configuration that defines the HTTP request to be made, and timeout and retry configuration.

Webhook HTTP requests are always a `POST`, and will always include the event data in the body, serialized as JSON.  Users define a fully-qualified endpoint address, an optional collection of headers, and an optional flag to ignore HTTPS errors caused by invalid (e.g. self signed) certificates.

If unconfigured, the default timeout for requests is 5 seconds, and each request will be attempted only once per event.

#### **YAML**
```yaml
integration:
  webhooks:
    my_basic_webhook_using_defaults:
      on:
        - All
      call:
        url: http://localhost:4224
    my_webhook_using_detailed_config:
      on:
        - DownloadFileComplete
      call:
        url: https://192.168.1.42:8080/slskd_webhook
        headers:
          - name: X-API-Key # if using API key style authentication
            value: foobar1234
          - name: Authorization # if using JWT authentication
            value: Bearer eyJ...ssw5c
          - name: User-Agent # can be useful!
            value: slskd/0.0
        ignore_certificate_errors: true # defaults to false
      timeout: 5000 # in milliseconds
      retry:
        attempts: 3
```