### PR TITLE
Adjust auto-reconnect logic

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -88,7 +88,7 @@ namespace slskd
             IManagedState<State> state,
             ISoulseekClient soulseekClient,
             FileService fileService,
-            IConnectionWatchdog connectionWatchdog,
+            ConnectionWatchdog connectionWatchdog,
             ITransferService transferService,
             IBrowseTracker browseTracker,
             IRoomTracker roomTracker,
@@ -213,7 +213,7 @@ namespace slskd
         private FileService Files { get; }
         private IRoomService RoomService { get; set; }
         private IBrowseTracker BrowseTracker { get; set; }
-        private IConnectionWatchdog ConnectionWatchdog { get; }
+        private ConnectionWatchdog ConnectionWatchdog { get; }
         private IMessagingService Messaging { get; set; }
         private ILogger Log { get; set; } = Serilog.Log.ForContext<Application>();
         private ConcurrentDictionary<string, ILogger> Loggers { get; } = new ConcurrentDictionary<string, ILogger>();
@@ -859,7 +859,7 @@ namespace slskd
             else
             {
                 Log.Error("Disconnected from the Soulseek server: {Message}", args.Exception?.Message ?? args.Message);
-                ConnectionWatchdog.Restart();
+                ConnectionWatchdog.Start();
             }
         }
 

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -992,8 +992,8 @@ namespace slskd
             {
                 Server = state.Server with
                 {
-                    Address = Client.Address,
-                    IPEndPoint = Client.IPEndPoint,
+                    Address = Client.State.HasFlag(SoulseekClientStates.Disconnected) ? null : Client.Address,
+                    IPEndPoint = Client.State.HasFlag(SoulseekClientStates.Disconnected) ? default : Client.IPEndPoint,
                     State = Client.State,
                 },
                 User = state.User with

--- a/src/slskd/Core/API/Controllers/ServerController.cs
+++ b/src/slskd/Core/API/Controllers/ServerController.cs
@@ -93,6 +93,9 @@ namespace slskd.Core.API
                 return Forbid();
             }
 
+            // stop the watchdog so that it will exit any retry logic
+            ConnectionWatchdog.Stop(abortReconnect: true);
+
             if (Client.State.HasFlag(SoulseekClientStates.Connected))
             {
                 // the IntentionalDisconnectException is used to indicate that the disconnect was intentional, which

--- a/src/slskd/Core/ConnectionWatchdog.cs
+++ b/src/slskd/Core/ConnectionWatchdog.cs
@@ -209,12 +209,27 @@ namespace slskd
 
                             break;
                         }
+                        catch (Exception ex) when (ex is TaskCanceledException || ex is OperationCanceledException)
+                        {
+                            Log.Information("Reconnection attempt cancelled");
+                            Log.Debug(ex, "ConnectAsync() threw {Exception}", ex);
+                            return;
+                        }
                         catch (Exception ex)
                         {
                             attempts++;
                             Log.Error("Failed to reconnect: {Message}", ex.Message);
                         }
                     }
+                }
+                catch (Exception ex) when (ex is TaskCanceledException || ex is OperationCanceledException)
+                {
+                    Log.Information("Reconnection attempt cancelled");
+                    Log.Debug(ex, "Reconnect logic threw {Exception}", ex);
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "Reconnect attempt failed: {Message}", ex.Message);
                 }
                 finally
                 {

--- a/src/slskd/Core/ConnectionWatchdog.cs
+++ b/src/slskd/Core/ConnectionWatchdog.cs
@@ -57,6 +57,10 @@ namespace slskd
     /// <summary>
     ///     Monitors the connection to the Soulseek network and reconnects with exponential backoff, if necessary.
     /// </summary>
+    /// <remarks>
+    ///     This class is intended to be Started either at application startup or when the connection is disconnected, and
+    ///     stopped when the application is connected again; it doesn't "run" all the time.
+    /// </remarks>
     public class ConnectionWatchdog : IConnectionWatchdog
     {
         private static readonly int ReconnectMaxDelayMilliseconds = 300000; // 5 minutes

--- a/src/slskd/Core/ConnectionWatchdog.cs
+++ b/src/slskd/Core/ConnectionWatchdog.cs
@@ -150,6 +150,8 @@ namespace slskd
         /// <param name="disposing"></param>
         protected virtual void Dispose(bool disposing)
         {
+            Stop(abortReconnect: true);
+
             if (!Disposed)
             {
                 if (disposing)

--- a/src/slskd/Core/ConnectionWatchdog.cs
+++ b/src/slskd/Core/ConnectionWatchdog.cs
@@ -213,7 +213,7 @@ namespace slskd
 
                             var approximateDelay = (int)Math.Ceiling((double)(delay + jitter) / 1000);
                             Log.Information($"Waiting about {(approximateDelay == 1 ? "a second" : $"{approximateDelay} seconds")} before attempting to reconnect");
-                            await Task.Delay(delay + jitter, cancellationToken: CancellationTokenSource.Token);
+                            await Task.Delay(delay + jitter, cancellationToken: CancellationTokenSource?.Token ?? CancellationToken.None);
 
                             Log.Information("Attempting to reconnect to the Soulseek server (#{Attempts})...", attempts);
                         }
@@ -227,7 +227,7 @@ namespace slskd
                             // reconnect with the latest configuration values we have for username and password, instead of the
                             // options that were captured at startup. if a user has updated these values prior to the disconnect,
                             // the changes will take effect now.
-                            var opt = Options.CurrentValue.Soulseek;
+                            var opt = OptionsMonitor.CurrentValue.Soulseek;
 
                             // note: cancelling the CTS before the connect logic is fully complete (e.g. reacting to the connect event)
                             // will cause the client to connect, then disconnect immediately
@@ -236,7 +236,7 @@ namespace slskd
                                 port: opt.Port,
                                 username: opt.Username,
                                 password: opt.Password,
-                                cancellationToken: CancellationTokenSource.Token);
+                                cancellationToken: CancellationTokenSource?.Token ?? CancellationToken.None);
 
                             break;
                         }

