### PR TITLE
feat(container): Add `jq`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ ARG REVISION=0
 ARG BUILD_DATE
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
+  jq \
   wget \
   tini \
   && \


### PR DESCRIPTION
Hi 👋🏼 

For the script integrations since the $DATA is in JSON it would be nice to write our custom scripts a bit cleaner and using `jq` would allow for that.

So instead of:

```sh
name=$(echo "$1" | awk -F'"localDirectoryName": "' '{print $2}' | awk -F'",' '{print $1}')
```

we can use:

```sh
name=$(jq -r '.localDirectoryName' <<< "$1")
```

Besides adding a few kilobytes to the image I don't see any harm with including this tool by default?