### PR TITLE
Bump Relay multipart request limits to insanely high values

### DIFF
--- a/src/slskd/Relay/API/Controllers/RelayController.cs
+++ b/src/slskd/Relay/API/Controllers/RelayController.cs
@@ -42,7 +42,8 @@ namespace slskd.Relay
     [ApiController]
     public class RelayController : ControllerBase
     {
-        private const long TEN_GIGABYTES = 10L * 1024L * 1024L * 1024L;
+        private const long ONE_GIBIBYTE = 1L * 1024L * 1024L * 1024L; // 1073741824
+        private const long ONE_TEBIBYTE = 1024L * ONE_GIBIBYTE; // 1099511627776
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="RelayController"/> class.
@@ -157,8 +158,8 @@ namespace slskd.Relay
         /// <param name="token">The unique identifier for the request.</param>
         /// <returns></returns>
         [HttpPost("controller/files/{token}")]
-        [RequestSizeLimit(TEN_GIGABYTES)]
-        [RequestFormLimits(MultipartBodyLengthLimit = TEN_GIGABYTES)]
+        [RequestSizeLimit(10L * ONE_TEBIBYTE)]
+        [RequestFormLimits(MultipartBodyLengthLimit = 10L * ONE_TEBIBYTE)]
         [DisableFormValueModelBinding]
         [Authorize(Policy = AuthPolicy.ApiKeyOnly, Roles = AuthRole.ReadWriteOrAdministrator)]
         public async Task<IActionResult> UploadFile(string token)
@@ -255,8 +256,8 @@ namespace slskd.Relay
         /// <param name="token">The unique identifier for the request.</param>
         /// <returns></returns>
         [HttpPost("controller/shares/{token}")]
-        [RequestSizeLimit(TEN_GIGABYTES)]
-        [RequestFormLimits(MultipartBodyLengthLimit = TEN_GIGABYTES)]
+        [RequestSizeLimit(ONE_TEBIBYTE)]
+        [RequestFormLimits(MultipartBodyLengthLimit = ONE_TEBIBYTE)]
         [Authorize(Policy = AuthPolicy.ApiKeyOnly, Roles = AuthRole.ReadWriteOrAdministrator)]
         public async Task<IActionResult> UploadShares(string token)
         {


### PR DESCRIPTION
#1229 bumped multipart request limits for the Relay up to 10gb, which I thought to be insanely high prior to seeing a reddit post where someone is attempting to download a 30gb file.

This PR bumps the limit for shares to one tebibyte (terrabyte) and the limit for individual files to 10 tebibytes.

If this project lasts long enough for this to become a problem, I will be amazed.