### PR TITLE
Tweak ASP.NET setup, add metadata to Swagger/OpenAPI

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -792,12 +792,20 @@ namespace slskd
             }
 
             services.AddRouting(options => options.LowercaseUrls = true);
-            services.AddControllers().AddJsonOptions(options =>
-            {
-                options.JsonSerializerOptions.Converters.Add(new IPAddressConverter());
-                options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
-                options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
-            });
+            services
+                .AddControllers()
+                .ConfigureApiBehaviorOptions(options =>
+                {
+                    options.SuppressInferBindingSourcesForParameters = true;
+                    options.SuppressMapClientErrors = true;
+                    options.SuppressModelStateInvalidFilter = true;
+                })
+                .AddJsonOptions(options =>
+                {
+                    options.JsonSerializerOptions.Converters.Add(new IPAddressConverter());
+                    options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                    options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+                });
 
             services
                 .AddSignalR(options =>

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -813,7 +813,10 @@ namespace slskd
 
             services.AddHealthChecks();
 
-            services.AddApiVersioning(options => options.ReportApiVersions = true)
+            services.AddApiVersioning(options =>
+                {
+                    options.ReportApiVersions = true;
+                })
                 .AddApiExplorer(options =>
                 {
                     options.GroupNameFormat = "'v'VVV";
@@ -825,13 +828,22 @@ namespace slskd
                 services.AddSwaggerGen(options =>
                 {
                     options.DescribeAllParametersInCamelCase();
-                    options.SwaggerDoc(
-                        "v0",
-                        new OpenApiInfo
+                    options.SwaggerDoc("v0", new OpenApiInfo
+                    {
+                        Version = "v0",
+                        Title = AppName,
+                        Description = "A modern client-server application for the Soulseek file sharing network",
+                        Contact = new OpenApiContact
                         {
-                            Title = AppName,
-                            Version = "v0",
-                        });
+                            Name = "GitHub Issues",
+                            Url = new Uri("https://github.com/slskd/slskd/issues"),
+                        },
+                        License = new OpenApiLicense
+                        {
+                            Name = "AGPL-3.0 license",
+                            Url = new Uri("https://github.com/slskd/slskd/blob/master/LICENSE"),
+                        },
+                    });
 
                     if (IOFile.Exists(XmlDocumentationFile))
                     {

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -799,6 +799,7 @@ namespace slskd
                     options.SuppressInferBindingSourcesForParameters = true;
                     options.SuppressMapClientErrors = true;
                     options.SuppressModelStateInvalidFilter = true;
+                    options.DisableImplicitFromServicesParameters = true;
                 })
                 .AddJsonOptions(options =>
                 {

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -795,10 +795,10 @@ namespace slskd
             services.AddControllers()
                 .ConfigureApiBehaviorOptions(options =>
                 {
-                    options.SuppressInferBindingSourcesForParameters = true;
-                    options.SuppressMapClientErrors = true;
-                    options.SuppressModelStateInvalidFilter = true;
-                    options.DisableImplicitFromServicesParameters = true;
+                    options.SuppressInferBindingSourcesForParameters = true; // explicit [FromRoute], etc
+                    options.SuppressMapClientErrors = true; // disables automatic ProblemDetails for 4xx
+                    options.SuppressModelStateInvalidFilter = true; // disables automatic 400 for model errors
+                    options.DisableImplicitFromServicesParameters = true; // explicit [FromServices]
                 })
                 .AddJsonOptions(options =>
                 {

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -843,8 +843,8 @@ namespace slskd
                         Description = "A modern client-server application for the Soulseek file sharing network",
                         Contact = new OpenApiContact
                         {
-                            Name = "GitHub Issues",
-                            Url = new Uri("https://github.com/slskd/slskd/issues"),
+                            Name = "GitHub",
+                            Url = new Uri("https://github.com/slskd/slskd"),
                         },
                         License = new OpenApiLicense
                         {

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -792,8 +792,7 @@ namespace slskd
             }
 
             services.AddRouting(options => options.LowercaseUrls = true);
-            services
-                .AddControllers()
+            services.AddControllers()
                 .ConfigureApiBehaviorOptions(options =>
                 {
                     options.SuppressInferBindingSourcesForParameters = true;


### PR DESCRIPTION
Suppresses some behaviors of ASP.NET that make it difficult to pin down API contracts