### PR TITLE
Fix bug causing 'Value cannot be null. (Parameter 'instance')' while editing a commented-out config

### DIFF
--- a/src/slskd/Core/API/Controllers/OptionsController.cs
+++ b/src/slskd/Core/API/Controllers/OptionsController.cs
@@ -190,6 +190,11 @@ namespace slskd.Core.API
             {
                 var options = yaml.FromYaml<Options>();
 
+                if (options is null)
+                {
+                    return true;
+                }
+
                 if (!options.TryValidate(out var result))
                 {
                     error = result.GetResultView();


### PR DESCRIPTION
Closes #1428 