### PR TITLE
Adding context menu to rooms with reply, view user profile, and browse shares

### DIFF
--- a/src/web/src/components/Browse/Browse.jsx
+++ b/src/web/src/components/Browse/Browse.jsx
@@ -6,6 +6,7 @@ import Directory from './Directory';
 import DirectoryTree from './DirectoryTree';
 import * as lzString from 'lz-string';
 import React, { Component } from 'react';
+import { withRouter } from 'react-router-dom';
 import { Card, Icon, Input, Loader, Segment } from 'semantic-ui-react';
 
 const initialState = {
@@ -42,6 +43,9 @@ class Browse extends Component {
       },
       () => this.saveState(),
     );
+    if (this.props.location.state?.user) {
+      this.setState({ username: this.props.location.state.user }, this.browse);
+    }
 
     document.addEventListener('keyup', this.keyUp, false);
   }
@@ -150,11 +154,13 @@ class Browse extends Component {
 
   loadState = () => {
     this.setState(
-      JSON.parse(
-        lzString.decompress(
-          localStorage.getItem('soulseek-example-browse-state') || '',
-        ),
-      ) || initialState,
+      (!this.props.location.state?.user &&
+        JSON.parse(
+          lzString.decompress(
+            localStorage.getItem('soulseek-example-browse-state') || '',
+          ),
+        )) ||
+        initialState,
     );
   };
 
@@ -351,4 +357,4 @@ class Browse extends Component {
   }
 }
 
-export default Browse;
+export default withRouter(Browse);

--- a/src/web/src/components/Rooms/Rooms.css
+++ b/src/web/src/components/Rooms/Rooms.css
@@ -1,3 +1,9 @@
+.popup-menu {
+  overflow-y: auto;
+  position: fixed;
+  z-index: 1000;
+}
+
 .rooms {
   padding-left: 15px;
   padding-right: 15px;

--- a/src/web/src/components/Users/Users.jsx
+++ b/src/web/src/components/Users/Users.jsx
@@ -4,9 +4,11 @@ import * as users from '../../lib/users';
 import PlaceholderSegment from '../Shared/PlaceholderSegment';
 import User from './User';
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Icon, Input, Item, Loader, Segment } from 'semantic-ui-react';
 
 const Users = () => {
+  const location = useLocation();
   const inputRef = useRef();
   const [user, setUser] = useState();
   const [usernameInput, setUsernameInput] = useState();
@@ -42,7 +44,8 @@ const Users = () => {
   useEffect(() => {
     document.addEventListener('keyup', keyUp, false);
 
-    const storedUsername = localStorage.getItem(activeUserInfoKey);
+    const storedUsername =
+      location.state?.user || localStorage.getItem(activeUserInfoKey);
 
     if (storedUsername !== undefined) {
       setSelectedUsername(storedUsername);


### PR DESCRIPTION
# Chat Room Context Menus
## Description
This PR adds a context menu for messages in chat rooms. The context menu adds the ability to format a reply, view the user's profile, or browse their shares. The context menu can be accessed by right clicking on a chat message in a room.
## Justification
Modern UI features are desired by many soulseek users who are hesitant to adopt slskd even if they understand the architectural advantages (see prevalence of hacky nicotine clients on dockerhub). A context menu to make the chat feel more user-friendly could attract users and I have had fun using it thus far.
## Considerations
I am trying to make a feature to ignore users, but it will be a more significant challenge to implement the backend endpoint to add a user to a blacklist. Current solutions for both user and managed blacklists seem improper for this task.
## Technical Information
In the Room component, I have added onContextMenu handlers on room messages that render a Portal (semantic-ui)  at the coordinates of the click. This menu contains buttons that can navigate the UI with react-router-dom and pass the necessary state. Browse and Users components are updated to receive the state and display it properly.

@jpdillingham 