### PR TITLE
Refactor transfer progress update logic

### DIFF
--- a/src/slskd/Transfers/Downloads/DownloadService.cs
+++ b/src/slskd/Transfers/Downloads/DownloadService.cs
@@ -155,11 +155,11 @@ namespace slskd.Transfers.Downloads
             using var context = ContextFactory.CreateDbContext();
 
             var existing = context.Transfers
-                    .Where(t => t.Direction == TransferDirection.Download)
-                    .Where(t => t.Username == transfer.Username)
-                    .Where(t => t.Filename == transfer.Filename)
-                    .Where(t => !t.Removed)
-                    .FirstOrDefault();
+                .Where(t => t.Direction == TransferDirection.Download)
+                .Where(t => t.Username == transfer.Username)
+                .Where(t => t.Filename == transfer.Filename)
+                .Where(t => !t.Removed)
+                .FirstOrDefault();
 
             if (existing != default)
             {

--- a/src/slskd/Transfers/Downloads/DownloadService.cs
+++ b/src/slskd/Transfers/Downloads/DownloadService.cs
@@ -283,10 +283,35 @@ namespace slskd.Transfers.Downloads
                                     },
                                     progressUpdated: (args) => rateLimiter.Invoke(() =>
                                     {
-                                        transfer = transfer.WithSoulseekTransfer(args.Transfer);
+                                        // don't do anything unless the `transfer` within the outer scope is in the
+                                        // InProgress state; this will help prevent out-of-band updates that are sometimes
+                                        // being made after the transfer is completed, causing them to appear 'stuck'
+                                        if (transfer.State == TransferStates.InProgress)
+                                        {
+                                            syncRoot.Wait(cts.Token);
 
-                                        // todo: broadcast to signalr hub
-                                        SynchronizedUpdate(transfer);
+                                            try
+                                            {
+                                                // check again to see if the state changed while we were waiting to obtain the lock
+                                                if (transfer.State == TransferStates.InProgress)
+                                                {
+                                                    // update only the properties that we expect to change between progress updates
+                                                    // this helps prevent this update from 'stepping' on other updates
+                                                    transfer.BytesTransferred = args.Transfer.BytesTransferred;
+                                                    transfer.AverageSpeed = args.Transfer.AverageSpeed;
+
+                                                    using var context = ContextFactory.CreateDbContext();
+
+                                                    context.Transfers.Where(t => t.Id == transfer.Id).ExecuteUpdate(setter => setter
+                                                        .SetProperty(t => t.BytesTransferred, transfer.BytesTransferred)
+                                                        .SetProperty(t => t.AverageSpeed, transfer.AverageSpeed));
+                                                }
+                                            }
+                                            finally
+                                            {
+                                                syncRoot.Release();
+                                            }
+                                        }
                                     }));
 
                                 var completedTransfer = await Client.DownloadAsync(


### PR DESCRIPTION
There's an ongoing problem on some systems (particularly those using copy-on-write filesystems like ZFS and Btrfs) where transfers get "stuck" in the database with a state that doesn't include the `Completed` flag, which causes all sorts of issues.

There are basically three ways this can happen:

1. A logical error that causes the transfer to exit "uncleanly" and without updating the database with a final status update
2. A race condition among threads that allows a progress update to happen after the final state update
3. A system- or filesystem-level issue that causes SQLite journal entries to arrive out of order, applying an update from a progress event after the final state update, overwriting a completed status with `InProgress`

I've made a bunch of changes in the past (and recently) to combat vectors 1 and 2, and this PR will help combat both 2 and 3.

Within the logic that updates the database with transfer progress, I've begun using the `ExecuteUpdate` method of EF, which will generate SQL statements similar to `UPDATE ... SET ... WHERE`, specifying only the columns that are explicitly defined in the code.  This sill stop progress updates from updating any column other than `BytesTransferred` or `AverageSpeed`, meaning these updates can't "step" on status anymore.

I've also added some checks that will prevent progress updates at all once the transfer has transitioned out of the `InProgress` state in memory, which should help guard against updates that set `BytesTransferred` to a value that's less than the total size after the transfer is complete, which _should_ be the only way this new logic can malfunction if updates arrive out of order.

There should now be only two scenarios where a transfer gets "stuck":

1. Status updates are applied out of order, e.g. `InProgress -> Completed` is applied `Completed -> InProgress`
2. Some other logical error causes the transfer to end without issuing a final database update

I don't have a solution for 1 and will continue to look for mitigations for 2.