### PR TITLE
refactor: Update Dockerfile and Entrypoint script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
             ghcr.io/slskd/slskd:canary
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          file: containers/Dockerfile
 
       - name: Build and push Release
         if: startsWith(github.ref, 'refs/tags/')
@@ -170,6 +171,7 @@ jobs:
             ghcr.io/slskd/slskd:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          file: containers/Dockerfile
 
   release:
     name: Create Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,14 @@
 name: CI
 on:
   push:
-    branches: [ master ]
+    branches: [master]
     tags: "[0-9]+.[0-9]+.[0-9]+"
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
 
 env:
-  DOTNET_VERSION: '8'
+  DOTNET_VERSION: "8"
 
 jobs:
   build:
@@ -41,7 +41,7 @@ jobs:
         with:
           name: web-${{ env.VERSION }}
           path: src/web/build
-  
+
   publish:
     name: Publish
     runs-on: ubuntu-latest
@@ -89,7 +89,7 @@ jobs:
         with:
           name: slskd-${{ env.VERSION }}-${{ matrix.runtime }}
           path: dist/${{ matrix.runtime }}
-  
+
   docker:
     name: Build Docker Image
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,57 +39,74 @@ ARG VERSION=0.0.1.65534-local
 ARG REVISION=0
 ARG BUILD_DATE
 
