### PR TITLE
Include agentName when completing agent GetFileStreamAsync

### DIFF
--- a/src/slskd/Relay/API/Hubs/RelayHub.cs
+++ b/src/slskd/Relay/API/Hubs/RelayHub.cs
@@ -218,7 +218,7 @@ namespace slskd.Relay
 
             Log.Warning("Agent {Agent} (connection {ConnectionId}) from {IP} reported upload failure for {Id}: {Message}", record.Agent, Context.ConnectionId, RemoteIpAddress, id, exception.Message);
 
-            Relay.NotifyFileStreamException(id, exception);
+            Relay.NotifyFileStreamException(record.Agent.Name, id, exception);
         }
 
         /// <summary>

--- a/src/slskd/Relay/RelayService.cs
+++ b/src/slskd/Relay/RelayService.cs
@@ -190,9 +190,10 @@ namespace slskd.Relay
         /// <summary>
         ///     Notifies the caller of <see cref="GetFileStreamAsync"/> of a failure to obtain a file stream from the requested agent.
         /// </summary>
+        /// <param name="agentName">The name of the agent.</param>
         /// <param name="id">The unique ID for the stream.</param>
         /// <param name="exception">The remote exception that caused the failure.</param>
-        void NotifyFileStreamException(Guid id, Exception exception);
+        void NotifyFileStreamException(string agentName, Guid id, Exception exception);
 
         /// <summary>
         ///     Registers the specified <paramref name="agent"/> with the specified <paramref name="connectionId"/>.
@@ -656,11 +657,12 @@ namespace slskd.Relay
         /// <summary>
         ///     Notifies the caller of <see cref="GetFileStreamAsync"/> of a failure to obtain a file stream from the requested agent.
         /// </summary>
+        /// <param name="agentName">The name of the agent.</param>
         /// <param name="id">The unique ID for the stream.</param>
         /// <param name="exception">The remote exception that caused the failure.</param>
-        public void NotifyFileStreamException(Guid id, Exception exception)
+        public void NotifyFileStreamException(string agentName, Guid id, Exception exception)
         {
-            var key = new WaitKey(nameof(GetFileStreamAsync), id);
+            var key = new WaitKey(nameof(GetFileStreamAsync), agentName, id);
             Waiter.Throw(key, exception);
         }
 


### PR DESCRIPTION
I noticed that there is a mismatch in the wait key being awaited and the one being completed when agents report a file stream exception.  This would cause transfers to time out instead of failing with a 'file not found' error, if the file couldn't be found or opened on the agent.