### PR TITLE
Feature/add profile picture support

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -192,6 +192,7 @@
 #   password: ~
 #   description: |
 #     A slskd user. https://github.com/slskd/slskd
+#   profile_picture: slsk-profile-picture.jpg
 #   listen_ip_address: 0.0.0.0
 #   listen_port: 50300
 #   diagnostic_level: Info
@@ -203,7 +204,7 @@
 #   connection:
 #     timeout:
 #       connect: 10000
-#       inactivity: 15000
+#       inactivity: 30000
 #     buffer:
 #       read: 16384
 #       write: 16384

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -1662,13 +1662,16 @@ namespace slskd
         /// <returns>A Task resolving the UserInfo instance.</returns>
         private async Task<UserInfo> UserInfoResolver(string username, IPEndPoint endpoint)
         {
+            var profilePicture = Users.GetProfilePicture(Options.Soulseek.ProfilePicture);
+
             if (Users.IsBlacklisted(username, endpoint.Address))
             {
                 return new UserInfo(
                     description: Options.Soulseek.Description,
                     uploadSlots: 0,
                     queueLength: int.MaxValue,
-                    hasFreeUploadSlot: false);
+                    hasFreeUploadSlot: false,
+                    picture: profilePicture);
             }
 
             try
@@ -1692,7 +1695,8 @@ namespace slskd
                     description: Options.Soulseek.Description,
                     uploadSlots: group.Slots,
                     queueLength: forecastedPosition,
-                    hasFreeUploadSlot: forecastedPosition == 0);
+                    hasFreeUploadSlot: forecastedPosition == 0,
+                    picture: profilePicture);
 
                 return info;
             }

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1532,6 +1532,14 @@ namespace slskd
             public string Description { get; init; } = "A slskd user. https://github.com/slskd/slskd";
 
             /// <summary>
+            ///     Gets the file path for the user's profile picture.
+            /// </summary>
+            [Argument(default, "slsk-profile-picture")]
+            [EnvironmentVariable("SLSK_PROFILE_PICTURE")]
+            [Description("path to the user's profile picture file")]
+            public string ProfilePicture { get; init; } = Program.DefaultProfilePicturePath;
+
+            /// <summary>
             ///     Gets the local IP address on which to listen for incoming connections.
             /// </summary>
             [Argument(default, "slsk-listen-ip-address")]
@@ -1656,7 +1664,7 @@ namespace slskd
                     [EnvironmentVariable("SLSK_INACTIVITY_TIMEOUT")]
                     [Description("connection inactivity timeout, in milliseconds")]
                     [Range(1000, int.MaxValue)]
-                    public int Inactivity { get; init; } = 15000;
+                    public int Inactivity { get; init; } = 30000;
                 }
 
                 /// <summary>

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -203,6 +203,11 @@ namespace slskd
         public static string DefaultIncompleteDirectory { get; private set; }
 
         /// <summary>
+        ///     Gets the default profile picture path.
+        /// </summary>
+        public static string DefaultProfilePicturePath { get; private set; } = Path.Combine(AppContext.BaseDirectory, "slsk-profile-picture.jpg");
+
+        /// <summary>
         ///     Gets the path where application logs are saved.
         /// </summary>
         public static string LogDirectory { get; private set; } = null;

--- a/src/slskd/Users/IUserService.cs
+++ b/src/slskd/Users/IUserService.cs
@@ -152,5 +152,12 @@ namespace slskd.Users
         /// <param name="username">The username of the peer.</param>
         /// <returns>The operation context.</returns>
         Task WatchAsync(string username);
+
+        /// <summary>
+        ///     Gets the profile picture as a byte array if it exists.
+        /// </summary>
+        /// <param name="profilePicture">The profile picture path to resolve.</param>
+        /// <returns>The profile picture as a byte array if it exists and can be read, null otherwise.</returns>
+        byte[] GetProfilePicture(string profilePicture);
     }
 }

