### PR TITLE
Add mobile support for the web UI

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         <title>slskd</title>
     </head>
     <body>

--- a/src/web/src/components/App.css
+++ b/src/web/src/components/App.css
@@ -99,6 +99,10 @@
 
 body {
     background-color: var(--background-color);
+    /* Safe area for notched devices (e.g. iPhone X+) */
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+    padding-bottom: env(safe-area-inset-bottom);
 }
 
 .ui.table td, th {
@@ -129,6 +133,69 @@ body {
     overflow: overlay !important;
     position: sticky !important;
     top: 0 !important;
+}
+
+/* Mobile: fixed top bar and content offset */
+.navigation-mobile {
+    overflow: visible !important;
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    z-index: 101;
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+}
+
+.navigation-mobile .menu .item {
+    min-height: 44px;
+    display: inline-flex !important;
+    align-items: center;
+}
+
+.navigation-mobile-drawer {
+    padding-top: env(safe-area-inset-top) !important;
+}
+
+.navigation-mobile-drawer .item {
+    min-height: 44px !important;
+    display: flex !important;
+    align-items: center;
+}
+
+/* Touch-friendly tap targets and layout (mobile) */
+@media (max-width: 767px) {
+    .app,
+    .app-content,
+    .app-content-inner {
+        max-width: 100vw;
+        overflow-x: hidden;
+    }
+
+    .ui.menu .item,
+    .ui.button,
+    .ui.table td .ui.button {
+        min-height: 44px;
+    }
+
+    .view {
+        padding-left: 15px;
+        padding-right: 15px;
+        padding-left: calc(15px + env(safe-area-inset-left));
+        padding-right: calc(15px + env(safe-area-inset-right));
+    }
+
+    .app-content-inner {
+        min-height: 100vh;
+        min-height: calc(100vh - env(safe-area-inset-bottom));
+    }
+
+    /* Prevent iOS zoom on input focus (font-size >= 16px) */
+    .ui.form input[type="text"],
+    .ui.form input[type="password"],
+    .ui.form input[type="search"] {
+        font-size: 16px !important;
+    }
 }
 
 .result-card {
@@ -188,6 +255,18 @@ body {
     padding: 20px !important;
     max-width: 1200px !important;
     margin-bottom: 16px !important;
+}
+
+@media (max-width: 767px) {
+    .ui.grid.login-grid {
+        padding-left: 15px;
+        padding-right: 15px;
+        padding-left: calc(15px + env(safe-area-inset-left));
+        padding-right: calc(15px + env(safe-area-inset-right));
+        padding-top: env(safe-area-inset-top);
+        min-height: 100vh;
+        min-height: calc(100dvh - env(safe-area-inset-bottom));
+    }
 }
 
 .login-button {

--- a/src/web/src/components/App.jsx
+++ b/src/web/src/components/App.jsx
@@ -30,16 +30,22 @@ import {
   Sidebar,
 } from 'semantic-ui-react';
 
+const MOBILE_BREAKPOINT = 767;
+const mobileQuery = () =>
+  window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`);
+
 const initialState = {
   applicationOptions: {},
   applicationState: {},
   error: false,
   initialized: false,
+  isMobile: typeof window !== 'undefined' && mobileQuery().matches,
   login: {
     error: undefined,
     pending: false,
   },
   retriesExhausted: false,
+  sidebarVisible: false,
 };
 
 const ModeSpecificConnectButton = ({
@@ -169,7 +175,18 @@ class App extends Component {
         );
     }
 
+    const mql = mobileQuery();
+    this.mobileMediaListener = () => this.setState({ isMobile: mql.matches });
+    mql.addEventListener('change', this.mobileMediaListener);
+
     this.init();
+  }
+
+  componentWillUnmount() {
+    const mql = mobileQuery();
+    if (this.mobileMediaListener) {
+      mql.removeEventListener('change', this.mobileMediaListener);
+    }
   }
 
   init = async () => {
@@ -268,14 +285,228 @@ class App extends Component {
     return { ...component };
   };
 
+  closeSidebar = () => {
+    this.setState({ sidebarVisible: false });
+  };
+
+  handleToggleSidebar = () => {
+    this.setState((s) => ({ sidebarVisible: !s.sidebarVisible }));
+  };
+
+  renderMobileLayout = ({
+    applicationOptions,
+    applicationState,
+    mainNav,
+    rightMenu,
+    sidebarVisible,
+    theme,
+  }) => {
+    const isAgent = applicationState?.relay?.mode === 'Agent';
+    const { version = {} } = applicationState;
+
+    return (
+      <>
+        <Sidebar.Pushable
+          as={Segment}
+          className="app"
+        >
+          <Sidebar
+            animation="overlay"
+            as={Menu}
+            className="navigation-mobile-drawer"
+            direction="left"
+            icon="labeled"
+            inverted
+            vertical
+            visible={sidebarVisible}
+            width="wide"
+          >
+            {version.isCanary && (
+              <Menu.Item>
+                <Icon
+                  color="yellow"
+                  name="flask"
+                />
+                Canary
+              </Menu.Item>
+            )}
+            {mainNav}
+            {rightMenu}
+          </Sidebar>
+          <Sidebar.Pusher
+            className="app-content"
+            onClick={() => sidebarVisible && this.closeSidebar()}
+          >
+            <Menu
+              className="navigation navigation-mobile"
+              fixed="top"
+              icon="labeled"
+              inverted
+            >
+              <Menu.Item onClick={this.handleToggleSidebar}>
+                <Icon name="sidebar" />
+                Menu
+              </Menu.Item>
+              <Menu.Menu position="right">
+                <ModeSpecificConnectButton
+                  connectionWatchdog={applicationState?.connectionWatchdog}
+                  controller={applicationState?.relay?.controller}
+                  mode={applicationState?.relay?.mode}
+                  pendingReconnect={applicationState?.pendingReconnect}
+                  server={applicationState?.server}
+                  user={applicationState?.user}
+                />
+              </Menu.Menu>
+            </Menu>
+            <div
+              className="app-content-inner"
+              style={{ paddingTop: 52 }}
+            >
+              <AppContext.Provider
+                // eslint-disable-next-line react/jsx-no-constructed-context-values
+                value={{
+                  options: applicationOptions,
+                  state: applicationState,
+                }}
+              >
+                {isAgent ? (
+                  <Switch>
+                    <Route
+                      path={`${urlBase}/system/:tab?`}
+                      render={(props) =>
+                        this.withTokenCheck(
+                          <System
+                            {...props}
+                            options={applicationOptions}
+                            state={applicationState}
+                          />,
+                        )
+                      }
+                    />
+                    <Redirect
+                      from="*"
+                      to={`${urlBase}/system`}
+                    />
+                  </Switch>
+                ) : (
+                  <Switch>
+                    <Route
+                      path={`${urlBase}/searches/:id?`}
+                      render={(props) =>
+                        this.withTokenCheck(
+                          <div className="view">
+                            <Searches
+                              server={applicationState.server}
+                              {...props}
+                            />
+                          </div>,
+                        )
+                      }
+                    />
+                    <Route
+                      path={`${urlBase}/browse`}
+                      render={(props) =>
+                        this.withTokenCheck(<Browse {...props} />)
+                      }
+                    />
+                    <Route
+                      path={`${urlBase}/users`}
+                      render={(props) =>
+                        this.withTokenCheck(<Users {...props} />)
+                      }
+                    />
+                    <Route
+                      path={`${urlBase}/chat`}
+                      render={(props) =>
+                        this.withTokenCheck(
+                          <Chat
+                            {...props}
+                            state={applicationState}
+                          />,
+                        )
+                      }
+                    />
+                    <Route
+                      path={`${urlBase}/rooms`}
+                      render={(props) =>
+                        this.withTokenCheck(<Rooms {...props} />)
+                      }
+                    />
+                    <Route
+                      path={`${urlBase}/uploads`}
+                      render={(props) =>
+                        this.withTokenCheck(
+                          <div className="view">
+                            <Transfers
+                              {...props}
+                              direction="upload"
+                            />
+                          </div>,
+                        )
+                      }
+                    />
+                    <Route
+                      path={`${urlBase}/downloads`}
+                      render={(props) =>
+                        this.withTokenCheck(
+                          <div className="view">
+                            <Transfers
+                              {...props}
+                              direction="download"
+                              server={applicationState.server}
+                            />
+                          </div>,
+                        )
+                      }
+                    />
+                    <Route
+                      path={`${urlBase}/system/:tab?`}
+                      render={(props) =>
+                        this.withTokenCheck(
+                          <System
+                            {...props}
+                            options={applicationOptions}
+                            state={applicationState}
+                            theme={theme}
+                          />,
+                        )
+                      }
+                    />
+                    <Redirect
+                      from="*"
+                      to={`${urlBase}/searches`}
+                    />
+                  </Switch>
+                )}
+              </AppContext.Provider>
+            </div>
+          </Sidebar.Pusher>
+        </Sidebar.Pushable>
+        <ToastContainer
+          autoClose={5_000}
+          closeOnClick
+          draggable={false}
+          hideProgressBar={false}
+          newestOnTop
+          pauseOnFocusLoss
+          pauseOnHover
+          position="bottom-center"
+          rtl={false}
+        />
+      </>
+    );
+  };
+
   render() {
     const {
       applicationOptions = {},
       applicationState = {},
       error,
       initialized,
+      isMobile,
       login,
       retriesExhausted,
+      sidebarVisible,
       theme = this.getSavedTheme() ||
         (window.matchMedia('(prefers-color-scheme: dark)').matches
           ? 'dark'
@@ -342,6 +573,154 @@ class App extends Component {
       document.documentElement.classList.remove('dark');
     }
 
+    const closeSidebar = this.closeSidebar;
+    const navLink = (to, iconName, label) => (
+      <Link
+        key={to}
+        onClick={isMobile ? closeSidebar : undefined}
+        to={to}
+      >
+        <Menu.Item>
+          <Icon name={iconName} />
+          {label}
+        </Menu.Item>
+      </Link>
+    );
+
+    const mainNav = isAgent ? (
+      <Menu.Item>
+        <Icon name="detective" />
+        Agent Mode
+      </Menu.Item>
+    ) : (
+      <>
+        {navLink(`${urlBase}/searches`, 'search', 'Search')}
+        {navLink(`${urlBase}/downloads`, 'download', 'Downloads')}
+        {navLink(`${urlBase}/uploads`, 'upload', 'Uploads')}
+        {navLink(`${urlBase}/rooms`, 'comments', 'Rooms')}
+        {navLink(`${urlBase}/chat`, 'comment', 'Chat')}
+        {navLink(`${urlBase}/users`, 'users', 'Users')}
+        {navLink(`${urlBase}/browse`, 'folder open', 'Browse')}
+      </>
+    );
+
+    const rightMenu = (
+      <>
+        <Menu.Item onClick={() => this.toggleTheme()}>
+          <Icon name="theme" />
+          Theme
+        </Menu.Item>
+        <ModeSpecificConnectButton
+          connectionWatchdog={connectionWatchdog}
+          controller={controller}
+          mode={mode}
+          pendingReconnect={pendingReconnect}
+          server={server}
+          user={user}
+        />
+        {(pendingReconnect || pendingRestart || pendingShareRescan) && (
+          <Menu.Item>
+            <Icon.Group className="menu-icon-group">
+              <Link
+                onClick={isMobile ? closeSidebar : undefined}
+                to={`${urlBase}/system/info`}
+              >
+                <Icon
+                  color="yellow"
+                  name="exclamation circle"
+                />
+              </Link>
+            </Icon.Group>
+            Pending Action
+          </Menu.Item>
+        )}
+        {isUpdateAvailable && (
+          <Modal
+            centered
+            closeIcon
+            size="mini"
+            trigger={
+              <Menu.Item>
+                <Icon.Group className="menu-icon-group">
+                  <Icon
+                    color="yellow"
+                    name="bullhorn"
+                  />
+                </Icon.Group>
+                New Version!
+              </Menu.Item>
+            }
+          >
+            <Modal.Header>New Version!</Modal.Header>
+            <Modal.Content>
+              <p>
+                You are currently running version <strong>{current}</strong>{' '}
+                while version <strong>{latest}</strong> is available.
+              </p>
+            </Modal.Content>
+            <Modal.Actions>
+              <Button
+                fluid
+                href="https://github.com/slskd/slskd/releases"
+                primary
+                style={{ marginLeft: 0 }}
+              >
+                See Release Notes
+              </Button>
+            </Modal.Actions>
+          </Modal>
+        )}
+        <Link
+          onClick={isMobile ? closeSidebar : undefined}
+          to={`${urlBase}/system`}
+        >
+          <Menu.Item>
+            <Icon name="cogs" />
+            System
+          </Menu.Item>
+        </Link>
+        {session.isLoggedIn() && (
+          <Modal
+            actions={[
+              'Cancel',
+              {
+                content: 'Log Out',
+                key: 'done',
+                negative: true,
+                onClick: this.logout,
+              },
+            ]}
+            centered
+            content="Are you sure you want to log out?"
+            header={
+              <Header
+                content="Confirm Log Out"
+                icon="sign-out"
+              />
+            }
+            size="mini"
+            trigger={
+              <Menu.Item>
+                <Icon name="sign-out" />
+                Log Out
+              </Menu.Item>
+            }
+          />
+        )}
+      </>
+    );
+
+    if (isMobile) {
+      return this.renderMobileLayout({
+        applicationOptions,
+        applicationState,
+        mainNav,
+        rightMenu,
+        sidebarVisible,
+        theme,
+      });
+    }
+
     return (
       <>
         <Sidebar.Pushable
@@ -368,157 +747,12 @@ class App extends Component {
                 Canary
               </Menu.Item>
             )}
-            {isAgent ? (
-              <Menu.Item>
-                <Icon name="detective" />
-                Agent Mode
-              </Menu.Item>
-            ) : (
-              <>
-                <Link to={`${urlBase}/searches`}>
-                  <Menu.Item>
-                    <Icon name="search" />
-                    Search
-                  </Menu.Item>
-                </Link>
-                <Link to={`${urlBase}/downloads`}>
-                  <Menu.Item>
-                    <Icon name="download" />
-                    Downloads
-                  </Menu.Item>
-                </Link>
-                <Link to={`${urlBase}/uploads`}>
-                  <Menu.Item>
-                    <Icon name="upload" />
-                    Uploads
-                  </Menu.Item>
-                </Link>
-                <Link to={`${urlBase}/rooms`}>
-                  <Menu.Item>
-                    <Icon name="comments" />
-                    Rooms
-                  </Menu.Item>
-                </Link>
-                <Link to={`${urlBase}/chat`}>
-                  <Menu.Item>
-                    <Icon name="comment" />
-                    Chat
-                  </Menu.Item>
-                </Link>
-                <Link to={`${urlBase}/users`}>
-                  <Menu.Item>
-                    <Icon name="users" />
-                    Users
-                  </Menu.Item>
-                </Link>
-                <Link to={`${urlBase}/browse`}>
-                  <Menu.Item>
-                    <Icon name="folder open" />
-                    Browse
-                  </Menu.Item>
-                </Link>
-              </>
-            )}
+            {mainNav}
             <Menu
               className="right"
               inverted
             >
-              <Menu.Item onClick={() => this.toggleTheme()}>
-                <Icon name="theme" />
-                Theme
-              </Menu.Item>
-              <ModeSpecificConnectButton
-                connectionWatchdog={connectionWatchdog}
-                controller={controller}
-                mode={mode}
-                pendingReconnect={pendingReconnect}
-                server={server}
-                user={user}
-              />
-              {(pendingReconnect || pendingRestart || pendingShareRescan) && (
-                <Menu.Item position="right">
-                  <Icon.Group className="menu-icon-group">
-                    <Link to={`${urlBase}/system/info`}>
-                      <Icon
-                        color="yellow"
-                        name="exclamation circle"
-                      />
-                    </Link>
-                  </Icon.Group>
-                  Pending Action
-                </Menu.Item>
-              )}
-              {isUpdateAvailable && (
-                <Modal
-                  centered
-                  closeIcon
-                  size="mini"
-                  trigger={
-                    <Menu.Item position="right">
-                      <Icon.Group className="menu-icon-group">
-                        <Icon
-                          color="yellow"
-                          name="bullhorn"
-                        />
-                      </Icon.Group>
-                      New Version!
-                    </Menu.Item>
-                  }
-                >
-                  <Modal.Header>New Version!</Modal.Header>
-                  <Modal.Content>
-                    <p>
-                      You are currently running version{' '}
-                      <strong>{current}</strong>
-                      while version <strong>{latest}</strong> is available.
-                    </p>
-                  </Modal.Content>
-                  <Modal.Actions>
-                    <Button
-                      fluid
-                      href="https://github.com/slskd/slskd/releases"
-                      primary
-                      style={{ marginLeft: 0 }}
-                    >
-                      See Release Notes
-                    </Button>
-                  </Modal.Actions>
-                </Modal>
-              )}
-              <Link to={`${urlBase}/system`}>
-                <Menu.Item>
-                  <Icon name="cogs" />
-                  System
-                </Menu.Item>
-              </Link>
-              {session.isLoggedIn() && (
-                <Modal
-                  actions={[
-                    'Cancel',
-                    {
-                      content: 'Log Out',
-                      key: 'done',
-                      negative: true,
-                      onClick: this.logout,
-                    },
-                  ]}
-                  centered
-                  content="Are you sure you want to log out?"
-                  header={
-                    <Header
-                      content="Confirm Log Out"
-                      icon="sign-out"
-                    />
-                  }
-                  size="mini"
-                  trigger={
-                    <Menu.Item>
-                      <Icon name="sign-out" />
-                      Log Out
-                    </Menu.Item>
-                  }
-                />
-              )}
+              {rightMenu}
             </Menu>
           </Sidebar>
           <Sidebar.Pusher className="app-content">

--- a/src/web/src/components/LoginForm.jsx
+++ b/src/web/src/components/LoginForm.jsx
@@ -50,11 +50,15 @@ const LoginForm = ({ error, loading, onLoginAttempt }) => {
 
   return (
     <Grid
-      style={{ height: '100vh' }}
+      className="login-grid"
+      style={{ height: '100vh', margin: 0 }}
       textAlign="center"
       verticalAlign="middle"
     >
-      <Grid.Column style={{ maxWidth: 372 }}>
+      <Grid.Column
+        style={{ maxWidth: 372 }}
+        width={16}
+      >
         <Header
           as="h2"
           style={{


### PR DESCRIPTION
## Summary
Makes the web app usable on phones with a responsive layout, touch-friendly controls, and support for notched devices.

## Changes

### Navigation
- **Mobile (≤767px):** Top bar with a hamburger that opens a left overlay drawer containing all nav links (Search, Downloads, Uploads, Rooms, Chat, Users, Browse) and right-side items (Theme, connection status, System, Log out). Tapping a link or the overlay closes the drawer.
- **Desktop:** Unchanged horizontal top menu.
- Breakpoint and layout switch are driven by `matchMedia('(max-width: 767px)')` with a listener so orientation/resize is handled without refresh.

### Layout & styling
- **Safe areas:** `env(safe-area-inset-*)` applied on `body`, the mobile top bar, and the drawer so content stays clear of notches and home indicators.
- **Touch targets:** Buttons and menu items use at least 44px height on mobile.
- **View padding:** Main content gets horizontal padding plus safe-area insets on small screens; horizontal overflow is constrained to avoid scrolling the whole page.
- **Login:** Login form is full-width on small screens with safe-area padding; grid uses a dedicated class for mobile spacing.

### Other notes
- `viewport-fit=cover` set in `index.html` so safe-area insets apply on supported devices.
- Form inputs use 16px font size on mobile to reduce zoom-on-focus.
- Mobile shell is rendered in `renderMobileLayout()` to keep `render()` complexity within the lint limit; shared nav and right-menu fragments are reused for both layouts.
