### PR TITLE
Refactor search logic to help prevent 'hanging' records

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -1258,18 +1258,18 @@ namespace slskd
         /// <param name="token">The unique token for the request, supplied by the requesting user.</param>
         /// <param name="directory">The requested directory.</param>
         /// <returns>A Task resolving an instance of Soulseek.Directory containing the contents of the requested directory.</returns>
-        private async Task<Soulseek.Directory> DirectoryContentsResponseResolver(string username, IPEndPoint endpoint, int token, string directory)
+        private async Task<IEnumerable<Soulseek.Directory>> DirectoryContentsResponseResolver(string username, IPEndPoint endpoint, int token, string directory)
         {
             if (Users.IsBlacklisted(username, endpoint.Address))
             {
                 Log.Information("Returned empty directory listing for blacklisted user {Username} ({IP})", username, endpoint.Address);
-                return new Soulseek.Directory(directory);
+                return [new Soulseek.Directory(directory)];
             }
 
             try
             {
                 var dir = await Shares.ListDirectoryAsync(directory);
-                return dir;
+                return [dir];
             }
             catch (Exception ex)
             {

--- a/src/slskd/Search/API/Controllers/SearchesController.cs
+++ b/src/slskd/Search/API/Controllers/SearchesController.cs
@@ -82,6 +82,7 @@ namespace slskd.Search.API
             try
             {
                 search = await Searches.StartAsync(id, SearchQuery.FromText(request.SearchText), SearchScope.Network, request.ToSearchOptions());
+                return Ok(search);
             }
             catch (Exception ex) when (ex is ArgumentException || ex is Soulseek.DuplicateTokenException)
             {
@@ -98,8 +99,6 @@ namespace slskd.Search.API
                 Log.Error(ex, "Failed to execute search {Search}: {Message}", request, ex.Message);
                 return StatusCode(500, ex.Message);
             }
-
-            return Ok(search);
         }
 
         /// <summary>

--- a/src/slskd/Search/SearchService.cs
+++ b/src/slskd/Search/SearchService.cs
@@ -330,8 +330,8 @@ namespace slskd.Search
                     }
                 });
 
+                // broadcast and return the _newly created_ search; it will continue to be updated in the background
                 await SearchHub.BroadcastUpdateAsync(search);
-
                 return search;
             }
             catch (Exception ex)

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -67,7 +67,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="7.1.1" />
     <PackageReference Include="Serilog.Sinks.Http" Version="8.0.0" />
-    <PackageReference Include="Soulseek" Version="7.0.0" />
+    <PackageReference Include="Soulseek" Version="7.0.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -67,7 +67,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="7.1.1" />
     <PackageReference Include="Serilog.Sinks.Http" Version="8.0.0" />
-    <PackageReference Include="Soulseek" Version="6.5.0" />
+    <PackageReference Include="Soulseek" Version="7.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/web/src/components/Search/SearchStatusIcon.jsx
+++ b/src/web/src/components/Search/SearchStatusIcon.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Icon, Popup } from 'semantic-ui-react';
 
-// as of 4.5.2, states are:
+// as of 3/26/25 states are:
 // transient:
-//   None, Requested, InProgress
+//   None, Queued, Requested, InProgress
 // terminal:
 //   good: Completed, [TimedOut | ResponseLimitReached | FileLimitReached]
 //   bad: Completed, [Errored | Cancelled]
@@ -11,6 +11,7 @@ import { Icon, Popup } from 'semantic-ui-react';
 const getIcon = ({ state, ...props }) => {
   switch (state) {
     case 'None':
+    case 'Queued':
     case 'Requested':
       return (
         <Icon


### PR DESCRIPTION
Essentially moves all of the search logic into a try/catch block to attempt to ensure searches are finalized if they don't complete successfully.

Soulseek.NET is bumped to 7.0.0 as well, which incorporates https://github.com/jpdillingham/Soulseek.NET/pull/839.  [This line](https://github.com/jpdillingham/Soulseek.NET/pull/839/files#diff-246696b5b1ce06f8977980e6acb1bfc649c4c9b18f56679fa53476613c77f432L3949) is of particular interest (I think) because it updates the state (and thus fires the `stateChanged` function) in the finally block, which possibly executes after the async `Task` for the search has completed.  This _might_ be playing into the problem.

Related to #1306