### PR TITLE
Fix 'stuck' searches, including those that contain a single letter

### DIFF
--- a/src/slskd/Search/SearchService.cs
+++ b/src/slskd/Search/SearchService.cs
@@ -1,4 +1,4 @@
-// <copyright file="SearchService.cs" company="slskd Team">
+﻿// <copyright file="SearchService.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -228,6 +228,8 @@ namespace slskd.Search
 
             var rateLimiter = new RateLimiter(250);
 
+            // initialize the search record, save it to the database, and broadcast the creation
+            // we do this so the UI has some feedback to show to the user that we've gotten their request
             var search = new Search()
             {
                 SearchText = query.SearchText,
@@ -243,6 +245,8 @@ namespace slskd.Search
 
             await SearchHub.BroadcastCreateAsync(search);
 
+            // initialize the list of responses that we'll use to accumulate them
+            // populated by the responseHandler we pass to SearchAsync
             List<SearchResponse> responses = new();
 
             options ??= new SearchOptions();
@@ -290,6 +294,11 @@ namespace slskd.Search
                         var soulseekSearch = await soulseekSearchTask;
                         search = search.WithSoulseekSearch(soulseekSearch);
                     }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Failed to execute search {Search}: {Message}", new { query, scope, options }, ex.Message);
+                        search.State = SearchStates.Completed | SearchStates.Errored;
+                    }
                     finally
                     {
                         rateLimiter.Dispose();
@@ -308,27 +317,30 @@ namespace slskd.Search
                         }
                         catch (Exception ex)
                         {
-                            // record will be left 'hanging' and will need to be cleaned up at the next boot
+                            // record may be left 'hanging' and will need to be cleaned up at the next boot
                             Log.Error(ex, "Failed to persist search for {SearchQuery} ({Id})", query, id);
                         }
                     }
                 });
+
+                await SearchHub.BroadcastUpdateAsync(search);
+
+                return search;
             }
             catch (Exception ex)
             {
+                // we'll end up here if the initial call throws for an ArgumentException, InvalidOperationException if
+                // the app isn't connected, and a few other straightforward issues that arise before even requesting the search
                 Log.Error(ex, "Failed to execute search {Search}: {Message}", new { query, scope, options }, ex.Message);
 
                 search.State = SearchStates.Completed | SearchStates.Errored;
                 search.EndedAt = search.StartedAt;
-                context.Update(search);
-                context.SaveChanges();
+                Update(search);
+
+                await SearchHub.BroadcastUpdateAsync(search with { Responses = [] });
 
                 throw;
             }
-
-            await SearchHub.BroadcastCreateAsync(search);
-
-            return search;
         }
 
         /// <summary>

--- a/src/slskd/Search/SearchService.cs
+++ b/src/slskd/Search/SearchService.cs
@@ -308,6 +308,7 @@ namespace slskd.Search
                         }
                         catch (Exception ex)
                         {
+                            // record will be left 'hanging' and will need to be cleaned up at the next boot
                             Log.Error(ex, "Failed to persist search for {SearchQuery} ({Id})", query, id);
                         }
                     }

--- a/src/slskd/Search/SearchService.cs
+++ b/src/slskd/Search/SearchService.cs
@@ -270,14 +270,19 @@ namespace slskd.Search
 
             try
             {
+                // initiate the search. this can throw at invocation if there's a problem with
+                // the client state (e.g. disconnected) or a problem with the search (e.g. no terms)
                 var soulseekSearchTask = Client.SearchAsync(
-                query,
-                responseHandler: (response) => responses.Add(response),
-                scope,
-                token,
-                options,
-                cancellationToken: cancellationTokenSource.Token);
+                    query,
+                    responseHandler: (response) => responses.Add(response),
+                    scope,
+                    token,
+                    options,
+                    cancellationToken: cancellationTokenSource.Token);
 
+                // seach looks ok so far; let the rest of the logic run asynchronously
+                // on a background thread. this logic needs to clean up after itself and
+                // update the search record to accurately reflect the final state
                 _ = Task.Run(async () =>
                 {
                     try

--- a/src/slskd/Search/SearchService.cs
+++ b/src/slskd/Search/SearchService.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SearchService.cs" company="slskd Team">
+// <copyright file="SearchService.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -240,6 +240,8 @@ namespace slskd.Search
             using var context = ContextFactory.CreateDbContext();
             context.Add(search);
             context.SaveChanges();
+
+            await SearchHub.BroadcastCreateAsync(search);
 
             List<SearchResponse> responses = new();
 

--- a/src/web/src/components/Search/Searches.jsx
+++ b/src/web/src/components/Search/Searches.jsx
@@ -72,7 +72,9 @@ const Searches = ({ server } = {}) => {
       });
     });
 
-    searchHub.on('create', () => {});
+    searchHub.on('create', (search) => {
+      console.log('search', search);
+    });
 
     searchHub.onreconnecting((connectionError) =>
       onConnectionError(connectionError?.message ?? 'Disconnected'),

--- a/src/web/src/components/Search/Searches.jsx
+++ b/src/web/src/components/Search/Searches.jsx
@@ -73,7 +73,7 @@ const Searches = ({ server } = {}) => {
     });
 
     searchHub.on('create', (search) => {
-      console.log('search', search);
+      onUpdate((old) => ({ ...old, [search.id]: search }));
     });
 
     searchHub.onreconnecting((connectionError) =>


### PR DESCRIPTION
The existing search logic is such that if any errors are encountered when initializing the search, the search record will get 'stuck' in the initializing state and will appear to be underway to the user.  Among the errors that can cause this are input errors, specifically input of search queries that consist of only a single letter, which are not allowed.

This PR ensures search records are cleaned up in the event of an error.