### PR TITLE
Add 'headless' mode

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -1,4 +1,5 @@
 # debug: false
+# headless: false
 # remote_configuration: false
 # remote_file_management: false
 # instance_name: default

--- a/docs/config.md
+++ b/docs/config.md
@@ -73,6 +73,20 @@ If an attacker were to gain access to the application and retrieve the YAML file
 remote_configuration: false
 ```
 
+# Headless Mode
+
+Users that want extra security and don't intend to use the application's web UI can disable it.  This setting is ideal in
+situations where slskd will be controlled by another application via the API (like when run as a Relay agent).
+
+| Command-Line             | Environment Variable         | Description                                                   |
+| ------------------------ | -----------------------------| ------------------------------------------------------------- |
+| `--headless` | `SLSKD_HEADLESS` | Determines whether the application should run in headless (no web UI) mode |
+
+#### **YAML**
+```yaml
+headless: false
+```
+
 # Permissions
 
 On [Unix-like](https://en.wikipedia.org/wiki/Unix-like) operating systems, slskd creates downloaded files with permissions dictated by the [umask](https://en.wikipedia.org/wiki/Umask) of the process, usually 022, which translates to a file mode of 644; read/write for the owner and read for the group and all others.

--- a/src/slskd/Core/API/Controllers/SessionController.cs
+++ b/src/slskd/Core/API/Controllers/SessionController.cs
@@ -22,6 +22,7 @@ namespace slskd.Core.API
     using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
+    using Serilog;
     using slskd.Authentication;
 
     /// <summary>
@@ -47,6 +48,7 @@ namespace slskd.Core.API
         private IOptionsSnapshot<Options> OptionsSnapshot { get; set; }
         private OptionsAtStartup OptionsAtStartup { get; set; }
         private ISecurityService Security { get; }
+        private ILogger Log { get; } = Serilog.Log.ForContext<SessionController>();
 
         /// <summary>
         ///     Checks whether the provided authentication is valid.
@@ -96,6 +98,12 @@ namespace slskd.Core.API
         [ProducesResponseType(typeof(string), 500)]
         public IActionResult Login([FromBody] LoginRequest login)
         {
+            if (OptionsAtStartup.Headless)
+            {
+                Log.Warning("Login from {User} rejected; web UI is DISABLED when running in headless mode", login.Username);
+                return Forbid();
+            }
+
             if (login == default)
             {
                 return BadRequest();

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -152,6 +152,15 @@ namespace slskd
         public bool Debug { get; init; } = Debugger.IsAttached;
 
         /// <summary>
+        ///     Gets a value indicating whether the application should run in headless (no web UI) mode.
+        /// </summary>
+        [Argument('H', "headless")]
+        [EnvironmentVariable("HEADLESS")]
+        [Description("run in headless (no web UI) mode")]
+        [RequiresRestart]
+        public bool Headless { get; init; } = false;
+
+        /// <summary>
         ///     Gets a value indicating whether remote configuration of options is allowed.
         /// </summary>
         [Argument(default, "remote-configuration")]


### PR DESCRIPTION
This PR adds a new `headless` option that, when turned on, prevents the application from serving static web content and forbids login (JWT creation) with username and password.

Most API endpoints remain functional but callers will need to use API key authentication or a JWT created outside of the application and signed with the configured signing key.

The following endpoints (functions) are effectively disabled, as they can only be authenticated with a JWT:

* Application shutdown and restart
* Retrieval of the 'debug' view of configuration (contains secrets)
* Retrieval of the YAML file contents or location on disk
* Update of the YAML file
* Connect and disconnect of the controller when running as a Relay agent

When I configured these to use JWT authentication only, I did so because I didn't think it made sense to do any of this programmatically, and since API keys are more likely to be exposed (e.g. committing to a repo), restricting access would help protect users against actions that would be disruptive.  I'm willing to rethink this if anyone has a use case; just create an issue and we can talk through it.

Closes #931 