### PR TITLE
Set concurrent search limit to 2 (from the default 10)

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -591,6 +591,7 @@ namespace slskd
                     maximumConcurrentUploads: OptionsAtStartup.Global.Upload.Slots,
                     maximumConcurrentDownloads: OptionsAtStartup.Global.Download.Slots,
                     minimumDiagnosticLevel: OptionsAtStartup.Soulseek.DiagnosticLevel.ToEnum<Soulseek.Diagnostics.DiagnosticLevel>(),
+                    maximumConcurrentSearches: 2,
                     raiseEventsAsynchronously: true)));
 
             // add the core application service to DI as well as a hosted service so that other services can


### PR DESCRIPTION
Users (and scripts, lidarr automation, etc) can currently execute 10 searches at the same time, which has the capacity to put way too much load on the application and create other problems and resource contention.  This PR lowers that limit to 2, which should should be plenty.