### PR TITLE
Rework "Browse" screen

### DIFF
--- a/src/web/src/components/Browse/Browse.css
+++ b/src/web/src/components/Browse/Browse.css
@@ -115,17 +115,11 @@
 }
 
 .browse-collapse-all-button {
-  position: absolute;
+  position: sticky;
   top: 0;
   right: 0;
-  margin-bottom: 10px !important;
-  float: none;
-  z-index: 1;
-}
-
-.browse-collapse-all-button {
-  margin-bottom: 10px !important;
   float: right;
+  z-index: 1000;
 }
 
 .browse-folderlist-item-container {

--- a/src/web/src/components/Browse/Browse.css
+++ b/src/web/src/components/Browse/Browse.css
@@ -48,10 +48,13 @@
 .browse-folderlist-header {
   cursor: pointer;
   margin-left: 3px !important;
+  display: inline-block;
+  white-space: nowrap;
 }
 
 .browse-folderlist-icon {
-  float: left;
+  float: none;
+  display: inline-block;
 }
 
 .browse-filelist {
@@ -99,8 +102,71 @@
 
 .browse-folderlist-icon {
   color: var(--slskd-browse-folderlist-header-color) !important;
+  margin-right: 3px !important;
 }
 
 .browse-folderlist-icon.selected {
   color: var(--slskd-browse-folderlist-header-selected-color) !important;
+}
+
+/* Collapsible DirectoryTree styles */
+.browse-directorytree-container {
+  position: relative;
+}
+
+.browse-collapse-all-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin-bottom: 10px !important;
+  float: none;
+  z-index: 1;
+}
+
+.browse-collapse-all-button {
+  margin-bottom: 10px !important;
+  float: right;
+}
+
+.browse-folderlist-item-container {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+}
+
+.browse-folderlist-expand-icon {
+  cursor: pointer !important;
+  margin-right: 2px !important;
+  color: var(--slskd-browse-folderlist-header-color) !important;
+  transition: transform 0.2s ease !important;
+  width: 14px !important;
+  min-width: 14px !important;
+}
+
+.browse-folderlist-expand-icon:hover {
+  color: var(--slskd-browse-folderlist-header-selected-color) !important;
+}
+
+.browse-folderlist-expand-icon.collapsed {
+  transform: rotate(0deg);
+}
+
+.browse-folderlist-expand-icon.expanded {
+  transform: rotate(0deg);
+}
+
+.browse-folderlist-expand-spacer {
+  width: 14px;
+  min-width: 14px;
+  margin-right: 2px;
+}
+
+.browse-folderlist-icon.hoverable {
+  cursor: pointer !important;
+  transition: all 0.2s ease !important;
+}
+
+.browse-folderlist-icon.hoverable:hover {
+  color: var(--slskd-browse-folderlist-header-selected-color) !important;
+  transform: scale(1.1);
 }

--- a/src/web/src/components/Browse/Browse.css
+++ b/src/web/src/components/Browse/Browse.css
@@ -32,9 +32,12 @@
   width: 100% !important;
   white-space: pre;
   overflow: auto !important;
-  max-height: 400px;
+  height: 400px;
+  min-height: 200px;
+  max-height: 900px;
   padding: 1em !important;
   box-shadow: unset !important;
+  resize: vertical;
 }
 
 .browse-folderlist-list {

--- a/src/web/src/components/Browse/Browse.jsx
+++ b/src/web/src/components/Browse/Browse.jsx
@@ -210,7 +210,7 @@ class Browse extends Component {
 
     const children = depthMap
       .get(depth)
-      .filter((d) => d.name.startsWith(root.name));
+      .filter((d) => d.name.startsWith(root.name + separator));
 
     return {
       ...root,

--- a/src/web/src/components/Browse/DirectoryTree.jsx
+++ b/src/web/src/components/Browse/DirectoryTree.jsx
@@ -1,10 +1,90 @@
-import React from 'react';
-import { List } from 'semantic-ui-react';
+import { useCallback, useState } from 'react';
+import { Button, List } from 'semantic-ui-react';
 
-const subtree = (root, selectedDirectoryName, onSelect) => {
-  return (root || []).map((d) => {
-    const selected = d.name === selectedDirectoryName;
-    // const dimIfLocked = { opacity: d.locked ? 0.5 : 1 };
+// Sort directories and files alphabetically, directories first
+const sortTree = (nodes) => {
+  if (!nodes) return [];
+
+  const directories = nodes
+    .filter((n) => n.children)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const files = nodes
+    .filter((n) => !n.children)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return [...directories, ...files];
+};
+
+const DirectoryTree = ({ onSelect, selectedDirectoryName, tree }) => {
+  // Initialize with all directories collapsed
+  const [collapsed, setCollapsed] = useState(() => {
+    const getAllDirectoryNames = (directories) => {
+      const names = new Set();
+
+      const traverse = (directories_) => {
+        for (const directory of directories_ || []) {
+          if (directory.children) {
+            names.add(directory.name);
+            traverse(directory.children);
+          }
+        }
+      };
+
+      traverse(directories || []);
+      return names;
+    };
+
+    return getAllDirectoryNames(tree);
+  });
+
+  const toggleCollapse = useCallback((directoryName) => {
+    setCollapsed((previous) => {
+      const newCollapsed = new Set(previous);
+      if (newCollapsed.has(directoryName)) {
+        newCollapsed.delete(directoryName);
+      } else {
+        newCollapsed.add(directoryName);
+      }
+
+      return newCollapsed;
+    });
+  }, []);
+
+  const collapseAll = useCallback(() => {
+    const getAllDirectoryNames = (directories) => {
+      const names = new Set();
+
+      const traverse = (directories_) => {
+        for (const directory of directories_ || []) {
+          if (directory.children) {
+            names.add(directory.name);
+            traverse(directory.children);
+          }
+        }
+      };
+
+      traverse(directories);
+      return names;
+    };
+
+    setCollapsed(getAllDirectoryNames(tree || []));
+  }, [tree]);
+
+  // eslint-disable-next-line complexity
+  const renderNode = (
+    d,
+    selectedDirectoryNameParameter,
+    onSelectParameter,
+    collapsedParameter,
+    toggleCollapseParameter,
+    level,
+  ) => {
+    const selected = d.name === selectedDirectoryNameParameter;
+    const isDirectory = Boolean(d.children);
+    const hasChildren = isDirectory && d.children.length > 0;
+    const isCollapsed = collapsedParameter.has(d.name);
+    const isLocked = d.locked === true;
 
     return (
       <List
@@ -12,38 +92,115 @@ const subtree = (root, selectedDirectoryName, onSelect) => {
         key={d.name}
       >
         <List.Item>
-          <List.Icon
-            className={
-              'browse-folderlist-icon' +
-              (selected ? ' selected' : '') +
-              (d.locked ? ' locked' : '')
-            }
-            name={
-              d.locked === true ? 'lock' : selected ? 'folder open' : 'folder'
-            }
-          />
-          <List.Content>
+          <div
+            className="browse-folderlist-item-container"
+            style={{ paddingLeft: `${level * 20}px` }}
+          >
+            {isDirectory && hasChildren && !isLocked ? (
+              <List.Icon
+                className={`browse-folderlist-expand-icon ${isCollapsed ? 'collapsed' : 'expanded'}`}
+                name={isCollapsed ? 'caret right' : 'caret down'}
+                onClick={() => toggleCollapseParameter(d.name)}
+              />
+            ) : (
+              <div className="browse-folderlist-expand-spacer" />
+            )}
+            <List.Icon
+              className={
+                'browse-folderlist-icon' +
+                (selected ? ' selected' : '') +
+                (isLocked ? ' locked' : '') +
+                (isDirectory && hasChildren && !isLocked ? ' hoverable' : '')
+              }
+              name={
+                isLocked
+                  ? 'lock'
+                  : selected
+                    ? isDirectory
+                      ? 'folder open'
+                      : 'file outline'
+                    : isDirectory
+                      ? 'folder'
+                      : 'file outline'
+              }
+              onClick={
+                isDirectory && hasChildren && !isLocked
+                  ? () => toggleCollapseParameter(d.name)
+                  : undefined
+              }
+            />
             <List.Header
               className={
                 'browse-folderlist-header' +
                 (selected ? ' selected' : '') +
-                (d.locked ? ' locked' : '')
+                (isLocked ? ' locked' : '')
               }
-              onClick={(event) => onSelect(event, d)}
+              onClick={(event) => onSelectParameter(event, d)}
             >
               {d.name.split('\\').pop().split('/').pop()}
             </List.Header>
-            <List.List>
-              {subtree(d.children, selectedDirectoryName, onSelect)}
-            </List.List>
+          </div>
+          <List.Content>
+            {isDirectory && hasChildren && !isCollapsed && (
+              <List.List>
+                {d.children.map((child) =>
+                  renderNode(
+                    child,
+                    selectedDirectoryNameParameter,
+                    onSelectParameter,
+                    collapsedParameter,
+                    toggleCollapseParameter,
+                    level + 1,
+                  ),
+                )}
+              </List.List>
+            )}
           </List.Content>
         </List.Item>
       </List>
     );
-  });
-};
+  };
 
-const DirectoryTree = ({ onSelect, selectedDirectoryName, tree }) =>
-  subtree(tree, selectedDirectoryName, onSelect);
+  const subtree = (
+    root,
+    selectedDirectoryNameParameter,
+    onSelectParameter,
+    collapsedParameter,
+    toggleCollapseParameter,
+    level = 0,
+  ) =>
+    sortTree(root).map((d) =>
+      renderNode(
+        d,
+        selectedDirectoryNameParameter,
+        onSelectParameter,
+        collapsedParameter,
+        toggleCollapseParameter,
+        level,
+      ),
+    );
+
+  return (
+    <div className="browse-directorytree-container">
+      {tree && tree.length > 0 && (
+        <Button
+          className="browse-collapse-all-button"
+          compact
+          onClick={collapseAll}
+          size="mini"
+        >
+          Collapse All
+        </Button>
+      )}
+      {subtree(
+        tree,
+        selectedDirectoryName,
+        onSelect,
+        collapsed,
+        toggleCollapse,
+      )}
+    </div>
+  );
+};
 
 export default DirectoryTree;

--- a/src/web/src/components/Browse/DirectoryTree.jsx
+++ b/src/web/src/components/Browse/DirectoryTree.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Button, List } from 'semantic-ui-react';
+import { List } from 'semantic-ui-react';
 
 const sortTree = (nodes) => {
   return nodes
@@ -25,10 +25,6 @@ const DirectoryTree = ({ onSelect, selectedDirectoryName, tree }) => {
 
       return newOpened;
     });
-  }, []);
-
-  const collapseAll = useCallback(() => {
-    setOpened(new Set());
   }, []);
 
   // eslint-disable-next-line complexity
@@ -90,16 +86,6 @@ const DirectoryTree = ({ onSelect, selectedDirectoryName, tree }) => {
 
   return (
     <div className="browse-directorytree-container">
-      {tree && tree.length > 0 && (
-        <Button
-          className="browse-collapse-all-button"
-          compact
-          onClick={collapseAll}
-          size="mini"
-        >
-          Collapse All
-        </Button>
-      )}
       {tree && tree.length > 0 && (
         <List className="browse-folderlist-list">
           {sortTree(tree).map((d) => renderNode(d, 0))}

--- a/src/web/src/components/Browse/DirectoryTree.jsx
+++ b/src/web/src/components/Browse/DirectoryTree.jsx
@@ -1,23 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Button, List } from 'semantic-ui-react';
 
-// Sort directories and files alphabetically, directories first
 const sortTree = (nodes) => {
-  if (!nodes) return [];
-
-  const directories = nodes
+  return nodes
     .filter((n) => n.children)
     .sort((a, b) => a.name.localeCompare(b.name));
-
-  const files = nodes
-    .filter((n) => !n.children)
-    .sort((a, b) => a.name.localeCompare(b.name));
-
-  return [...directories, ...files];
 };
 
 const DirectoryTree = ({ onSelect, selectedDirectoryName, tree }) => {
-  // Only keep track of opened nodes at the first level
   const [opened, setOpened] = useState(new Set());
 
   useEffect(() => {
@@ -41,12 +31,10 @@ const DirectoryTree = ({ onSelect, selectedDirectoryName, tree }) => {
     setOpened(new Set());
   }, []);
 
-  // Only render the first level, and children if opened
   // eslint-disable-next-line complexity
   const renderNode = (d, level = 0) => {
     const selected = d.name === selectedDirectoryName;
-    const isDirectory = Boolean(d.children);
-    const hasChildren = isDirectory && d.children.length > 0;
+    const hasChildren = d.children.length > 0;
     const isOpened = opened.has(d.name);
     const isLocked = d.locked === true;
 
@@ -56,7 +44,7 @@ const DirectoryTree = ({ onSelect, selectedDirectoryName, tree }) => {
           className="browse-folderlist-item-container"
           style={{ paddingLeft: `${level * 20}px` }}
         >
-          {isDirectory && hasChildren && !isLocked ? (
+          {hasChildren && !isLocked ? (
             <List.Icon
               className={`browse-folderlist-expand-icon ${isOpened ? 'expanded' : 'collapsed'}`}
               name={isOpened ? 'caret down' : 'caret right'}
@@ -70,21 +58,11 @@ const DirectoryTree = ({ onSelect, selectedDirectoryName, tree }) => {
               'browse-folderlist-icon' +
               (selected ? ' selected' : '') +
               (isLocked ? ' locked' : '') +
-              (isDirectory && hasChildren && !isLocked ? ' hoverable' : '')
+              (hasChildren && !isLocked ? ' hoverable' : '')
             }
-            name={
-              isLocked
-                ? 'lock'
-                : selected
-                  ? isDirectory
-                    ? 'folder open'
-                    : 'file outline'
-                  : isDirectory
-                    ? 'folder'
-                    : 'file outline'
-            }
+            name={isLocked ? 'lock' : selected ? 'folder open' : 'folder'}
             onClick={
-              isDirectory && hasChildren && !isLocked
+              hasChildren && !isLocked
                 ? () => toggleCollapse(d.name)
                 : undefined
             }
@@ -101,8 +79,7 @@ const DirectoryTree = ({ onSelect, selectedDirectoryName, tree }) => {
           </List.Header>
         </div>
 
-        {/* Only render children if this node is opened and it's a directory */}
-        {isDirectory && hasChildren && isOpened && (
+        {hasChildren && isOpened && (
           <List.List>
             {sortTree(d.children).map((child) => renderNode(child, level + 1))}
           </List.List>


### PR DESCRIPTION
![Screenshot From 2025-06-21 06-31-02](https://github.com/user-attachments/assets/8a65e798-d55c-4e32-85c6-ceea0633947a)

- Make directory tree resizable from 200-800px
- Collapse tree directories, open by arrow button click
- Sort directories in tree
- Fixed bug in tree parsing (in Browse.jsx)

## Draft todo

- [ ] Floating "Collapse All" button
- [ ] Sort items on backend
- [ ] A+ task: partial tree loading (full tree is still parsed on page load)