### PR TITLE
docs: fix YAML indentation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -405,17 +405,17 @@ groups:
       strategy: roundrobin
       slots: 10
       speed_limit: 50000 # kibibytes
-  limits:
-    queued:
-      files: 150
-      megabytes: 1500
-    daily:
-      files: 2147483647 # effectively unlimited, weekly still applies
-      megabytes: 2147483647
-    weekly:
-      files: 1500
-      megabytes: 15000
-      failures: 150
+    limits:
+      queued:
+        files: 150
+        megabytes: 1500
+      daily:
+        files: 2147483647 # effectively unlimited, weekly still applies
+        megabytes: 2147483647
+      weekly:
+        files: 1500
+        megabytes: 15000
+        failures: 150
   leechers:
     thresholds:
       files: 1


### PR DESCRIPTION
Hi, I think there is a typo in the indentation of this YAML block. Do you agree?