### PR TITLE
Add jq in docker image to make using scripts more easy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ ARG BUILD_DATE
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
   wget \
+  jq \
   tini \
   && \
   rm -rf \


### PR DESCRIPTION
Hi,

I've been using the new script integration feature, and it would make things easier to be able to use jq to parse the $DATA content.

For example :

I had to use awk to parse the localDirectoryName, but it does not work well when there are special characters (like ") in the value.

With jq changing `path=$(echo "$line" | awk -F'"localDirectoryName":"' '{print $2}' | awk -F'"' '{print $1}' | awk '{printf "%s", $0}')` to `path="$(jq -r ".localDirectoryName")"` would make it more resilient (and readable)

