### PR TITLE
Add an endpoint to allow raising of events (for testing purposes)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -961,18 +961,18 @@ Here's an example of what a `DownloadFileComplete` event (at the time of this wr
 }
 ```
 
-Users developing integrations can use the internal `RaiseEvent` HTTP endpoint to create sample events and put them on the bus.  This will help test integrations end to end without having to take action within the application.
+Users developing integrations can use the internal `RaiseEvent` HTTP endpoint to create sample events and put them on the bus.  This will help test integrations end to end without having to take action within the application, but be aware; using this endpoint after testing is complete is not a good idea!
 
 Here's an example cURL command for the endpoint:
 
 ```bash
 curl --location 'localhost:5030/api/v0/events/downloadfilecomplete' \
---header 'Content-Type: application/json' \
---header 'X-API-Key: <an API key from your config>' \
---data '"asdfasfdasfd"'
+  --header 'Content-Type: application/json' \
+  --header 'X-API-Key: <an API key from your config>' \
+  --data '"asdfasfdasfd"'
 ```
 
-The data passed is a 'disambiguator' that's prepended to sample data.  This will help users differentiate between different event instances.
+The data passed is a 'disambiguator' that's prepended to sample data.  This helps differentiate between different event instances.
 
 ### Webhooks
 

--- a/src/slskd/Events/API/EventsController.cs
+++ b/src/slskd/Events/API/EventsController.cs
@@ -25,6 +25,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Serilog;
+using slskd.Transfers;
 
 /// <summary>
 ///     Events.
@@ -133,7 +134,7 @@ public class EventsController : ControllerBase
 
             Event @event = eventType switch
             {
-                EventType.DownloadFileComplete => new DownloadFileCompleteEvent { LocalFilename = $"{d}local.file", RemoteFilename = $"{d}remote.file", Transfer = null },
+                EventType.DownloadFileComplete => new DownloadFileCompleteEvent { LocalFilename = $"{d}local.file", RemoteFilename = $"{d}remote.file", Transfer = new Transfer() },
                 EventType.DownloadDirectoryComplete => new DownloadDirectoryCompleteEvent { LocalDirectoryName = $"{d}local.directory", RemoteDirectoryName = $"{d}remote.directory", Username = $"{d}username" },
                 EventType.Noop => new NoopEvent(),
                 _ => throw new SlskdException($"Event type {eventType} is an enum member but is not handled.  Please submit an issue on GitHub."),

--- a/src/slskd/Events/API/EventsController.cs
+++ b/src/slskd/Events/API/EventsController.cs
@@ -114,7 +114,7 @@ public class EventsController : ControllerBase
     [ProducesResponseType(typeof(Event), 201)]
     public IActionResult RaiseEvent([FromRoute] string type, [FromBody] string disambiguator)
     {
-        if (!Enum.TryParse<EventType>(type, out var eventType))
+        if (!Enum.TryParse<EventType>(type, ignoreCase: true, out var eventType))
         {
             var names = Enum.GetNames(typeof(EventType))
                 .Where(n => n != EventType.Any.ToString() && n != EventType.None.ToString());

--- a/src/slskd/Events/API/EventsController.cs
+++ b/src/slskd/Events/API/EventsController.cs
@@ -95,16 +95,16 @@ public class EventsController : ControllerBase
     }
 
     /// <summary>
-    ///     Raises a sample event of the specified <see cref="EventType"/>.
+    ///     Raises a sample event of the specified type.
     /// </summary>
     /// <param name="type">The type of event to raise.</param>
     /// <param name="disambiguator">An optional string used to disambiguate generated events.</param>
     /// <returns>The randomly generated event that was raised.</returns>
-    /// <response code="400">If the offset is less than zero, or if the limit is less than or equal to zero.</response>
+    /// <response code="400">The specified type is not a valid event type.</response>
     /// <response code="401">Authentication credentials are omitted.</response>
     /// <response code="403">Authentication is valid but not sufficient to access this endpoint.</response>
     /// <response code="500">An unexpected error is encountered.</response>
-    /// <response code="200">The request completed successfully.</response>
+    /// <response code="201">The request completed successfully.</response>
     [HttpPost("{type}", Name = nameof(RaiseEvent))]
     [Authorize(Policy = AuthPolicy.Any)]
     [ProducesResponseType(typeof(string), 400)]
@@ -127,18 +127,18 @@ public class EventsController : ControllerBase
             return BadRequest($"Event type '{type}' can not be raised");
         }
 
-        var d = disambiguator;
-
-        Event @event = eventType switch
-        {
-            EventType.DownloadFileComplete => new DownloadFileCompleteEvent { LocalFilename = $"{d}local.file", RemoteFilename = $"{d}remote.file", Transfer = null },
-            EventType.DownloadDirectoryComplete => new DownloadDirectoryCompleteEvent { LocalDirectoryName = $"{d}local.directory", RemoteDirectoryName = $"{d}remote.directory", Username = $"{d}username" },
-            EventType.Noop => new NoopEvent(),
-            _ => throw new SlskdException($"Event type {eventType} is an enum member but is not handled.  Please submit an issue on GitHub."),
-        };
-
         try
         {
+            var d = disambiguator;
+
+            Event @event = eventType switch
+            {
+                EventType.DownloadFileComplete => new DownloadFileCompleteEvent { LocalFilename = $"{d}local.file", RemoteFilename = $"{d}remote.file", Transfer = null },
+                EventType.DownloadDirectoryComplete => new DownloadDirectoryCompleteEvent { LocalDirectoryName = $"{d}local.directory", RemoteDirectoryName = $"{d}remote.directory", Username = $"{d}username" },
+                EventType.Noop => new NoopEvent(),
+                _ => throw new SlskdException($"Event type {eventType} is an enum member but is not handled.  Please submit an issue on GitHub."),
+            };
+
             EventBus.Raise(@event);
             return StatusCode(201, @event);
         }

--- a/src/slskd/Events/API/EventsController.cs
+++ b/src/slskd/Events/API/EventsController.cs
@@ -105,7 +105,7 @@ public class EventsController : ControllerBase
     /// <response code="403">Authentication is valid but not sufficient to access this endpoint.</response>
     /// <response code="500">An unexpected error is encountered.</response>
     /// <response code="200">The request completed successfully.</response>
-    [HttpPost("", Name = nameof(RaiseEvent))]
+    [HttpPost("{type}", Name = nameof(RaiseEvent))]
     [Authorize(Policy = AuthPolicy.Any)]
     [ProducesResponseType(typeof(string), 400)]
     [ProducesResponseType(401)]

--- a/src/slskd/Events/API/EventsController.cs
+++ b/src/slskd/Events/API/EventsController.cs
@@ -98,7 +98,7 @@ public class EventsController : ControllerBase
     ///     Raises a sample event of the specified <see cref="EventType"/>.
     /// </summary>
     /// <param name="type">The type of event to raise.</param>
-    /// <param name="disambiguator">A string used to disambiguate generated events.</param>
+    /// <param name="disambiguator">An optional string used to disambiguate generated events.</param>
     /// <returns>The randomly generated event that was raised.</returns>
     /// <response code="400">If the offset is less than zero, or if the limit is less than or equal to zero.</response>
     /// <response code="401">Authentication credentials are omitted.</response>
@@ -133,6 +133,7 @@ public class EventsController : ControllerBase
         {
             EventType.DownloadFileComplete => new DownloadFileCompleteEvent { LocalFilename = $"{d}local.file", RemoteFilename = $"{d}remote.file", Transfer = null },
             EventType.DownloadDirectoryComplete => new DownloadDirectoryCompleteEvent { LocalDirectoryName = $"{d}local.directory", RemoteDirectoryName = $"{d}remote.directory", Username = $"{d}username" },
+            EventType.Noop => new NoopEvent(),
             _ => throw new SlskdException($"Event type {eventType} is an enum member but is not handled.  Please submit an issue on GitHub."),
         };
 

--- a/src/slskd/Events/Types/Events.cs
+++ b/src/slskd/Events/Types/Events.cs
@@ -22,10 +22,10 @@ using slskd.Transfers;
 
 public enum EventType
 {
-    None = 0,
-    Any = 1,
-    DownloadFileComplete = 2,
-    DownloadDirectoryComplete = 3,
+    None,
+    DownloadFileComplete,
+    DownloadDirectoryComplete,
+    Any,
 }
 
 public abstract record Event
@@ -33,20 +33,23 @@ public abstract record Event
     public Guid Id { get; } = Guid.NewGuid();
     public DateTime Timestamp { get; init; } = DateTime.UtcNow;
     public abstract EventType Type { get; }
+    public abstract int Version { get; }
 }
 
 public sealed record DownloadFileCompleteEvent : Event
 {
-    public override EventType Type => EventType.DownloadFileComplete;
-    public string LocalFilename { get; init; }
-    public string RemoteFilename { get; init; }
-    public Transfer Transfer { get; init; }
+    public override EventType Type { get; } = EventType.DownloadFileComplete;
+    public override int Version { get; } = 0;
+    public required string LocalFilename { get; init; }
+    public required string RemoteFilename { get; init; }
+    public required Transfer Transfer { get; init; }
 }
 
 public sealed record DownloadDirectoryCompleteEvent : Event
 {
-    public override EventType Type => EventType.DownloadDirectoryComplete;
-    public string LocalDirectoryName { get; init; }
-    public string RemoteDirectoryName { get; init; }
-    public string Username { get; init; }
+    public override EventType Type { get; } = EventType.DownloadDirectoryComplete;
+    public override int Version { get; } = 0;
+    public required string LocalDirectoryName { get; init; }
+    public required string RemoteDirectoryName { get; init; }
+    public required string Username { get; init; }
 }

--- a/src/slskd/Events/Types/Events.cs
+++ b/src/slskd/Events/Types/Events.cs
@@ -49,6 +49,7 @@ public sealed record DownloadFileCompleteEvent : Event
 public sealed record DownloadDirectoryCompleteEvent : Event
 {
     public override EventType Type => EventType.DownloadDirectoryComplete;
+    public override int Version { get; } = 0;
     public string LocalDirectoryName { get; init; }
     public string RemoteDirectoryName { get; init; }
     public string Username { get; init; }
@@ -57,4 +58,5 @@ public sealed record DownloadDirectoryCompleteEvent : Event
 public sealed record NoopEvent : Event
 {
     public override EventType Type => EventType.Noop;
+    public override int Version { get; } = 0;
 }


### PR DESCRIPTION
Part of the ongoing work to add webhooks and scripts, this PR adds the `RaiseEvent` HTTP endpoint (helpful for testing) and finalizes the documentation.