### PR TITLE
Add metric to count search requests per second

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -1466,6 +1466,7 @@ namespace slskd
 
                 Metrics.Search.ResponseLatency.Observe(sw.ElapsedMilliseconds);
                 Metrics.Search.CurrentResponseLatency.Update(sw.ElapsedMilliseconds);
+                Metrics.Search.RequestCount.CountUp();
 
                 if (results.Any())
                 {

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -1433,6 +1433,7 @@ namespace slskd
         private async Task<SearchResponse> SearchResponseResolver(string username, int token, SearchQuery query)
         {
             Metrics.Search.RequestsReceived.Inc(1);
+            Metrics.Search.CurrentRequestRate.CountUp(1);
 
             if (Users.IsBlacklisted(username))
             {
@@ -1466,7 +1467,6 @@ namespace slskd
 
                 Metrics.Search.ResponseLatency.Observe(sw.ElapsedMilliseconds);
                 Metrics.Search.CurrentResponseLatency.Update(sw.ElapsedMilliseconds);
-                Metrics.Search.RequestCount.CountUp();
 
                 if (results.Any())
                 {

--- a/src/slskd/Common/TimedCounter.cs
+++ b/src/slskd/Common/TimedCounter.cs
@@ -1,0 +1,89 @@
+﻿// <copyright file="TimedCounter.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+using System;
+using System.Timers;
+
+namespace slskd
+{
+    /// <summary>
+    ///     A counter that counts up over a set time period.
+    /// </summary>
+    public class TimedCounter : IDisposable
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="TimedCounter"/> class.
+        /// </summary>
+        /// <param name="interval">The interval at which the OnElapsed delegate is called and the count resets.</param>
+        /// <param name="onElapsed">The delagate to invoke with the current count when the timer elapses.</param>
+        public TimedCounter(TimeSpan interval, Action<long> onElapsed)
+        {
+            OnElapsed = onElapsed;
+
+            Timer = new Timer(interval);
+            Timer.Elapsed += Elapsed;
+            Timer.Start();
+        }
+
+        /// <summary>
+        ///     Gets the current count.
+        /// </summary>
+        public long Count { get; private set; } = 0;
+
+        private Timer Timer { get; }
+        private Action<long> OnElapsed { get; }
+        private bool Disposed { get; set; }
+
+        /// <summary>
+        ///     Counts up by the specified <paramref name="count"/>.
+        /// </summary>
+        /// <param name="count">The number to add to the count.</param>
+        public void CountUp(long count = 1)
+        {
+            Count += count;
+        }
+
+        /// <summary>
+        ///     Disposes this instance.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!Disposed)
+            {
+                if (disposing)
+                {
+                    Timer.Dispose();
+                }
+
+                Disposed = true;
+            }
+        }
+
+        private void Elapsed(object sender, ElapsedEventArgs args)
+        {
+            var count = Count;
+            Count = 0;
+            OnElapsed?.Invoke(count);
+        }
+    }
+}

--- a/src/slskd/Core/Metrics.cs
+++ b/src/slskd/Core/Metrics.cs
@@ -17,6 +17,8 @@
 
 namespace slskd
 {
+    using System;
+
     using System.IO;
     using System.Threading.Tasks;
     using Prometheus;
@@ -57,6 +59,11 @@ namespace slskd
             public static ExponentialMovingAverage CurrentResponseLatency { get; } = new ExponentialMovingAverage(smoothingFactor: 0.5, onUpdate: value => CurrentResponseLatencyGauge.Set(value));
 
             /// <summary>
+            ///     Gets an automatically resetting counter of the number of search requests received.
+            /// </summary>
+            public static TimedCounter RequestCount { get; } = new TimedCounter(TimeSpan.FromSeconds(1), onElapsed: count => CurrentRequestRateGauge.Set(count));
+
+            /// <summary>
             ///     Gets a counter representing the total number of search requests received.
             /// </summary>
             public static Counter RequestsReceived { get; } = Prometheus.Metrics.CreateCounter("slskd_search_requests_received", "Total number of search requests received");
@@ -67,6 +74,7 @@ namespace slskd
             public static Counter ResponsesSent { get; } = Prometheus.Metrics.CreateCounter("slskd_search_responses_sent", "Total number of search responses sent");
 
             private static Gauge CurrentResponseLatencyGauge { get; } = Prometheus.Metrics.CreateGauge("slskd_search_response_latency_current", "The average time taken to resolve a response to an incoming search request, in milliseconds");
+            private static Gauge CurrentRequestRateGauge { get; } = Prometheus.Metrics.CreateGauge("slskd_search_request_rate_current", "Number of search requests received in the last second");
         }
 
         public static class Browse

--- a/src/slskd/Core/Metrics.cs
+++ b/src/slskd/Core/Metrics.cs
@@ -61,7 +61,7 @@ namespace slskd
             /// <summary>
             ///     Gets an automatically resetting counter of the number of search requests received.
             /// </summary>
-            public static TimedCounter RequestCount { get; } = new TimedCounter(TimeSpan.FromSeconds(1), onElapsed: count => CurrentRequestRateGauge.Set(count));
+            public static TimedCounter CurrentRequestRate { get; } = new TimedCounter(TimeSpan.FromSeconds(1), onElapsed: count => CurrentRequestRateGauge.Set(count));
 
             /// <summary>
             ///     Gets a counter representing the total number of search requests received.


### PR DESCRIPTION
Prometheus can already figure this out from the search counter.  This is computed locally so we can display it on the UI without computing it from history.