### PR TITLE
Add chat events for webhooks and scripts

### DIFF
--- a/src/slskd/Events/API/EventsController.cs
+++ b/src/slskd/Events/API/EventsController.cs
@@ -137,6 +137,9 @@ public class EventsController : ControllerBase
                 EventType.DownloadFileComplete => new DownloadFileCompleteEvent { LocalFilename = $"{d}local.file", RemoteFilename = $"{d}remote.file", Transfer = new Transfer() },
                 EventType.DownloadDirectoryComplete => new DownloadDirectoryCompleteEvent { LocalDirectoryName = $"{d}local.directory", RemoteDirectoryName = $"{d}remote.directory", Username = $"{d}username" },
                 EventType.UploadFileComplete => new UploadFileCompleteEvent { LocalFilename = $"{d}local.file", RemoteFilename = $"{d}remote.file", Transfer = new Transfer() },
+                EventType.PrivateMessageReceived => new PrivateMessageReceivedEvent { Username = $"{d}username", Message = $"{d}message", Blacklisted = false },
+                EventType.PublicChatMessageReceived => new PublicChatMessageReceivedEvent { RoomName = $"{d}room", Username = $"{d}username", Message = $"{d}message", Blacklisted = false },
+                EventType.RoomMessageReceived => new RoomMessageReceivedEvent { RoomName = $"{d}room", Username = $"{d}username", Message = $"{d}message", Blacklisted = false },
                 EventType.Noop => new NoopEvent(),
                 _ => throw new SlskdException($"Event type {eventType} is an enum member but is not handled.  Please submit an issue on GitHub."),
             };

--- a/src/slskd/Events/Types/Events.cs
+++ b/src/slskd/Events/Types/Events.cs
@@ -27,6 +27,9 @@ public enum EventType
     DownloadFileComplete = 2,
     DownloadDirectoryComplete = 3,
     UploadFileComplete = 4,
+    PrivateMessageReceived = 5,
+    PublicChatMessageReceived = 6,
+    RoomMessageReceived = 7,
     Noop = int.MaxValue,
 }
 
@@ -63,6 +66,35 @@ public sealed record UploadFileCompleteEvent : Event
     public required string LocalFilename { get; init; }
     public required string RemoteFilename { get; init; }
     public required Transfer Transfer { get; init; }
+}
+
+public sealed record PrivateMessageReceivedEvent : Event
+{
+    public override EventType Type => EventType.PrivateMessageReceived;
+    public override int Version => 0;
+    public required string Username { get; init; }
+    public required string Message { get; init; }
+    public required bool Blacklisted { get; init; }
+}
+
+public sealed record PublicChatMessageReceivedEvent : Event
+{
+    public override EventType Type => EventType.PublicChatMessageReceived;
+    public override int Version => 0;
+    public required string RoomName { get; init; }
+    public required string Username { get; init; }
+    public required string Message { get; init; }
+    public required bool Blacklisted { get; init; }
+}
+
+public sealed record RoomMessageReceivedEvent : Event
+{
+    public override EventType Type => EventType.RoomMessageReceived;
+    public override int Version => 0;
+    public required string RoomName { get; init; }
+    public required string Username { get; init; }
+    public required string Message { get; init; }
+    public required bool Blacklisted { get; init; }
 }
 
 public sealed record NoopEvent : Event


### PR DESCRIPTION
Hey there, apologies for the unsolicited PR—feel free to completely reject this if it's out of scope!

This PR adds three new events for webhooks and scripts: `PrivateMessageReceived`, `PublicChatMessageReceived`, and `RoomMessageReceived`. The format for these looks like this:

```json
{
  "type": "PrivateMessageReceived",
  "version": 0,
  "username": "User",
  "message": "Example message",
  "blacklisted": false,
  "id": "ba0392f7-154a-40d2-bf3e-463fcb3cefaf",
  "timestamp": "2025-06-25T21:50:05.3390708Z"
}

{
  "type": "RoomMessageReceived",
  "version": 0,
  "roomName": "ExampleRoom",
  "username": "User",
  "message": "Example message",
  "blacklisted": false,
  "id": "6e105322-e16d-4626-ac71-434f0da6b679",
  "timestamp": "2025-06-25T22:23:57.5679935Z"
}
```

I made the decision to send chat events *before* the blacklist check, and include `blacklisted` in the data, under the assumption that consumers will perform their own filtering. However, if you'd rather the blacklist always be respected, or an option be added for this, I'm happy to change it.

On the other hand, I chose to filter out replayed messages entirely. Again, happy to change this and add a field to the data if you prefer.

I also haven't been able to test `PublicChatMessageReceived`—does slskd actually have public chat capability? If not, I can remove this event if it would just be bloat.

Finally, with regards to the code: I currently raise the events directly in `Application.cs`, as that's where Pushbullet notifications are also pushed. This required adding `EventBus` to `Application`. I noticed the existing events mostly exist in their appropriate `Service` classes, so I could move these if you like (e.g. to `ConversationService` perhaps?).

My personal stake in this PR is only the private chat feature, but if you're interested in more coverage in the event bus for future PRs, I'd be willing to take a look!