### PR TITLE
Tweak how file access is handled when validating config

### DIFF
--- a/src/slskd/Common/Validation/FileExistsAttribute.cs
+++ b/src/slskd/Common/Validation/FileExistsAttribute.cs
@@ -53,7 +53,8 @@ namespace slskd.Validation
                     {
                         try
                         {
-                            File.Open(file, FileMode.Open, FileAccess.Value).Dispose();
+                            using var fs = File.Open(file, FileMode.Open, FileAccess.Value);
+                            fs.Close();
                         }
                         catch (IOException)
                         {


### PR DESCRIPTION
A discord user is having a problem where the https PFX file is randomly being reported as being locked.  This PR explicitly closes the file in the validation logic and uses a different method for disposal, just in case it's holding the file open.