### PR TITLE
Fix bug preventing full directory from being fetched while reviewing search results

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -830,6 +830,12 @@ namespace slskd
 
             var logger = Loggers.GetOrAdd(source, Log.ForContext("Context", "Soulseek").ForContext("SubContext", source));
 
+            if (args.IncludesException && OptionsAtStartup.Debug)
+            {
+                logger.Write(TranslateLogLevel(args.Level), exception: args.Exception, "{@Message}", args.Message);
+                return;
+            }
+
             logger.Write(TranslateLogLevel(args.Level), "{@Message}", args.Message);
         }
 

--- a/src/slskd/Users/API/Controllers/UsersController.cs
+++ b/src/slskd/Users/API/Controllers/UsersController.cs
@@ -152,7 +152,7 @@ namespace slskd.Users.API
         /// <returns></returns>
         [HttpPost("{username}/directory")]
         [Authorize(Policy = AuthPolicy.Any)]
-        [ProducesResponseType(typeof(Directory), 200)]
+        [ProducesResponseType(typeof(IEnumerable<Directory>), 200)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> Directory([FromRoute, Required] string username, [FromBody, Required] DirectoryContentsRequest request)
         {

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -67,7 +67,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="7.1.1" />
     <PackageReference Include="Serilog.Sinks.Http" Version="8.0.0" />
-    <PackageReference Include="Soulseek" Version="7.0.1" />
+    <PackageReference Include="Soulseek" Version="7.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/web/src/components/Search/Response.jsx
+++ b/src/web/src/components/Search/Response.jsx
@@ -83,10 +83,16 @@ class Response extends Component {
       const oldTree = { ...this.state.tree };
       const oldFiles = oldTree[directory];
 
-      const { files, name } = await getDirectoryContents({
+      // some clients might send more than one directory in the response,
+      // if the requested directory contains subdirectories. the root directory
+      // is always first, and for now we'll only display the contents of that.
+      const allDirectories = await getDirectoryContents({
         directory,
         username,
       });
+
+      const theRootDirectory = allDirectories?.[0];
+      const { files, name } = theRootDirectory;
 
       // the api returns file names only, so we need to prepend the directory
       // to make it look like a search result.  we also need to preserve


### PR DESCRIPTION
Soulseek.NET v7 changed the return type of the underlying method to return multiple directories, and in doing so created a bug.  That bug was fixed with the upgrade to 7.0.3.

Additionally, I never adjusted the related logic in slskd to handle multiple directories.  This PR does that, taking the first directory only.

I _might_ update things later to include subdirectories, but because this only works with Soulseek NS (Qt and Nicotine+ don't send more than 1 directory, nor does slskd) it's not a high priority.