### PR TITLE
Fix debug log that displays information about migrations at startup

### DIFF
--- a/src/slskd/Core/Data/Migrator.cs
+++ b/src/slskd/Core/Data/Migrator.cs
@@ -98,7 +98,7 @@ public class Migrator
             throw;
         }
 
-        Log.Debug("Migrations: {Migrations}", new { migrationsToApply, migrationsToSkip });
+        Log.Debug("Migrations: {@Migrations}", new { migrationsToApply, migrationsToSkip });
 
         if (migrationsToApply.Count == 0)
         {


### PR DESCRIPTION
These lists weren't being serialized properly.