### PR TITLE
Fix search retention example

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -158,7 +158,7 @@
 #         role: readonly # readonly, readwrite, administrator
 #         cidr: 0.0.0.0/0,::/0
 # retention:
-#   searches: 10080 # 7 days, in minutes
+#   search: 10080 # 7 days, in minutes
 #   transfers:
 #     upload:
 #       succeeded: 1440 # 1 day, in minutes


### PR DESCRIPTION
The example YAML file incorrectly demonstrates the search retention setting as `searches`, when it's really `search`