### PR TITLE
Make check of index names in transfer indexes migration case insensitive

### DIFF
--- a/src/slskd/Core/Data/Migrations/Z07062025_TransferIndexesMigration.cs
+++ b/src/slskd/Core/Data/Migrations/Z07062025_TransferIndexesMigration.cs
@@ -41,8 +41,8 @@ public class Z07062025_TransferIndexesMigration : IMigration
         var idxes = SchemaInspector.GetDatabaseIndexes(ConnectionString);
         var txfers = idxes["Transfers"];
 
-        var directionExists = txfers.Any(c => c.Name == "IDX_Transfers_Direction");
-        var stateExists = txfers.Any(c => c.Name == "IDX_Transfers_State");
+        var directionExists = txfers.Any(c => c.Name.Equals("IDX_Transfers_Direction", StringComparison.OrdinalIgnoreCase));
+        var stateExists = txfers.Any(c => c.Name.Equals("IDX_Transfers_State", StringComparison.OrdinalIgnoreCase));
 
         if (directionExists && stateExists)
         {


### PR DESCRIPTION
I noticed that this migration is running every time slskd starts up on one of my systems.  After manually checking the indexes I found that they exist but the name is prefixed with `idx_` not `IDX_`.  I may have created those indexes manually, or there may be some technical or platform specific reason for this; either way, a case insensitive check will fix it.