--- a/src/slskd/Core/ConnectionWatchdog.cs
+++ b/src/slskd/Core/ConnectionWatchdog.cs
@@ -233,7 +233,18 @@ namespace slskd
                 }
                 finally
                 {
-                    CancellationTokenSource?.Dispose();
+                    var cts = CancellationTokenSource;
+                    CancellationTokenSource = null;
+
+                    try
+                    {
+                        cts?.Dispose();
+                    }
+                    catch (Exception)
+                    {
+                        // noop. i don't think this can throw, but if we fail to release the SyncRoot we'll be in trouble.
+                    }
+
                     SyncRoot.Release();
                 }
             }

--- a/src/slskd/Core/ConnectionWatchdog.cs
+++ b/src/slskd/Core/ConnectionWatchdog.cs
@@ -26,47 +26,13 @@ namespace slskd
     using Soulseek;
 
     /// <summary>
-    ///     Monitors the connection to the Soulseek server and reconnects with exponential backoff, if necessary.
-    /// </summary>
-    public interface IConnectionWatchdog : IDisposable
-    {
-        /// <summary>
-        ///     Gets a value indicating whether the watchdog is monitoring the server connection.
-        /// </summary>
-        /// <remarks>
-        ///     Generally true when the application *SHOULD* be connected to the server, but isn't.
-        ///     Otherwise false (e.g. when connected).
-        /// </remarks>
-        bool IsEnabled { get; }
-
-        /// <summary>
-        ///     Initializes the watchdog and makes the initial connection to the server.
-        /// </summary>
-        /// <remarks>This should be called at application startup.</remarks>
-        void Start();
-
-        /// <summary>
-        ///     Starts monitoring the server connection following a disconnect.
-        /// </summary>
-        /// <remarks>This should be called when the connection is disconnected.</remarks>
-        void Restart();
-
-        /// <summary>
-        ///     Stops monitoring the server connection.
-        /// </summary>
-        /// <param name="abortReconnect">A value indicating whether to abort an ongoing reconnect attempt.</param>
-        /// <remarks>This should be called when the application is reasonably certain that the connection is connected.</remarks>
-        void Stop(bool abortReconnect = false);
-    }
-
-    /// <summary>
     ///     Monitors the connection to the Soulseek network and reconnects with exponential backoff, if necessary.
     /// </summary>
     /// <remarks>
     ///     This class is intended to be Started either at application startup or when the connection is disconnected, and
     ///     stopped when the application is connected again; it doesn't "run" all the time.
     /// </remarks>
