### PR TITLE
Ensure lists stored as class property values are read only and properly materialized

### DIFF
--- a/src/slskd/Events/EventService.cs
+++ b/src/slskd/Events/EventService.cs
@@ -48,7 +48,7 @@ public class EventService
     /// <returns>The retrieved list.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the specified <paramref name="offset"/> is less than zero.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the specified <paramref name="limit"/> is zero.</exception>
-    public virtual IReadOnlyCollection<EventRecord> Get(int offset = 0, int limit = int.MaxValue)
+    public virtual IReadOnlyList<EventRecord> Get(int offset = 0, int limit = int.MaxValue)
     {
         if (offset < 0)
         {
@@ -68,7 +68,8 @@ public class EventService
                 .OrderByDescending(e => e.Timestamp)
                 .Skip(offset)
                 .Take(limit)
-                .ToList();
+                .ToList()
+                .AsReadOnly();
 
             return events;
         }

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -160,17 +160,20 @@ namespace slskd.Shares
                 prefix = share.RemotePath + (share.RemotePath.EndsWith('\\') ? string.Empty : '\\');
             }
 
+            // snapshot the current list of repositories
+            var repositories = AllRepositories.ToList();
+
             // Soulseek requires that each directory in the tree have an entry in the list returned in a browse response. if
             // missing, files that are nested within directories which contain only directories (no files) are displayed as being
             // in the root. to get around this, prime a dictionary with all known directories, and an empty Soulseek.Directory. if
             // there are any files in the directory, this entry will be overwritten with a new Soulseek.Directory containing the
             // files. if not they'll be left as is.
-            foreach (var directory in AllRepositories.SelectMany(r => r.ListDirectories(prefix)))
+            foreach (var directory in repositories.SelectMany(r => r.ListDirectories(prefix)))
             {
                 directories.TryAdd(directory, new Directory(directory));
             }
 
-            var files = AllRepositories.SelectMany(r => r.ListFiles(prefix, includeFullPath: true));
+            var files = repositories.SelectMany(r => r.ListFiles(prefix, includeFullPath: true));
 
             var groups = files
                 .GroupBy(file => file.Filename.GetNormalizedDirectoryName())

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -116,7 +116,7 @@ namespace slskd.Shares
         private StorageMode CacheStorageMode { get; }
         private ILogger Log { get; } = Serilog.Log.ForContext<ShareService>();
         private (Host Host, IShareRepository Repository) Local { get; set; }
-        private IEnumerable<IShareRepository> AllRepositories { get; set; }
+        private IReadOnlyCollection<IShareRepository> AllRepositories { get; set; }
 
         /// <summary>
         ///     Adds a new, or updates an existing, share host.
@@ -133,7 +133,9 @@ namespace slskd.Shares
 
             AllRepositories = HostDictionary.Values
                 .Select(value => value.Repository)
-                .Prepend(Local.Repository);
+                .Prepend(Local.Repository)
+                .ToList()
+                .AsReadOnly();
 
             State.SetValue(state => state with
             {
@@ -239,7 +241,9 @@ namespace slskd.Shares
 
             AllRepositories = HostDictionary.Values
                 .Select(value => value.Repository)
-                .Prepend(Local.Repository);
+                .Prepend(Local.Repository)
+                .ToList()
+                .AsReadOnly();
 
             State.SetValue(state => state with
             {

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -322,6 +322,9 @@ namespace slskd.Shares
         ///     Returns the list of all <see cref="Scan"/>  started at or after the specified <paramref name="startedAtOrAfter"/>
         ///     unix timestamp.
         /// </summary>
+        /// <remarks>
+        ///     Note that this returns the scan history for local shares only.
+        /// </remarks>
         /// <param name="startedAtOrAfter">A unix timestamp that serves as the lower bound of the time-based listing.</param>
         /// <returns>The operation context, including the list of found scans.</returns>
         public Task<IEnumerable<Scan>> ListScansAsync(long startedAtOrAfter = 0)

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -59,7 +59,7 @@ namespace slskd.Shares
 
             Local = (host, repository);
 
-            AllRepositories = new List<IShareRepository>(new[] { repository });
+            AllRepositories = [repository];
 
             Scanner = scanner ?? new ShareScanner(
                 workerCount: options.Shares.Cache.Workers,
@@ -116,7 +116,7 @@ namespace slskd.Shares
         private StorageMode CacheStorageMode { get; }
         private ILogger Log { get; } = Serilog.Log.ForContext<ShareService>();
         private (Host Host, IShareRepository Repository) Local { get; set; }
-        private IReadOnlyCollection<IShareRepository> AllRepositories { get; set; }
+        private IReadOnlyList<IShareRepository> AllRepositories { get; set; }
 
         /// <summary>
         ///     Adds a new, or updates an existing, share host.


### PR DESCRIPTION
Following up from #1413 I took a look at all of the stateful service classes and am making various small adjustments to ensure things are stored as read only lists and that they are materialized to memory where needed, instead of potentially allowing lazy enumeration.