### PR TITLE
Fix bug preventing proper change detection when updating options with an enum type

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -1270,6 +1270,8 @@ namespace slskd
             // shenanigans here could lead to missed updates.
             await OptionsSyncRoot.WaitAsync();
 
+            Log.Debug("OptionsMonitor OnChange Invoked");
+
             try
             {
                 var pendingRestart = false;
@@ -1281,8 +1283,11 @@ namespace slskd
                 // don't react to duplicate/no-change events https://github.com/slskd/slskd/issues/126
                 if (!diff.Any())
                 {
+                    Log.Debug("Diff of previous and new options is the same; nothing to do");
                     return;
                 }
+
+                Log.Debug("Diff of previous and new options contains {Count} changed properties: {Properties}", diff.Count(), diff.Select(p => p.FQN));
 
                 foreach (var (property, fqn, left, right) in diff)
                 {

--- a/src/slskd/Common/CommonExtensions.cs
+++ b/src/slskd/Common/CommonExtensions.cs
@@ -116,7 +116,7 @@ namespace slskd
                         differences.Add((prop, fqn, leftVal, rightVal));
                     }
                 }
-                else if (propType.IsPrimitive || Nullable.GetUnderlyingType(propType) != null || new[] { typeof(string), typeof(decimal) }.Contains(propType))
+                else if (propType.IsPrimitive || propType.IsEnum || Nullable.GetUnderlyingType(propType) != null || new[] { typeof(string), typeof(decimal) }.Contains(propType))
                 {
                     if (!Equals(leftVal, rightVal))
                     {

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -36,10 +36,10 @@ namespace slskd
     using slskd.Relay;
     using slskd.Shares;
     using slskd.Validation;
-    using Soulseek.Diagnostics;
     using Utility.CommandLine;
     using Utility.EnvironmentVariables;
     using YamlDotNet.Serialization;
+    using SoulseekDiagnostics = Soulseek.Diagnostics;
 
     /// <summary>
     ///     Disambiguates options derived at startup from options that may update at run time.
@@ -1572,8 +1572,9 @@ namespace slskd
             [Argument(default, "slsk-diag-level")]
             [EnvironmentVariable("SLSK_DIAG_LEVEL")]
             [Description("minimum diagnostic level (None, Warning, Info, Debug)")]
+            [Enum(typeof(SoulseekDiagnostics.DiagnosticLevel))]
             [RequiresRestart]
-            public DiagnosticLevel DiagnosticLevel { get; init; } = DiagnosticLevel.Info;
+            public string DiagnosticLevel { get; init; } = SoulseekDiagnostics.DiagnosticLevel.Info.ToString().ToLowerInvariant();
 
             /// <summary>
             ///     Gets options for the distributed network.

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -584,7 +584,7 @@ namespace slskd
                 new SoulseekClient(options: new SoulseekClientOptions(
                     maximumConcurrentUploads: OptionsAtStartup.Global.Upload.Slots,
                     maximumConcurrentDownloads: OptionsAtStartup.Global.Download.Slots,
-                    minimumDiagnosticLevel: OptionsAtStartup.Soulseek.DiagnosticLevel)));
+                    minimumDiagnosticLevel: OptionsAtStartup.Soulseek.DiagnosticLevel.ToEnum<Soulseek.Diagnostics.DiagnosticLevel>())));
 
             // add the core application service to DI as well as a hosted service so that other services can
             // access instance methods


### PR DESCRIPTION
I noticed this morning that changing the Soulseek diagnostic level from `Info` to `Debug` didn't update the UI or tell me I had to restart.  Digging further I found that the 'diff' that is done between the old and new configuration didn't detect the change, and the underlying cause is that the diff logic ignores enum values (rather, tries to traverse them).

`DiagnosticLevel` is the only option that's backed by an enum, so it is the only one affected.