### PR TITLE
Make search results page size configurable

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -147,6 +147,7 @@
 #   url_base: /
 #   content_path: wwwroot
 #   logging: false
+#   search_page_size: 5
 #   authentication:
 #     disabled: false
 #     username: slskd

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1863,6 +1863,15 @@ namespace slskd
             public bool Logging { get; init; } = false;
 
             /// <summary>
+            ///     Gets the number of search results to display per page in the web UI.
+            /// </summary>
+            [Argument(default, "search-page-size")]
+            [EnvironmentVariable("SEARCH_PAGE_SIZE")]
+            [Description("number of search results to display per page in the web UI")]
+            [Range(1, int.MaxValue)]
+            public int SearchPageSize { get; init; } = 5;
+
+            /// <summary>
             ///     Gets authentication options.
             /// </summary>
             [Validate]

--- a/src/web/src/components/App.jsx
+++ b/src/web/src/components/App.jsx
@@ -555,6 +555,7 @@ class App extends Component {
                       this.withTokenCheck(
                         <div className="view">
                           <Searches
+                            pageSize={applicationOptions?.web?.searchPageSize}
                             server={applicationState.server}
                             {...props}
                           />

--- a/src/web/src/components/Search/Detail/SearchDetail.jsx
+++ b/src/web/src/components/Search/Detail/SearchDetail.jsx
@@ -31,6 +31,7 @@ const SearchDetail = ({
   onCreate,
   onRemove,
   onStop,
+  pageSize,
   removing,
   search,
   stopping,
@@ -50,7 +51,7 @@ const SearchDetail = ({
   const [hideNoFreeSlots, setHideNoFreeSlots] = useState(false);
   const [foldResults, setFoldResults] = useState(false);
   const [resultFilters, setResultFilters] = useState('');
-  const [displayCount, setDisplayCount] = useState(5);
+  const [displayCount, setDisplayCount] = useState(pageSize);
 
   // when the search transitions from !isComplete -> isComplete,
   // fetch the results from the server
@@ -124,7 +125,7 @@ const SearchDetail = ({
     setError(undefined);
     setResults([]);
     setHiddenResults([]);
-    setDisplayCount(5);
+    setDisplayCount(pageSize);
   };
 
   const create = async ({ navigate, search: searchForCreate }) => {
@@ -249,11 +250,12 @@ const SearchDetail = ({
             <Button
               className="showmore-button"
               fluid
-              onClick={() => setDisplayCount(displayCount + 5)}
+              onClick={() => setDisplayCount(displayCount + pageSize)}
               primary
               size="large"
             >
-              Show {remainingCount > 5 ? 5 : remainingCount} More Results{' '}
+              Show {remainingCount > pageSize ? pageSize : remainingCount} More
+              Results{' '}
               {`(${remainingCount} remaining, ${filteredCount} hidden by filter(s))`}
             </Button>
           ) : filteredCount > 0 ? (

--- a/src/web/src/components/Search/Searches.jsx
+++ b/src/web/src/components/Search/Searches.jsx
@@ -12,7 +12,9 @@ import { toast } from 'react-toastify';
 import { Button, Icon, Input, Segment } from 'semantic-ui-react';
 import { v4 as uuidv4 } from 'uuid';
 
-const Searches = ({ server } = {}) => {
+const DEFAULT_PAGE_SIZE = 5;
+
+const Searches = ({ pageSize = DEFAULT_PAGE_SIZE, server } = {}) => {
   const [connecting, setConnecting] = useState(true);
   const [error, setError] = useState(undefined);
   const [searches, setSearches] = useState({});
@@ -188,6 +190,7 @@ const Searches = ({ server } = {}) => {
           onCreate={create}
           onRemove={remove}
           onStop={stop}
+          pageSize={pageSize}
           removing={removing}
           search={searches[searchId]}
           stopping={stopping}


### PR DESCRIPTION
At the moment, the search results page size is hardcoded to 5. This PR makes the page size configurable.

Closes #1371