### PR TITLE
Eliminate 'magic strings' when referencing databases and connection strings

### DIFF
--- a/src/slskd/Core/Data/ConnectionString.cs
+++ b/src/slskd/Core/Data/ConnectionString.cs
@@ -22,26 +22,9 @@ namespace slskd;
 /// </summary>
 public record ConnectionString
 {
-    /// <summary>
-    ///     Gets the connection string.
-    /// </summary>
     public required string Value { get; init; }
 
-    /// <summary>
-    ///     Implicit conversion from string to ConnectionString.
-    /// </summary>
-    /// <param name="value">The string value.</param>
     public static implicit operator ConnectionString(string value) => new() { Value = value };
-
-    /// <summary>
-    ///     Implicit conversion from ConnectionString to string.
-    /// </summary>
-    /// <param name="connectionString">The ConnectionString instance.</param>
     public static implicit operator string(ConnectionString connectionString) => connectionString.Value;
-
-    /// <summary>
-    ///     Returns the string representation of the connection string.
-    /// </summary>
-    /// <returns>The connection string value.</returns>
     public override string ToString() => Value;
 }

--- a/src/slskd/Core/Data/Databases.cs
+++ b/src/slskd/Core/Data/Databases.cs
@@ -1,4 +1,4 @@
-// <copyright file="ConnectionStringDictionary.cs" company="slskd Team">
+// <copyright file="Databases.cs" company="slskd Team">
 //     Copyright (c) slskd Team. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -15,21 +15,18 @@
 //     along with this program.  If not, see https://www.gnu.org/licenses/.
 // </copyright>
 
-namespace slskd;
-
-using System.Collections.Generic;
-
 /// <summary>
-///     Provides a lightweight read-only construct to store connection strings keyed by database name.
+///     A primitive type for Database names and a static value for each of them. And a list.
 /// </summary>
-public class ConnectionStringDictionary
+public class Database
 {
-    public ConnectionStringDictionary(Dictionary<Database, ConnectionString> dictionary)
-    {
-        Strings = dictionary;
-    }
+    public static Database Search { get; } = new Database { Name = nameof(Search).ToLower() };
+    public static Database Transfers { get; } = new Database { Name = nameof(Transfers).ToLower() };
+    public static Database Messaging { get; } = new Database { Name = nameof(Messaging).ToLower() };
+    public static Database Events { get; } = new Database { Name = nameof(Events).ToLower() };
+    public static Database[] List { get; } = [Search, Transfers, Messaging, Events];
 
-    private Dictionary<Database, ConnectionString> Strings { get; } = [];
+    public required string Name { get; init; }
 
-    public ConnectionString this[Database database] => Strings[database];
+    public override string ToString() => Name;
 }

--- a/src/slskd/Core/Data/Migrations/Z04012025_TransferStateMigration.cs
+++ b/src/slskd/Core/Data/Migrations/Z04012025_TransferStateMigration.cs
@@ -20,7 +20,6 @@ namespace slskd.Migrations;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using Microsoft.Data.Sqlite;
 using Serilog;
