### PR TITLE
Substantially improve performance of search request filtering

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -135,7 +135,7 @@ namespace slskd
                 regexOptions |= RegexOptions.IgnoreCase;
             }
 
-            CompiledSearchResponseFilters = OptionsAtStartup.Filters.Search.Request.Select(f => new Regex(f, regexOptions));
+            CompiledSearchRequestFilters = OptionsAtStartup.Filters.Search.Request.Select(f => new Regex(f, regexOptions)).ToArray();
 
             State = state;
             State.OnChange(state => State_OnChange(state));
@@ -228,7 +228,7 @@ namespace slskd
         private ISearchService Search { get; set; }
         private IRelayService Relay { get; set; }
         private IMemoryCache Cache { get; set; } = new MemoryCache(new MemoryCacheOptions());
-        private IEnumerable<Regex> CompiledSearchResponseFilters { get; set; }
+        private Regex[] CompiledSearchRequestFilters { get; set; }
         private IEnumerable<Guid> ActiveDownloadIdsAtPreviousShutdown { get; set; } = Enumerable.Empty<Guid>();
         private Options.FlagsOptions Flags { get; set; }
         private IReadOnlyCollection<string> ExcludedSearchPhrases { get; set; } = Enumerable.Empty<string>().ToList();
@@ -1319,7 +1319,7 @@ namespace slskd
                 if (PreviousOptions.Filters.Search.Request.Except(newOptions.Filters.Search.Request).Any()
                     || newOptions.Filters.Search.Request.Except(PreviousOptions.Filters.Search.Request).Any())
                 {
-                    CompiledSearchResponseFilters = newOptions.Filters.Search.Request.Select(f => new Regex(f, RegexOptions.Compiled));
+                    CompiledSearchRequestFilters = newOptions.Filters.Search.Request.Select(f => new Regex(f, RegexOptions.Compiled)).ToArray();
                     Log.Information("Updated and re-compiled search response filters");
                 }
 
@@ -1445,7 +1445,7 @@ namespace slskd
                 return null;
             }
 
-            if (CompiledSearchResponseFilters.Any(filter => filter.IsMatch(query.SearchText)))
+            if (CompiledSearchRequestFilters.Any(filter => filter.IsMatch(query.SearchText)))
             {
                 return null;
             }


### PR DESCRIPTION
Long story short, I discovered the CPU utilization rose substantially for each entry in the list of incoming search request filters, as did garbage collection pressure.  I finally tracked it down to inefficiencies of `IEnumerable` handling; to iterate over one (such as `Any()` in this example) a whole state machine is created, and this can't be optimized out because of the dynamic nature.

I switched the type of collection for the compiled filter regular expressions from `IEnumerable` to `Regex[]` and the computation time for filtering dropped from ~45ms for a list of 30 filters to under 1ms (not sure how many ns but negligible).

<img width="1071" height="734" alt="image" src="https://github.com/user-attachments/assets/980afc2b-de08-408b-939f-e096e405b310" />

Here we see, from left to right:

* 2 search filters
* Distributed network disabled (trying to find the source)
* 15 search filters
* 0 search filters

I'm positive that I've identified the culprit and have verified locally the benefits to this change.  I'm expecting performance with just about any number of filters to be the same as with zero filters once this change is deployed.