### PR TITLE
Fix regression in scripts and webhooks causing json to be missing detail

### DIFF
--- a/src/slskd/Integrations/Scripts/ScriptService.cs
+++ b/src/slskd/Integrations/Scripts/ScriptService.cs
@@ -180,7 +180,11 @@ public class ScriptService
                     Log.Debug("Running script '{Script}': \"{Executable}\" {Args} (id: {ProcessId})", script.Key, executable, run.Args ?? string.Join(' ', run.Arglist ?? []), processId);
                     var sw = Stopwatch.StartNew();
 
-                    process.StartInfo.EnvironmentVariables["SLSKD_SCRIPT_DATA"] = JsonSerializer.Serialize(data, JsonSerializerOptions);
+                    process.StartInfo.EnvironmentVariables["SLSKD_SCRIPT_DATA"] = JsonSerializer.Serialize(
+                        value: data,
+                        inputType: data.GetType(), // if omitted object is serialized as EventType, losing everything else
+                        options: JsonSerializerOptions);
+
                     process.Start();
 
                     process.WaitForExit();

--- a/src/slskd/Integrations/Webhooks/WebhookService.cs
+++ b/src/slskd/Integrations/Webhooks/WebhookService.cs
@@ -94,7 +94,10 @@ public class WebhookService
                 }
 
                 var content = new StringContent(
-                    content: JsonSerializer.Serialize(data, JsonSerializerOptions),
+                    content: JsonSerializer.Serialize(
+                        value: data,
+                        inputType: data.GetType(), // if omitted object is serialized as EventType, losing everything else
+                        options: JsonSerializerOptions),
                     encoding: Encoding.UTF8,
                     mediaType: "application/json");
 


### PR DESCRIPTION
This is a rather sneaky regression introduced in #1384, which included a change that was, ironically, supposed to guard against regressions like this by moving the serialization logic inside the script and webhook services, instead of a shared extension.  In doing so the compiler optimized out the runtime type checking that allowed serialization to work properly, and inlined `EventData` which contains only a few properties.

This PR adjusts the `JsonSerializer.Serialize()` call to explicitly tell it to check the runtime type.

Closes #1388 