@@ -40,9 +39,13 @@ using slskd.Transfers;
 /// </summary>
 public class Z04012025_TransferStateMigration : IMigration
 {
+    public Z04012025_TransferStateMigration(ConnectionStringDictionary connectionStrings)
+    {
+        ConnectionString = connectionStrings[Database.Transfers];
+    }
+
     private ILogger Log { get; } = Serilog.Log.ForContext<Z04012025_TransferStateMigration>();
-    private string DatabaseName { get; } = "transfers";
-    private string ConnectionString => $"Data Source={Path.Combine(Program.DataDirectory, $"{DatabaseName}.db")}";
+    private string ConnectionString { get; }
 
     public bool NeedsToBeApplied()
     {

--- a/src/slskd/Core/Data/Migrations/Z07062025_TransferIndexesMigration.cs
+++ b/src/slskd/Core/Data/Migrations/Z07062025_TransferIndexesMigration.cs
@@ -18,7 +18,6 @@
 namespace slskd.Migrations;
 
 using System;
-using System.IO;
 using System.Linq;
 using Microsoft.Data.Sqlite;
 using Serilog;
@@ -28,9 +27,13 @@ using Serilog;
 /// </summary>
 public class Z07062025_TransferIndexesMigration : IMigration
 {
+    public Z07062025_TransferIndexesMigration(ConnectionStringDictionary connectionStrings)
+    {
+        ConnectionString = connectionStrings[Database.Transfers];
+    }
+
     private ILogger Log { get; } = Serilog.Log.ForContext<Z07062025_TransferIndexesMigration>();
-    private string DatabaseName { get; } = "transfers";
-    private string ConnectionString => $"Data Source={Path.Combine(Program.DataDirectory, $"{DatabaseName}.db")}";
+    private string ConnectionString { get; }
 
     public bool NeedsToBeApplied()
     {

--- a/src/slskd/Core/Data/Migrations/Z07262025_PrivateMessageWasReplayedMigration.cs
+++ b/src/slskd/Core/Data/Migrations/Z07262025_PrivateMessageWasReplayedMigration.cs
@@ -18,7 +18,6 @@
 namespace slskd.Migrations;
 
 using System;
-using System.IO;
 using System.Linq;
 using Microsoft.Data.Sqlite;
 using Serilog;
@@ -29,9 +28,13 @@ using slskd.Messaging;
 /// </summary>
 public class Z07262025_PrivateMessageWasReplayedMigration : IMigration
 {
+    public Z07262025_PrivateMessageWasReplayedMigration(ConnectionStringDictionary connectionStrings)
+    {
+        ConnectionString = connectionStrings[Database.Messaging];
+    }
+
     private ILogger Log { get; } = Serilog.Log.ForContext<Z07262025_PrivateMessageWasReplayedMigration>();
-    private string DatabaseName { get; } = "messaging";
-    private string ConnectionString => $"Data Source={Path.Combine(Program.DataDirectory, $"{DatabaseName}.db")}";
+    private string ConnectionString { get; }
 
     public bool NeedsToBeApplied()
     {

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -596,25 +596,23 @@ namespace slskd
 
             // wire up all of the connection strings we'll use. this is somewhat annoying but necessary because of the
             // intersection of run-time options (volatile, non-volatile) and ORM/mappers in use (EF, Dapper)
-            var databases = new[] { "search", "transfers", "messaging", "events" };
-
-            var connectionStrings = new ConnectionStringDictionary(databases
+            var connectionStringDictionary = new ConnectionStringDictionary(Database.List
                 .Select(database =>
                 {
                     var connStr = OptionsAtStartup.Flags.Volatile
                         ? $"Data Source=file:{database}?mode=memory;Cache=shared;Pooling=True;"
                         : $"Data Source={Path.Combine(DataDirectory, $"{database}.db")};Cache=shared;Pooling=True;";
 
-                    return new KeyValuePair<string, ConnectionString>(database, connStr);
+                    return new KeyValuePair<Database, ConnectionString>(database, connStr);
                 })
                 .ToDictionary(x => x.Key, x => x.Value));
 
-            services.AddDbContext<SearchDbContext>(connectionStrings["search"]);
-            services.AddDbContext<TransfersDbContext>(connectionStrings["transfers"]);
-            services.AddDbContext<MessagingDbContext>(connectionStrings["messaging"]);
-            services.AddDbContext<EventsDbContext>(connectionStrings["events"]);
+            services.AddDbContext<SearchDbContext>(connectionStringDictionary[Database.Search]);
+            services.AddDbContext<TransfersDbContext>(connectionStringDictionary[Database.Transfers]);
+            services.AddDbContext<MessagingDbContext>(connectionStringDictionary[Database.Messaging]);
+            services.AddDbContext<EventsDbContext>(connectionStringDictionary[Database.Events]);
 
-            services.AddSingleton<ConnectionStringDictionary>(connectionStrings);
+            services.AddSingleton<ConnectionStringDictionary>(connectionStringDictionary);
 
             if (!OptionsAtStartup.Flags.Volatile)
             {
@@ -622,7 +620,7 @@ namespace slskd
                 // bootup process. the presence of a Migrator instance in DI determines whether a migration is needed.
                 // it's important that we keep this list of databases in sync with those used by the application; anything
                 // not in this list will not be able to be migrated.
-                services.AddSingleton<Migrator>(_ => new Migrator(databases));
+                services.AddSingleton<Migrator>(_ => new Migrator(databases: connectionStringDictionary));
             }
 
             services.AddSingleton<EventService>();


### PR DESCRIPTION
With Dapper on the way code will be dealing with specific databases and connection strings more frequently.  This PR adds a primitive `Database` type to represent database names and adjusts the `ConnectionStringDictionary` so that the key is a `Database`.  This type is deliberately designed without implicit conversions to `string`.

Adjusts the `Migration` logic to pass the connection string dictionary down; migrations no longer need to reference databases by name or build connection strings.