-RUN apt-get update && apt-get install --no-install-recommends -y \
-  wget \
-  tini \
-  && \
-  rm -rf \
-  /tmp/* \
-  /var/lib/apt/lists/* \
-  /var/cache/apt/* \
-  /var/tmp/*
+ARG DEBIAN_FRONTEND=noninteractive
 
-RUN bash -c 'mkdir -p /app/{incomplete,downloads} \ 
-  && chmod -R 777 /app \
-  && mkdir -p /.net \
-  && chmod 777 /.net'
+RUN set -eux; \
+      apt-get update; \
+      apt-get install --no-install-recommends -y \
+        wget \
+        tini \
+      ; \
+      rm -rf \
+        /var/lib/apt/lists \
+        /var/lib/dpkg/status-old \
+      ;
+
+RUN set -eux; \
+      mkdir -p \
+        /app/incomplete \
+        /app/downloads \
+        /.net \
+      ; \
+      chmod -R 0777 \
+        /app \
+        /.net \
+      ;
 
 VOLUME /app
 
-HEALTHCHECK --interval=60s --timeout=3s --start-period=5s --retries=3 CMD wget -q -O - http://localhost:${SLSKD_HTTP_PORT}/health
-
 ENV DOTNET_EnableDiagnostics=0 \
-  DOTNET_BUNDLE_EXTRACT_BASE_DIR=/.net \
-  DOTNET_gcServer=0 \
-  DOTNET_gcConcurrent=1 \
-  DOTNET_GCHeapHardLimit=1F400000	\
-  DOTNET_GCConserveMemory=9 \
-  SLSKD_UMASK=0022 \
-  SLSKD_HTTP_PORT=5030 \
-  SLSKD_HTTPS_PORT=5031 \
-  SLSKD_SLSK_LISTEN_PORT=50300 \
-  SLSKD_APP_DIR=/app \
-  SLSKD_DOCKER_TAG=$TAG \
-  SLSKD_DOCKER_VERSION=$VERSION \
-  SLSKD_DOCKER_REVISON=$REVISION \
-  SLSKD_DOCKER_BUILD_DATE=$BUILD_DATE
+    DOTNET_BUNDLE_EXTRACT_BASE_DIR=/.net \
+    DOTNET_gcServer=0 \
+    DOTNET_gcConcurrent=1 \
+    DOTNET_GCHeapHardLimit=1F400000	\
+    DOTNET_GCConserveMemory=9 \
+    SLSKD_UMASK=0022 \
+    SLSKD_HTTP_PORT=5030 \
+    SLSKD_HTTPS_PORT=5031 \
+    SLSKD_SLSK_LISTEN_PORT=50300 \
+    SLSKD_APP_DIR=/app \
+    SLSKD_DOCKER_TAG=$TAG \
+    SLSKD_DOCKER_VERSION=$VERSION \
+    SLSKD_DOCKER_REVISON=$REVISION \
+    SLSKD_DOCKER_BUILD_DATE=$BUILD_DATE
 
 LABEL org.opencontainers.image.title=slskd \
-  org.opencontainers.image.description="A modern client-server application for the Soulseek file sharing network" \
-  org.opencontainers.image.authors="slskd Team" \
-  org.opencontainers.image.vendor="slskd Team" \
-  org.opencontainers.image.licenses=AGPL-3.0 \
-  org.opencontainers.image.url=https://slskd.org \
-  org.opencontainers.image.source=https://github.com/slskd/slskd \
-  org.opencontainers.image.documentation=https://github.com/slskd/slskd \
-  org.opencontainers.image.version=$VERSION \
-  org.opencontainers.image.revision=$REVISION \
-  org.opencontainers.image.created=$BUILD_DATE
+      org.opencontainers.image.description="A modern client-server application for the Soulseek file sharing network" \
+      org.opencontainers.image.authors="slskd Team" \
+      org.opencontainers.image.vendor="slskd Team" \
+      org.opencontainers.image.licenses=AGPL-3.0 \
+      org.opencontainers.image.url=https://slskd.org \
+      org.opencontainers.image.source=https://github.com/slskd/slskd \
+      org.opencontainers.image.documentation=https://github.com/slskd/slskd \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$REVISION \
+      org.opencontainers.image.created=$BUILD_DATE
 
 WORKDIR /slskd
 COPY --from=publish /slskd/dist/${TARGETPLATFORM} .
 
-RUN echo "umask \$SLSKD_UMASK && ./slskd" > start.sh \
-  && chmod +x start.sh
+RUN set -eux; \
+      echo 'umask $SLSKD_UMASK && exec ./slskd' > start.sh; \
+      chmod +x start.sh;
 
-ENTRYPOINT ["/usr/bin/tini", "--", "./start.sh"]
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+CMD ["./start.sh"]
+
+HEALTHCHECK \
+  --interval=60s \
+  --timeout=3s \
+  --start-period=5s \
+  --retries=3 \
+  CMD wget -q -O - http://localhost:${SLSKD_HTTP_PORT}/health

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -44,7 +44,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN set -eux; \
       apt-get update; \
       apt-get install --no-install-recommends -y \
-        wget \
+        curl \
         gosu \
       ; \
       rm -rf \
@@ -106,4 +106,4 @@ HEALTHCHECK \
   --timeout=3s \
   --start-period=5s \
   --retries=3 \
-  CMD wget -q -O - http://localhost:${SLSKD_HTTP_PORT}/health
+  CMD curl -sfS http://localhost:${SLSKD_HTTP_PORT}/health || exit 1

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -45,12 +45,13 @@ RUN set -eux; \
       apt-get update; \
       apt-get install --no-install-recommends -y \
         wget \
-        tini \
       ; \
       rm -rf \
         /var/lib/apt/lists \
         /var/lib/dpkg/status-old \
       ;
+
+VOLUME /app
 
 RUN set -eux; \
       mkdir -p \
@@ -62,8 +63,6 @@ RUN set -eux; \
         /app \
         /.net \
       ;
-
-VOLUME /app
 
 ENV DOTNET_EnableDiagnostics=0 \
     DOTNET_BUNDLE_EXTRACT_BASE_DIR=/.net \
@@ -93,16 +92,11 @@ LABEL org.opencontainers.image.title=slskd \
       org.opencontainers.image.revision=$REVISION \
       org.opencontainers.image.created=$BUILD_DATE
 
+COPY containers/rootfs /
 WORKDIR /slskd
 COPY --from=publish /slskd/dist/${TARGETPLATFORM} .
 
-RUN set -eux; \
-      echo 'umask $SLSKD_UMASK && exec ./slskd' > start.sh; \
-      chmod +x start.sh;
-
-ENTRYPOINT ["/usr/bin/tini", "--"]
-
-CMD ["./start.sh"]
+ENTRYPOINT ["entrypoint"]
 
 HEALTHCHECK \
   --interval=60s \

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -45,6 +45,7 @@ RUN set -eux; \
       apt-get update; \
       apt-get install --no-install-recommends -y \
         wget \
+        gosu \
       ; \
       rm -rf \
         /var/lib/apt/lists \
@@ -62,7 +63,8 @@ RUN set -eux; \
       chmod -R 0777 \
         /app \
         /.net \
-      ;
+      ; \
+      ln -s /slskd/slskd /usr/bin/;
 
 ENV DOTNET_EnableDiagnostics=0 \
     DOTNET_BUNDLE_EXTRACT_BASE_DIR=/.net \
@@ -97,6 +99,7 @@ WORKDIR /slskd
 COPY --from=publish /slskd/dist/${TARGETPLATFORM} .
 
 ENTRYPOINT ["entrypoint"]
+CMD ["slskd"]
 
 HEALTHCHECK \
   --interval=60s \

--- a/containers/rootfs/usr/bin/entrypoint
+++ b/containers/rootfs/usr/bin/entrypoint
@@ -3,8 +3,12 @@
 set -eu
 
 main() {
-  umask "$SLSKD_UMASK"
-  exec /slskd/slskd
+  if [ "$1" = 'slskd' ] && [ "$(id -u)" -eq '0' ]; then
+    umask "$SLSKD_UMASK"
+    exec gosu app "$0" "$@"
+  fi
+
+  exec "$@"
 }
 
 main "$@"

--- a/containers/rootfs/usr/bin/entrypoint
+++ b/containers/rootfs/usr/bin/entrypoint
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+set -eu
+
+main() {
+  umask "$SLSKD_UMASK"
+  exec /slskd/slskd
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

This pull request updates the infrastructure used for building container images.
1. The Dockerfile has been moved to the containers directory, and the CI workflow file has been updated to reflect this new location.
1. A new entrypoint script has been created to handle the container's startup process.
1. The entrypoint script now changes the user for the main application.

## Details

The container image build infrastructure should be in the `containers` directory. All files needed exclusively for building images should be placed within this directory. The contents of the `containers/rootfs` directory will be copied to the root directory (`/`) of the container, allowing any files to be delivered to their exact locations inside the container.

The previous entrypoint script chains `tini` -> `sh` -> `slskd`. The updated entry point script changes the user before starting `slskd` and directly transfers control to the `slskd` binary. The `app` user is provided by the `dotnet` image itself.
This change **may break** startup process for the users because shared files and directories were owned by root. I can add `chown` calls inside the entrypoint.

## Additional

- The `HEALTHCHECK` now uses `curl` instead of `wget` for improved error messages. 
- Reformatted the GitHub workflow script using Prettier for consistency.  
- I adopted the `RUN` command chaining style, similar to official Docker images.  
- Created a symlink from `/slskd/slskd` to `/usr/bin/slskd`.