-    public class ConnectionWatchdog : IConnectionWatchdog
+    public class ConnectionWatchdog
     {
         private static readonly int ReconnectMaxDelayMilliseconds = 300000; // 5 minutes
 
@@ -122,7 +88,7 @@ namespace slskd
         ///     Initializes the watchdog and makes the initial connection to the server.
         /// </summary>
         /// <remarks>This should be called at application startup.</remarks>
-        public void Start()
+        public virtual void Start()
         {
             WatchdogTimer.Enabled = true;
             _ = AttemptReconnect(attempts: 0);
@@ -143,7 +109,7 @@ namespace slskd
         /// </summary>
         /// <param name="abortReconnect">A value indicating whether to abort an ongoing reconnect attempt.</param>
         /// <remarks>This should be called when the application is reasonably certain that the connection is connected.</remarks>
-        public void Stop(bool abortReconnect = false)
+        public virtual void Stop(bool abortReconnect = false)
         {
             WatchdogTimer.Enabled = false;
 

--- a/src/slskd/Core/ConnectionWatchdog.cs
+++ b/src/slskd/Core/ConnectionWatchdog.cs
@@ -101,13 +101,20 @@ namespace slskd
         }
 
         /// <summary>
-        ///     Starts monitoring the server connection.
+        ///     Stops the watchdog and aborts any active reconnection loop, then starts again.
         /// </summary>
-        /// <remarks>This should be called when the connection is disconnected.</remarks>
-        public void Restart()
+        /// <remarks>
+        ///     This should be called when we have a reason to restart an in-process retry loop, such as a setting change,
+        ///     user request, etc.
+        /// </remarks>
+        public virtual void Restart()
         {
-            WatchdogTimer.Enabled = true;
-            _ = AttemptReconnect(attempts: 1);
+            if (IsEnabled)
+            {
+                Log.Information("(Re)connection process restarted");
+                Stop(abortReconnect: true);
+                Start();
+            }
         }
 
         /// <summary>

--- a/src/slskd/Core/ConnectionWatchdog.cs
+++ b/src/slskd/Core/ConnectionWatchdog.cs
@@ -124,6 +124,7 @@ namespace slskd
         /// <remarks>This should be called when the application is reasonably certain that the connection is connected.</remarks>
         public virtual void Stop(bool abortReconnect = false)
         {
+            // stop the timer first to avoid having it start the connection process again when the cts is cancelled
             WatchdogTimer.Enabled = false;
 
             // note: the connect event fires before the connection logic is complete, so there is a chain of events
@@ -132,7 +133,14 @@ namespace slskd
             // wants to abort the reconnect logic.
             if (abortReconnect)
             {
-                CancellationTokenSource?.Cancel();
+                try
+                {
+                    CancellationTokenSource?.Cancel(throwOnFirstException: false);
+                }
+                catch (Exception)
+                {
+                    // noop. Cancel() can throw if registered callbacks throw, but we don't have any right now and we don't care anyway
+                }
             }
         }
 

--- a/src/slskd/Core/State.cs
+++ b/src/slskd/Core/State.cs
@@ -35,6 +35,7 @@ namespace slskd
         public bool PendingReconnect { get; init; }
         public bool PendingRestart { get; init; }
         public ServerState Server { get; init; } = new ServerState();
+        public ServerConnectionWatchdogState ConnectionWatchdog { get; init; } = new ServerConnectionWatchdogState();
         public RelayState Relay { get; init; } = new RelayState();
         public UserState User { get; init; } = new UserState();
         public DistributedNetworkState DistributedNetwork { get; init; } = new DistributedNetworkState();
@@ -61,8 +62,17 @@ namespace slskd
         public IPEndPoint IPEndPoint { get; init; }
         public SoulseekClientStates State { get; init; }
         public bool IsConnected => State.HasFlag(SoulseekClientStates.Connected);
+        public bool IsConnecting => State.HasFlag(SoulseekClientStates.Connecting);
         public bool IsLoggedIn => State.HasFlag(SoulseekClientStates.LoggedIn);
+        public bool IsLoggingIn => State.HasFlag(SoulseekClientStates.LoggingIn);
         public bool IsTransitioning => State.HasFlag(SoulseekClientStates.Connecting) || State.HasFlag(SoulseekClientStates.Disconnecting) || State.HasFlag(SoulseekClientStates.LoggingIn);
+    }
+
+    public record ServerConnectionWatchdogState
+    {
+        public bool IsEnabled { get; init; } = false;
+        public bool IsAttemptingConnection { get; init; } = false;
+        public DateTime? NextAttemptAt { get; init; }
     }
 
     public record RelayState

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -592,7 +592,7 @@ namespace slskd
             services.AddHostedService(p => p.GetRequiredService<IApplication>());
 
             services.AddSingleton<IWaiter, Waiter>();
-            services.AddSingleton<IConnectionWatchdog, ConnectionWatchdog>();
+            services.AddSingleton<ConnectionWatchdog, ConnectionWatchdog>();
 
             if (OptionsAtStartup.Flags.Volatile)
             {


### PR DESCRIPTION
A user on Discord questioned whether a DNS resolution failure might be breaking reconnect logic, so I went down a rabbit hole and made some changes.

Functional change:
* Changing options while the app is trying to reconnect will attempt reconnect immediately and reset the backoff logic (users no longer have to wait ~5 minutes for the next attempt for changes to server address or port take effect)
* Clicking the network icon on the UI also resets the backoff logic, and when connecting the app using the UI, the connection 'watchdog' is now used, ensuring retries if the initial attempt fails
* Disconnecting via the API now cancels any in-progress reconnect process
* The network icon overlay changes to indicate when a retry attempt is underway (green sync icon), when we're waiting for the next attempt (yellow clock) and when the app is both disconnected and not making an attempt to reconnect (red x)

Connecting:

<img width="109" height="74" alt="image" src="https://github.com/user-attachments/assets/cbad5ebb-80d9-4a3e-ae08-524fa5215129" />

Waiting:

<img width="111" height="73" alt="image" src="https://github.com/user-attachments/assets/e1b1132a-78aa-48c9-b9d5-449cc16b5d3c" />


Code changes:
* Remove `IConnectionWatchdog` interface.  Lately I'm finding C# interfaces annoying and redundant 🤷 
* Add a cancellation token to the retry logic and the delays and connection logic within to ensure the loop is exited promptly
* Added `ServerConnectionWatchdog` to application state that includes flags to indicate when it's active, when it's in a retry loop, and the approximate timestamp of the next attempt

Also fixes what I'd consider a bug with the server state; address and IP are now null when the server is disconnected.