### PR TITLE
Ensure execute bits are set on directory mode

### DIFF
--- a/src/slskd/Files/FileExtensions.cs
+++ b/src/slskd/Files/FileExtensions.cs
@@ -59,4 +59,32 @@ public static class FileExtensions
 
         return (UnixFileMode)mode;
     }
+
+    /// <summary>
+    ///     Returns the specified <paramref name="unixFileMode"/> with execute flags added for each read flag, ensuring that the resulting
+    ///     mask can be used for directories (which require the execute flag for traversal).
+    /// </summary>
+    /// <param name="unixFileMode">The existing mode.</param>
+    /// <returns>The updated mode.</returns>
+    public static UnixFileMode WithExecuteFlagsForEachReadFlag(this UnixFileMode unixFileMode)
+    {
+        var u = unixFileMode;
+
+        if (u.HasFlag(UnixFileMode.UserRead))
+        {
+            u |= UnixFileMode.UserExecute;
+        }
+
+        if (u.HasFlag(UnixFileMode.GroupRead))
+        {
+            u |= UnixFileMode.GroupExecute;
+        }
+
+        if (u.HasFlag(UnixFileMode.OtherRead))
+        {
+            u |= UnixFileMode.OtherExecute;
+        }
+
+        return u;
+    }
 }

--- a/src/slskd/Files/FileService.cs
+++ b/src/slskd/Files/FileService.cs
@@ -333,7 +333,7 @@ namespace slskd.Files
             {
                 if (!OperatingSystem.IsWindows() && unixCreateMode.HasValue)
                 {
-                    Directory.CreateDirectory(path, unixCreateMode.Value);
+                    Directory.CreateDirectory(path, unixCreateMode.Value.WithExecuteFlagsForEachReadFlag());
                 }
                 else
                 {
@@ -407,7 +407,7 @@ namespace slskd.Files
             {
                 if (!OperatingSystem.IsWindows() && unixCreateMode.HasValue)
                 {
-                    Directory.CreateDirectory(destinationDirectory, unixCreateMode.Value);
+                    Directory.CreateDirectory(destinationDirectory, unixCreateMode.Value.WithExecuteFlagsForEachReadFlag());
                 }
                 else
                 {

--- a/tests/slskd.Tests.Unit/Files/FileExtensionsTests.cs
+++ b/tests/slskd.Tests.Unit/Files/FileExtensionsTests.cs
@@ -68,4 +68,79 @@ public class FileExtensionsTests
         Assert.NotNull(ex);
         Assert.IsType<ArgumentOutOfRangeException>(ex);
     }
+
+    [Fact]
+    public void WithExecuteFlagsForEachReadFlag_Adds_UserExecute_When_UserRead_Is_Set()
+    {
+        var result = UnixFileMode.UserRead.WithExecuteFlagsForEachReadFlag();
+
+        Assert.True(result.HasFlag(UnixFileMode.UserExecute));
+    }
+
+    [Fact]
+    public void WithExecuteFlagsForEachReadFlag_Adds_GroupExecute_When_GroupRead_Is_Set()
+    {
+        var result = UnixFileMode.GroupRead.WithExecuteFlagsForEachReadFlag();
+
+        Assert.True(result.HasFlag(UnixFileMode.GroupExecute));
+    }
+
+    [Fact]
+    public void WithExecuteFlagsForEachReadFlag_Adds_OtherExecute_When_OtherRead_Is_Set()
+    {
+        var result = UnixFileMode.OtherRead.WithExecuteFlagsForEachReadFlag();
+
+        Assert.True(result.HasFlag(UnixFileMode.OtherExecute));
+    }
+
+    [Fact]
+    public void WithExecuteFlagsForEachReadFlag_Does_Not_Add_UserExecute_When_UserRead_Is_Not_Set()
+    {
+        var result = UnixFileMode.UserWrite.WithExecuteFlagsForEachReadFlag();
+
+        Assert.False(result.HasFlag(UnixFileMode.UserExecute));
+    }
+
+    [Fact]
+    public void WithExecuteFlagsForEachReadFlag_Does_Not_Add_GroupExecute_When_GroupRead_Is_Not_Set()
+    {
+        var result = UnixFileMode.GroupWrite.WithExecuteFlagsForEachReadFlag();
+
+        Assert.False(result.HasFlag(UnixFileMode.GroupExecute));
+    }
+
+    [Fact]
+    public void WithExecuteFlagsForEachReadFlag_Does_Not_Add_OtherExecute_When_OtherRead_Is_Not_Set()
+    {
+        var result = UnixFileMode.OtherWrite.WithExecuteFlagsForEachReadFlag();
+
+        Assert.False(result.HasFlag(UnixFileMode.OtherExecute));
+    }
+
+    [Fact]
+    public void WithExecuteFlagsForEachReadFlag_Preserves_Existing_Flags()
+    {
+        var mode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead;
+
+        var result = mode.WithExecuteFlagsForEachReadFlag();
+
+        Assert.True(result.HasFlag(UnixFileMode.UserRead));
+        Assert.True(result.HasFlag(UnixFileMode.UserWrite));
+        Assert.True(result.HasFlag(UnixFileMode.GroupRead));
+    }
+
+    [Theory]
+    [InlineData(UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead,
+        UnixFileMode.UserRead | UnixFileMode.UserExecute | UnixFileMode.GroupRead | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute)]
+    [InlineData(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead,
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.GroupRead | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute)]
+    [InlineData(UnixFileMode.None, UnixFileMode.None)]
+    [InlineData(UnixFileMode.UserWrite | UnixFileMode.GroupWrite | UnixFileMode.OtherWrite,
+        UnixFileMode.UserWrite | UnixFileMode.GroupWrite | UnixFileMode.OtherWrite)]
+    public void WithExecuteFlagsForEachReadFlag_Works_As_Expected(UnixFileMode input, UnixFileMode expected)
+    {
+        var result = input.WithExecuteFlagsForEachReadFlag();
+
+        Assert.Equal(expected, result);
+    }
 }


### PR DESCRIPTION
#1638 began applying user-defined unix file mode to directories as well as files, but the .NET framework takes the provided mode exactly as given and execute flags for classes with read access were not applied as expected.  This PR ensures that the execute flag is properly set.