### PR TITLE
Refactor initialization of database connection strings

### DIFF
--- a/src/slskd/Core/Data/ConnectionString.cs
+++ b/src/slskd/Core/Data/ConnectionString.cs
@@ -1,0 +1,47 @@
+// <copyright file="ConnectionString.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd;
+
+/// <summary>
+///     A primitive type to differentiate connection strings from other strings.
+/// </summary>
+public record ConnectionString
+{
+    /// <summary>
+    ///     Gets the connection string.
+    /// </summary>
+    public required string Value { get; init; }
+
+    /// <summary>
+    ///     Implicit conversion from string to ConnectionString.
+    /// </summary>
+    /// <param name="value">The string value.</param>
+    public static implicit operator ConnectionString(string value) => new() { Value = value };
+
+    /// <summary>
+    ///     Implicit conversion from ConnectionString to string.
+    /// </summary>
+    /// <param name="connectionString">The ConnectionString instance.</param>
+    public static implicit operator string(ConnectionString connectionString) => connectionString.Value;
+
+    /// <summary>
+    ///     Returns the string representation of the connection string.
+    /// </summary>
+    /// <returns>The connection string value.</returns>
+    public override string ToString() => Value;
+}

--- a/src/slskd/Core/Data/ConnectionStringDictionary.cs
+++ b/src/slskd/Core/Data/ConnectionStringDictionary.cs
@@ -1,0 +1,39 @@
+// <copyright file="ConnectionStringDictionary.cs" company="slskd Team">
+//     Copyright (c) slskd Team. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published
+//     by the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//
+//     You should have received a copy of the GNU Affero General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace slskd;
+
+using System.Collections.Generic;
+
+/// <summary>
+///     Provides a lightweight read-only construct to store connection strings keyed by database name.
+/// </summary>
+public class ConnectionStringDictionary
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ConnectionStringDictionary"/> class.
+    /// </summary>
+    /// <param name="dict">The Dictionary over which to create this read-only copy.</param>
+    public ConnectionStringDictionary(Dictionary<string, ConnectionString> dict)
+    {
+        Strings = dict;
+    }
+
+    private Dictionary<string, ConnectionString> Strings { get; } = [];
+
+    public ConnectionString this[string name] => Strings[name];
+}


### PR DESCRIPTION
I'm working on adding Dapper, which deals with connection strings directly.  Currently the only way to get a connection string is by instantiating an Entity Framework `DbContext`, and that's wasteful and creates further dependency on something I want to remove.

This PR adds `ConnectionStringDictionary`, which is an extremely light, immutable, key-value store of database names and connection strings.  This is injected into the DI container as a singleton and will be available to services downstream.

Also adds a `ConnectionString` class that works like a `string`, just to help avoid confusing the two.