### PR TITLE
Include Content-Type header when returning Prometheus metrics via /metrics

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -949,6 +949,10 @@ namespace slskd
 
                     endpoints.MapGet(url, async context =>
                     {
+                        // at the time of writing, the prometheus library doesn't include a way to add authentication
+                        // to the UseMetricServer() middleware. this is most likely a consequence of me mixing
+                        // and matching minimal API stuff with controllers. if i ever straighten that out,
+                        // this should be revisited.
                         if (!options.Authentication.Disabled)
                         {
                             var auth = context.Request.Headers["Authorization"].FirstOrDefault();

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -964,8 +964,10 @@ namespace slskd
                             }
                         }
 
-                        var response = await Metrics.BuildAsync();
-                        await context.Response.WriteAsync(response);
+                        var metricsAsText = await Metrics.BuildAsync();
+
+                        context.Response.Headers.Append("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+                        await context.Response.WriteAsync(metricsAsText);
                     });
                 }
             });


### PR DESCRIPTION
Fixes #1243 

![image](https://github.com/user-attachments/assets/9d6bb0a6-0bc5-494b-8c8b-b475e0b14e5e)
