### PR TITLE
Enqueue files one at a time

### DIFF
--- a/src/slskd/Transfers/Downloads/DownloadService.cs
+++ b/src/slskd/Transfers/Downloads/DownloadService.cs
@@ -672,9 +672,25 @@ namespace slskd.Transfers.Downloads
                 throw new ArgumentException("At least one file is required", nameof(files));
             }
 
-            var tasks = files.Select(file => EnqueueAsync(username, file.Filename, file.Size));
+            List<Transfer> transfers = [];
+            List<Exception> exceptions = [];
 
-            var transfers = await Task.WhenAll(tasks);
+            foreach (var file in files)
+            {
+                try
+                {
+                    transfers.Add(await EnqueueAsync(username, file.Filename, file.Size));
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            }
+
+            if (exceptions.Any())
+            {
+                throw new AggregateException(exceptions);
+            }
 
             return transfers.ToList();
         }


### PR DESCRIPTION
Starting the tasks all at the same time seemed to cause some issues, particularly with timeouts.  I think that because they all started instantaneously, the client on the other side couldn't respond in a timely manner.

There's some optimization to do in that flow, I think particularly around quotas.