--- a/src/slskd/Users/UserService.cs
+++ b/src/slskd/Users/UserService.cs
@@ -19,13 +19,16 @@ using Microsoft.Extensions.Options;
 
 namespace slskd.Users
 {
+    using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
     using NetTools;
     using Serilog;
+    using slskd.Files;
     using Soulseek;
 
     /// <summary>
@@ -65,16 +68,21 @@ namespace slskd.Users
     /// </remarks>
     public class UserService : IUserService
     {
+        private readonly FileService fileService;
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="UserService"/> class.
         /// </summary>
         /// <param name="soulseekClient"></param>
         /// <param name="optionsMonitor"></param>
+        /// <param name="fileService"></param>
         public UserService(
             ISoulseekClient soulseekClient,
-            IOptionsMonitor<Options> optionsMonitor)
+            IOptionsMonitor<Options> optionsMonitor,
+            FileService fileService)
         {
             Client = soulseekClient;
+            this.fileService = fileService;
 
             OptionsMonitor = optionsMonitor;
             OptionsMonitor.OnChange(options => Configure(options));
@@ -145,6 +153,47 @@ namespace slskd.Users
         /// </remarks>
         private ConcurrentDictionary<string, User> UserDictionary { get; set; } = new ConcurrentDictionary<string, User>();
         private ConcurrentDictionary<string, bool> WatchedUsernamesDictionary { get; set; } = new ConcurrentDictionary<string, bool>();
+
+        /// <summary>
+        ///     Gets the profile picture as a byte array if it exists.
+        /// </summary>
+        /// <param name="profilePicture">The profile picture path to resolve.</param>
+        /// <returns>The profile picture as a byte array if it exists and can be read, null otherwise.</returns>
+        public byte[] GetProfilePicture(string profilePicture)
+        {
+            if (string.IsNullOrWhiteSpace(profilePicture))
+            {
+                Log.Warning("Profile picture path is not set");
+                return null;
+            }
+
+            try
+            {
+                // Ensure the path is relative to the app directory for security
+                var fullPath = Path.GetFullPath(
+                    Path.Combine(AppContext.BaseDirectory, profilePicture));
+
+                var fileInfo = fileService.ResolveFileInfo(fullPath);
+                if (!fileInfo.Exists)
+                {
+                    Log.Warning("Profile picture '{Path}' not found", profilePicture);
+                    return null;
+                }
+
+                // Read the file into a byte array
+                return System.IO.File.ReadAllBytes(fileInfo.FullName);
+            }
+            catch (UnauthorizedException ex)
+            {
+                Log.Warning(ex, "Access to profile picture '{Path}' was denied", profilePicture);
+                return null;
+            }
+            catch (IOException ex)
+            {
+                Log.Warning(ex, "Failed to read profile picture '{Path}'", profilePicture);
+                return null;
+            }
+        }
 
         /// <summary>
         ///     Gets the name of the group for the specified <paramref name="username"/>.

--- a/tests/slskd.Tests.Unit/Users/UserServiceTests.cs
+++ b/tests/slskd.Tests.Unit/Users/UserServiceTests.cs
@@ -1,8 +1,8 @@
 ﻿namespace slskd.Tests.Unit.Users
 {
     using System.Collections.Generic;
+    using System.IO;
     using AutoFixture.Xunit2;
-    using Microsoft.EntityFrameworkCore;
     using Moq;
     using slskd.Files;
     using slskd.Users;
@@ -121,6 +121,59 @@
             }
         }
 
+        public class GetProfilePicture
+        {
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData(" ")]
+            public void Returns_Null_When_Path_Is_NullOrWhitespace(string path)
+            {
+                var (service, _) = GetFixture();
+                
+                var result = service.GetProfilePicture(path);
+                
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void Returns_Null_When_File_Does_Not_Exist()
+            {
+                const string nonExistentPath = "nonexistent-file.jpg";
+                var (service, _) = GetFixture();
+                
+                var result = service.GetProfilePicture(nonExistentPath);
+                
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void Returns_File_Bytes_When_File_Exists()
+            {
+                var tempFile = Path.GetTempFileName();
+                try
+                {
+                    // Write some test data to the temp file
+                    System.IO.File.WriteAllBytes(tempFile, new byte[] { 1, 2, 3, 4, 5 });
+                    
+                    var (service, _) = GetFixture();
+                    
+                    var result = service.GetProfilePicture(tempFile);
+                    
+                    Assert.NotNull(result);
+                    Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, result);
+                }
+                finally
+                {
+                    // Clean up
+                    if (System.IO.File.Exists(tempFile))
+                    {
+                        System.IO.File.Delete(tempFile);
+                    }
+                }
+            }
+        }
+
         private static (UserService governor, Mocks mocks) GetFixture(Options options = null)
         {
             var mocks = new Mocks(options);
@@ -137,6 +190,7 @@
             public Mocks(Options options = null)
             {
                 OptionsMonitor = new TestOptionsMonitor<Options>(options ?? new Options());
+                FileService = new FileService(OptionsMonitor);
             }
 
             public Mock<ISoulseekClient> SoulseekClient { get; } = new Mock<ISoulseekClient>();

--- a/tests/slskd.Tests.Unit/Users/UserServiceTests.cs
+++ b/tests/slskd.Tests.Unit/Users/UserServiceTests.cs
@@ -4,6 +4,7 @@
     using AutoFixture.Xunit2;
     using Microsoft.EntityFrameworkCore;
     using Moq;
+    using slskd.Files;
     using slskd.Users;
     using Soulseek;
     using Xunit;
@@ -125,7 +126,8 @@
             var mocks = new Mocks(options);
             var service = new UserService(
                 mocks.SoulseekClient.Object,
-                mocks.OptionsMonitor);
+                mocks.OptionsMonitor,
+                mocks.FileService);
 
             return (service, mocks);
         }
@@ -139,6 +141,7 @@
 
             public Mock<ISoulseekClient> SoulseekClient { get; } = new Mock<ISoulseekClient>();
             public TestOptionsMonitor<Options> OptionsMonitor { get; init; }
+            public FileService FileService { get; init; }
         }
     }
 }


### PR DESCRIPTION
# Add Profile Picture Support

This PR adds support for profile pictures in slskd, allowing the server to provide a profile picture to other Soulseek clients when they request user information. Related to #193

## Changes

- Added configuration option for profile picture path
- Implemented profile picture retrieval in UserService
- Updated UserInfo responses to include profile pictures
- Increased default connection inactivity timeout to 30s to support larger data transfers
- Added appropriate error handling for missing or inaccessible profile pictures

## Notes
- Profile pictures require a longer connection timeout (30s) to ensure reliable transfer

## Configuration

Users can specify a profile picture in their configuration:

```yaml
soulseek:
  profile_picture: path/to/image.jpg  # Path relative to application base directory