### PR TITLE
fix favicon.ico relative path

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -4,6 +4,7 @@
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>slskd</title>
+        <link rel="shortcut icon" href="./favicon.ico" />
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
In case slskd is hosted not under `/` base URL but rather something like `/slskd`.

By default browsers try to fetch `/favicon.ico` which is not there, but this PR fixes it to become relative to the HTML file.