### PR TITLE
feat: peer-to-browser audio streaming via /api/v0/stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .DS_Store
 /src/slskd/bin/
 /src/slskd/obj/
-/src/slskd/wwwroot/
+# /src/slskd/wwwroot/ — removed: replaced Angular build output with static vanilla JS
 /src/slskd/slskd.csproj.user
 /TestResults/
 /dist/

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -782,6 +782,8 @@ namespace slskd
             services.AddSingleton<IUploadService, UploadService>();
             services.AddSingleton<FileService>();
 
+            services.AddSingleton<slskd.Stream.IStreamService, slskd.Stream.StreamService>();
+
             services.AddSingleton<IRelayService, RelayService>();
 
             services.AddSingleton<IFTPClientFactory, FTPClientFactory>();
@@ -1111,6 +1113,7 @@ namespace slskd
                 endpoints.MapHub<LogsHub>("/hub/logs");
                 endpoints.MapHub<SearchHub>("/hub/search");
                 endpoints.MapHub<RelayHub>("/hub/relay");
+                endpoints.MapHub<slskd.Stream.StreamHub>("/hub/stream");
 
                 endpoints.MapControllers();
                 endpoints.MapHealthChecks("/health");

--- a/src/slskd/Stream/API/Controllers/StreamController.cs
+++ b/src/slskd/Stream/API/Controllers/StreamController.cs
@@ -88,12 +88,13 @@ namespace slskd.Stream.API
 
             // iOS Safari (WebKit) sends Range: bytes=0- on the first request to any audio src.
             // Without a 206 + Content-Range response the audio element stalls immediately.
-            // We don't support arbitrary seeking in v1, so we always respond as if the full
-            // file starts at byte 0 and the total length is unknown (*).
+            // RFC 7233 requires last-byte-pos to be a digit — "bytes 0-/*" is invalid.
+            // Use "bytes 0-1/2" as the minimal valid 206 that satisfies WebKit's range check;
+            // the actual body is still the full streaming response.
             if (Request.Headers.ContainsKey(HeaderNames.Range))
             {
                 Response.StatusCode = 206;
-                Response.Headers["Content-Range"] = "bytes 0-/*";
+                Response.Headers["Content-Range"] = "bytes 0-1/2";
                 Response.Headers["Accept-Ranges"] = "bytes";
             }
 

--- a/src/slskd/Stream/API/Controllers/StreamController.cs
+++ b/src/slskd/Stream/API/Controllers/StreamController.cs
@@ -1,0 +1,143 @@
+// <copyright file="StreamController.cs" company="JP Dillingham">
+//           ▄▄▄▄     ▄▄▄▄     ▄▄▄▄
+//     ▄▄▄▄▄▄█  █▄▄▄▄▄█  █▄▄▄▄▄█  █
+//     █__ --█  █__ --█    ◄█  -  █
+//     █▄▄▄▄▄█▄▄█▄▄▄▄▄█▄▄█▄▄█▄▄▄▄▄█
+//   ┍━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ━━━━ ━  ━┉   ┉     ┉
+//   │ Copyright (c) JP Dillingham.
+//   │
+//   │ This program is free software: you can redistribute it and/or modify
+//   │ it under the terms of the GNU Affero General Public License as published
+//   │ by the Free Software Foundation, version 3.
+//   │
+//   │ This program is distributed in the hope that it will be useful,
+//   │ but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   │ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   │ GNU Affero General Public License for more details.
+//   │
+//   │ You should have received a copy of the GNU Affero General Public License
+//   │ along with this program.  If not, see https://www.gnu.org/licenses/.
+//   │
+//   │ https://slskd.org
+//   │
+//   ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ╌ ╌╌╌╌ ╌
+//   │ SPDX-FileCopyrightText: JP Dillingham
+//   │ SPDX-License-Identifier: AGPL-3.0-only
+//   ╰───────────────────────────────────────────╶──── ─ ─── ─  ── ──┈  ┈
+// </copyright>
+
+namespace slskd.Stream.API
+{
+    using System;
+    using System.IO;
+    using System.IO.Pipelines;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Net.Http.Headers;
+
+    /// <summary>
+    ///     Streaming audio from a Soulseek peer directly to the browser.
+    ///
+    ///     Request flow:
+    ///
+    ///       GET /api/v0/stream/{username}/{**filename}
+    ///              │
+    ///              ├─ Sets Content-Type from file extension
+    ///              ├─ If iOS/WebKit sends Range: bytes=0- → responds 206 + Content-Range
+    ///              │   so Safari's audio element doesn't stall
+    ///              │
+    ///              ├─ Creates a Pipe (64KB segments, 1MB backpressure window)
+    ///              ├─ Fire-and-forgets write task (peer → PipeWriter)
+    ///              └─ Awaits pipe.Reader.CopyToAsync(Response.Body)
+    ///                   │
+    ///                   └─ 30-second stall timeout cancels both sides
+    /// </summary>
+    [Route("api/v{version:apiVersion}/stream")]
+    [ApiVersion("0")]
+    public class StreamController : ControllerBase
+    {
+        public StreamController(IStreamService streamService)
+        {
+            Streams = streamService;
+        }
+
+        private IStreamService Streams { get; }
+
+        /// <summary>
+        ///     Stream a file from a Soulseek peer.
+        /// </summary>
+        /// <param name="username">The Soulseek username of the peer.</param>
+        /// <param name="filename">The remote file path as reported by the peer's browse/search results.</param>
+        /// <param name="cancellationToken">Cancelled when the browser closes the connection.</param>
+        [HttpGet("{username}/{**filename}")]
+        [Authorize(Policy = AuthPolicy.Any)]
+        public async Task StreamFile(
+            [FromRoute] string username,
+            [FromRoute] string filename,
+            CancellationToken cancellationToken)
+        {
+            var pipe = new Pipe(new PipeOptions(
+                minimumSegmentSize: 65536,        // 64 KB segments — reduces allocations for audio payloads
+                pauseWriterThreshold: 1048576,    // pause peer download when 1 MB is buffered
+                resumeWriterThreshold: 524288));  // resume when buffer drains to 512 KB
+
+            Response.ContentType = GuessContentType(filename);
+
+            // iOS Safari (WebKit) sends Range: bytes=0- on the first request to any audio src.
+            // Without a 206 + Content-Range response the audio element stalls immediately.
+            // We don't support arbitrary seeking in v1, so we always respond as if the full
+            // file starts at byte 0 and the total length is unknown (*).
+            if (Request.Headers.ContainsKey(HeaderNames.Range))
+            {
+                Response.StatusCode = 206;
+                Response.Headers["Content-Range"] = "bytes 0-/*";
+                Response.Headers["Accept-Ranges"] = "bytes";
+            }
+
+            // 30-second stall timeout: if the peer stops sending data (or the browser stops
+            // consuming it) for 30 seconds we cancel both the read and write sides so the
+            // connection closes rather than leaking indefinitely.
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+            try
+            {
+                // Fire-and-forget: write task feeds bytes from the peer into the pipe.
+                // We deliberately do NOT await it here — if we used Task.WhenAll and both
+                // tasks faulted, the second exception would be swallowed.  Instead the write
+                // task completes the PipeWriter (with or without an exception) which causes
+                // CopyToAsync on the reader side to return/throw naturally.
+                _ = Streams.StreamToPipeAsync(username, filename, pipe.Writer, linkedCts.Token);
+
+                await pipe.Reader.CopyToAsync(Response.Body, linkedCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Browser closed the tab / stall timeout fired — clean exit, no error to surface.
+            }
+            finally
+            {
+                // Always release the reader regardless of outcome to avoid pipe memory leaks.
+                await pipe.Reader.CompleteAsync();
+            }
+        }
+
+        /// <summary>
+        ///     Infers an audio MIME type from the file extension.
+        ///     Falls back to application/octet-stream for unknown types.
+        /// </summary>
+        internal static string GuessContentType(string filename) =>
+            Path.GetExtension(filename).ToLowerInvariant() switch
+            {
+                ".mp3"  => "audio/mpeg",
+                ".flac" => "audio/flac",
+                ".ogg"  => "audio/ogg",
+                ".m4a"  => "audio/mp4",
+                ".wav"  => "audio/wav",
+                _       => "application/octet-stream",
+            };
+    }
+}

--- a/src/slskd/Stream/API/Controllers/StreamController.cs
+++ b/src/slskd/Stream/API/Controllers/StreamController.cs
@@ -129,7 +129,7 @@ namespace slskd.Stream.API
         ///     Infers an audio MIME type from the file extension.
         ///     Falls back to application/octet-stream for unknown types.
         /// </summary>
-        internal static string GuessContentType(string filename) =>
+        public static string GuessContentType(string filename) =>
             Path.GetExtension(filename).ToLowerInvariant() switch
             {
                 ".mp3"  => "audio/mpeg",

--- a/src/slskd/Stream/StreamHub.cs
+++ b/src/slskd/Stream/StreamHub.cs
@@ -1,0 +1,50 @@
+// <copyright file="StreamHub.cs" company="JP Dillingham">
+//           ▄▄▄▄     ▄▄▄▄     ▄▄▄▄
+//     ▄▄▄▄▄▄█  █▄▄▄▄▄█  █▄▄▄▄▄█  █
+//     █__ --█  █__ --█    ◄█  -  █
+//     █▄▄▄▄▄█▄▄█▄▄▄▄▄█▄▄█▄▄█▄▄▄▄▄█
+//   ┍━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ━━━━ ━  ━┉   ┉     ┉
+//   │ Copyright (c) JP Dillingham.
+//   │
+//   │ This program is free software: you can redistribute it and/or modify
+//   │ it under the terms of the GNU Affero General Public License as published
+//   │ by the Free Software Foundation, version 3.
+//   │
+//   │ This program is distributed in the hope that it will be useful,
+//   │ but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   │ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   │ GNU Affero General Public License for more details.
+//   │
+//   │ You should have received a copy of the GNU Affero General Public License
+//   │ along with this program.  If not, see https://www.gnu.org/licenses/.
+//   │
+//   │ https://slskd.org
+//   │
+//   ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ╌ ╌╌╌╌ ╌
+//   │ SPDX-FileCopyrightText: JP Dillingham
+//   │ SPDX-License-Identifier: AGPL-3.0-only
+//   ╰───────────────────────────────────────────╶──── ─ ─── ─  ── ──┈  ┈
+// </copyright>
+
+namespace slskd.Stream
+{
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.SignalR;
+
+    /// <summary>
+    ///     Event method names for the stream SignalR hub.
+    /// </summary>
+    public static class StreamHubMethods
+    {
+        /// <summary>Fired when a peer disconnects mid-stream.</summary>
+        public static readonly string StreamError = "streamError";
+    }
+
+    /// <summary>
+    ///     SignalR hub for real-time stream status events.
+    /// </summary>
+    [Authorize(Policy = AuthPolicy.Any)]
+    public class StreamHub : Hub
+    {
+    }
+}

--- a/src/slskd/Stream/StreamService.cs
+++ b/src/slskd/Stream/StreamService.cs
@@ -1,0 +1,112 @@
+// <copyright file="StreamService.cs" company="JP Dillingham">
+//           ▄▄▄▄     ▄▄▄▄     ▄▄▄▄
+//     ▄▄▄▄▄▄█  █▄▄▄▄▄█  █▄▄▄▄▄█  █
+//     █__ --█  █__ --█    ◄█  -  █
+//     █▄▄▄▄▄█▄▄█▄▄▄▄▄█▄▄█▄▄█▄▄▄▄▄█
+//   ┍━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ━━━━ ━  ━┉   ┉     ┉
+//   │ Copyright (c) JP Dillingham.
+//   │
+//   │ This program is free software: you can redistribute it and/or modify
+//   │ it under the terms of the GNU Affero General Public License as published
+//   │ by the Free Software Foundation, version 3.
+//   │
+//   │ This program is distributed in the hope that it will be useful,
+//   │ but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   │ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   │ GNU Affero General Public License for more details.
+//   │
+//   │ You should have received a copy of the GNU Affero General Public License
+//   │ along with this program.  If not, see https://www.gnu.org/licenses/.
+//   │
+//   │ https://slskd.org
+//   │
+//   ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ╌ ╌╌╌╌ ╌
+//   │ SPDX-FileCopyrightText: JP Dillingham
+//   │ SPDX-License-Identifier: AGPL-3.0-only
+//   ╰───────────────────────────────────────────╶──── ─ ─── ─  ── ──┈  ┈
+// </copyright>
+
+namespace slskd.Stream
+{
+    using System;
+    using System.IO.Pipelines;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.SignalR;
+    using Soulseek;
+
+    /// <summary>
+    ///     Bridges a Soulseek peer download directly to an HTTP response body via a Pipe.
+    ///
+    ///     Data flow:
+    ///
+    ///       Peer TCP ──► Soulseek.NET ──► PipeWriter.AsStream()
+    ///                                           │
+    ///                                     (backpressure)
+    ///                                           │
+    ///                                     PipeReader.CopyToAsync()
+    ///                                           │
+    ///                                     HTTP chunked response ──► browser
+    ///
+    ///     The write task is fire-and-forget; the controller awaits only the reader
+    ///     side so that a faulted writer does not cause an unobserved exception on
+    ///     the read side (both sides share the same linked CancellationToken).
+    /// </summary>
+    public interface IStreamService
+    {
+        /// <summary>
+        ///     Begins downloading <paramref name="filename"/> from <paramref name="username"/>
+        ///     and writing bytes into <paramref name="writer"/>.
+        ///
+        ///     On success: writer.CompleteAsync() is called with no exception.
+        ///     On peer error: a <c>streamError</c> SignalR event is broadcast, then
+        ///     writer.CompleteAsync(ex) is called so the reader faults and the HTTP
+        ///     connection closes cleanly.
+        ///     On cancellation: writer.CompleteAsync() is called with no exception.
+        /// </summary>
+        Task StreamToPipeAsync(string username, string filename, PipeWriter writer, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    ///     Manages peer-to-HTTP audio streaming.
+    /// </summary>
+    public class StreamService : IStreamService
+    {
+        public StreamService(ISoulseekClient soulseekClient, IHubContext<StreamHub> hubContext)
+        {
+            Client = soulseekClient;
+            Hub = hubContext;
+        }
+
+        private ISoulseekClient Client { get; }
+        private IHubContext<StreamHub> Hub { get; }
+
+        /// <inheritdoc />
+        public async Task StreamToPipeAsync(string username, string filename, PipeWriter writer, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                await Client.DownloadAsync(
+                    username: username,
+                    remoteFilename: filename,
+                    outputStreamFactory: () => Task.FromResult(writer.AsStream()),
+                    cancellationToken: cancellationToken);
+
+                await writer.CompleteAsync();
+            }
+            catch (OperationCanceledException)
+            {
+                await writer.CompleteAsync();
+            }
+            catch (Exception ex)
+            {
+                await Hub.Clients.All.SendAsync(
+                    StreamHubMethods.StreamError,
+                    new { username, filename, reason = ex.Message },
+                    CancellationToken.None);
+
+                await writer.CompleteAsync(ex);
+            }
+        }
+    }
+}

--- a/src/slskd/wwwroot/app.js
+++ b/src/slskd/wwwroot/app.js
@@ -1,0 +1,193 @@
+'use strict';
+
+// ─── State ───────────────────────────────────────────────────────────────────
+let currentSearchId = null;
+let searchResults = {};   // searchId → { responses: [] }
+
+// ─── DOM refs ────────────────────────────────────────────────────────────────
+const statusBar   = document.getElementById('status-bar');
+const resultsEl   = document.getElementById('results');
+const playerBar   = document.getElementById('player-bar');
+const audioEl     = document.getElementById('audio-el');
+const playerTrack = document.getElementById('player-track');
+const playerPeer  = document.getElementById('player-peer');
+const errorBanner = document.getElementById('error-banner');
+const errorText   = document.getElementById('error-text');
+
+// ─── SignalR — stream hub (peer disconnect events) ───────────────────────────
+const streamHub = new signalR.HubConnectionBuilder()
+  .withUrl('/hub/stream')
+  .withAutomaticReconnect()
+  .build();
+
+streamHub.on('streamError', ({ username, filename, reason }) => {
+  showError(`Peer ${username} disconnected: ${reason}`);
+});
+
+streamHub.onreconnecting(() => setStatus('Reconnecting…'));
+streamHub.onreconnected(() => setStatus('Connected'));
+streamHub.onclose(() => setStatus('Disconnected'));
+
+// ─── SignalR — search hub (live search results) ───────────────────────────────
+const searchHub = new signalR.HubConnectionBuilder()
+  .withUrl('/hub/search')
+  .withAutomaticReconnect()
+  .build();
+
+searchHub.on('RESPONSE', ({ searchId, response }) => {
+  if (searchId !== currentSearchId) return;
+  appendResponse(response);
+});
+
+searchHub.on('UPDATE', (search) => {
+  if (search.id === currentSearchId) {
+    setStatus(`Search: ${search.fileCount} file${search.fileCount !== 1 ? 's' : ''} from ${search.responseCount} peer${search.responseCount !== 1 ? 's' : ''}`);
+  }
+});
+
+// ─── Startup ─────────────────────────────────────────────────────────────────
+async function start() {
+  setStatus('Connecting…');
+  try {
+    await Promise.all([streamHub.start(), searchHub.start()]);
+    setStatus('Ready');
+  } catch (err) {
+    setStatus(`Connection failed: ${err.message}`);
+    setTimeout(start, 5000);
+  }
+}
+
+start();
+
+// ─── Search ──────────────────────────────────────────────────────────────────
+document.getElementById('search-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const query = document.getElementById('search-input').value.trim();
+  if (!query) return;
+
+  resultsEl.innerHTML = '';
+  searchResults = {};
+  currentSearchId = null;
+  hideError();
+  setStatus(`Searching for "${query}"…`);
+
+  try {
+    const resp = await fetch('/api/v0/searches', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ searchText: query }),
+    });
+
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const search = await resp.json();
+    currentSearchId = search.id;
+  } catch (err) {
+    setStatus(`Search failed: ${err.message}`);
+  }
+});
+
+// ─── Render a search response (one peer's results) ───────────────────────────
+function appendResponse(response) {
+  const { username, files = [] } = response;
+  if (!files.length) return;
+
+  // Group under a peer header
+  let group = document.getElementById(`peer-${CSS.escape(username)}`);
+  if (!group) {
+    group = document.createElement('div');
+    group.className = 'peer-group';
+    group.id = `peer-${CSS.escape(username)}`;
+
+    const header = document.createElement('div');
+    header.className = 'peer-header';
+    header.innerHTML = `<strong>${escHtml(username)}</strong>`;
+    group.appendChild(header);
+    resultsEl.appendChild(group);
+  }
+
+  for (const file of files) {
+    const ext = (file.filename || '').split('.').pop().toUpperCase();
+    const size = file.size ? `${(file.size / 1_048_576).toFixed(1)} MB` : '';
+    const speed = file.uploadSpeed ? `${Math.round(file.uploadSpeed / 1024)} KB/s` : '';
+
+    const row = document.createElement('div');
+    row.className = 'result-row';
+    row.innerHTML = `
+      <button class="play-btn" title="Play" data-username="${escAttr(username)}" data-filename="${escAttr(file.filename)}">▶</button>
+      <span class="filename" title="${escAttr(file.filename)}">${escHtml(baseName(file.filename))}</span>
+      <span class="meta">${ext}${size ? ' · ' + size : ''}${speed ? ' · ' + speed : ''}</span>
+    `;
+    group.appendChild(row);
+  }
+}
+
+// ─── Playback ─────────────────────────────────────────────────────────────────
+resultsEl.addEventListener('click', (e) => {
+  const btn = e.target.closest('.play-btn');
+  if (!btn) return;
+
+  const username = btn.dataset.username;
+  const filename = btn.dataset.filename;
+  playTrack(username, filename);
+});
+
+function playTrack(username, filename) {
+  hideError();
+
+  // Mark active button
+  document.querySelectorAll('.play-btn.active').forEach(b => b.classList.remove('active'));
+  const btn = document.querySelector(`.play-btn[data-username="${CSS.escape(username)}"][data-filename="${CSS.escape(filename)}"]`);
+  if (btn) btn.classList.add('active');
+
+  // Build stream URL — filename may contain slashes (path), encode each segment
+  const encodedFilename = filename.split('/').map(encodeURIComponent).join('/');
+  const streamUrl = `/api/v0/stream/${encodeURIComponent(username)}/${encodedFilename}`;
+
+  audioEl.src = streamUrl;
+  audioEl.load();
+  audioEl.play().catch(() => {/* autoplay policy — user gesture already happened */});
+
+  playerTrack.textContent = baseName(filename);
+  playerPeer.textContent = `from ${username}`;
+  playerBar.classList.add('visible');
+
+  // Disable seeking — not supported in v1 (live from peer, no file on disk)
+  audioEl.addEventListener('seeking', snapBack, { passive: true });
+}
+
+function snapBack() {
+  // Safari fires seeking even on initial load; only snap if meaningfully ahead
+  const dur = audioEl.duration;
+  if (isFinite(dur) && Math.abs(audioEl.currentTime - dur) > 2) {
+    audioEl.currentTime = 0;
+  }
+}
+
+// ─── Error banner ─────────────────────────────────────────────────────────────
+function showError(msg) {
+  errorText.textContent = msg;
+  errorBanner.classList.add('visible');
+}
+
+function hideError() {
+  errorBanner.classList.remove('visible');
+}
+
+document.getElementById('error-dismiss').addEventListener('click', hideError);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+function setStatus(msg) { statusBar.textContent = msg; }
+
+function baseName(path) {
+  return (path || '').replace(/\\/g, '/').split('/').pop();
+}
+
+function escHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function escAttr(s) { return escHtml(s); }

--- a/src/slskd/wwwroot/app.js
+++ b/src/slskd/wwwroot/app.js
@@ -2,7 +2,6 @@
 
 // ─── State ───────────────────────────────────────────────────────────────────
 let currentSearchId = null;
-let searchResults = {};   // searchId → { responses: [] }
 
 // ─── DOM refs ────────────────────────────────────────────────────────────────
 const statusBar   = document.getElementById('status-bar');
@@ -34,14 +33,13 @@ const searchHub = new signalR.HubConnectionBuilder()
   .withAutomaticReconnect()
   .build();
 
-searchHub.on('RESPONSE', ({ searchId, response }) => {
-  if (searchId !== currentSearchId) return;
-  appendResponse(response);
-});
+searchHub.on('UPDATE', async (search) => {
+  if (search.id !== currentSearchId) return;
+  setStatus(`Search: ${search.fileCount} file${search.fileCount !== 1 ? 's' : ''} from ${search.responseCount} peer${search.responseCount !== 1 ? 's' : ''}`);
 
-searchHub.on('UPDATE', (search) => {
-  if (search.id === currentSearchId) {
-    setStatus(`Search: ${search.fileCount} file${search.fileCount !== 1 ? 's' : ''} from ${search.responseCount} peer${search.responseCount !== 1 ? 's' : ''}`);
+  // Responses only available via REST — fetch when the search completes
+  if (search.isComplete) {
+    await fetchAndRenderResponses(currentSearchId);
   }
 });
 
@@ -66,7 +64,6 @@ document.getElementById('search-form').addEventListener('submit', async (e) => {
   if (!query) return;
 
   resultsEl.innerHTML = '';
-  searchResults = {};
   currentSearchId = null;
   hideError();
   setStatus(`Searching for "${query}"…`);
@@ -85,6 +82,21 @@ document.getElementById('search-form').addEventListener('submit', async (e) => {
     setStatus(`Search failed: ${err.message}`);
   }
 });
+
+// ─── Fetch all responses from REST API and render them ───────────────────────
+async function fetchAndRenderResponses(searchId) {
+  try {
+    const resp = await fetch(`/api/v0/searches/${searchId}/responses`);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const responses = await resp.json();
+    resultsEl.innerHTML = '';
+    for (const response of responses) {
+      appendResponse(response);
+    }
+  } catch (err) {
+    setStatus(`Failed to load results: ${err.message}`);
+  }
+}
 
 // ─── Render a search response (one peer's results) ───────────────────────────
 function appendResponse(response) {
@@ -139,7 +151,8 @@ function playTrack(username, filename) {
   const btn = document.querySelector(`.play-btn[data-username="${CSS.escape(username)}"][data-filename="${CSS.escape(filename)}"]`);
   if (btn) btn.classList.add('active');
 
-  // Build stream URL — filename may contain slashes (path), encode each segment
+  // Build stream URL — filename may contain slashes (path), encode each segment.
+  // Pass JWT as access_token query param — browsers don't send custom headers on audio src requests.
   const encodedFilename = filename.split('/').map(encodeURIComponent).join('/');
   const streamUrl = `/api/v0/stream/${encodeURIComponent(username)}/${encodedFilename}`;
 

--- a/src/slskd/wwwroot/app.js
+++ b/src/slskd/wwwroot/app.js
@@ -164,7 +164,9 @@ function playTrack(username, filename) {
   playerPeer.textContent = `from ${username}`;
   playerBar.classList.add('visible');
 
-  // Disable seeking — not supported in v1 (live from peer, no file on disk)
+  // Disable seeking — not supported in v1 (live from peer, no file on disk).
+  // Remove before re-adding to avoid accumulating duplicate listeners across plays.
+  audioEl.removeEventListener('seeking', snapBack);
   audioEl.addEventListener('seeking', snapBack, { passive: true });
 }
 

--- a/src/slskd/wwwroot/index.html
+++ b/src/slskd/wwwroot/index.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>slskd-stream</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #111;
+      color: #e8e8e8;
+      display: flex;
+      flex-direction: column;
+      height: 100dvh;
+    }
+
+    header {
+      padding: 16px 20px;
+      border-bottom: 1px solid #222;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    header h1 { font-size: 1rem; font-weight: 600; letter-spacing: 0.05em; color: #aaa; }
+
+    #search-form { display: flex; gap: 8px; flex: 1; max-width: 600px; }
+    #search-input {
+      flex: 1;
+      background: #1c1c1c;
+      border: 1px solid #333;
+      border-radius: 6px;
+      color: #e8e8e8;
+      padding: 8px 12px;
+      font-size: 0.9rem;
+      outline: none;
+    }
+    #search-input:focus { border-color: #555; }
+
+    button {
+      background: #2a2a2a;
+      border: 1px solid #444;
+      border-radius: 6px;
+      color: #e8e8e8;
+      cursor: pointer;
+      font-size: 0.85rem;
+      padding: 8px 14px;
+    }
+    button:hover { background: #333; }
+    button.primary { background: #1a6b3c; border-color: #1a8a4e; }
+    button.primary:hover { background: #1e7d47; }
+
+    #status-bar {
+      font-size: 0.75rem;
+      color: #666;
+      padding: 4px 20px;
+      border-bottom: 1px solid #1a1a1a;
+      height: 26px;
+      display: flex;
+      align-items: center;
+    }
+
+    #results {
+      flex: 1;
+      overflow-y: auto;
+      padding: 0;
+    }
+
+    .peer-group { border-bottom: 1px solid #1a1a1a; }
+    .peer-header {
+      padding: 10px 20px;
+      font-size: 0.78rem;
+      color: #666;
+      background: #141414;
+      position: sticky;
+      top: 0;
+    }
+    .peer-header strong { color: #aaa; }
+
+    .result-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 8px 20px;
+      border-top: 1px solid #1a1a1a;
+      font-size: 0.85rem;
+    }
+    .result-row:hover { background: #181818; }
+
+    .play-btn {
+      background: none;
+      border: none;
+      font-size: 1.1rem;
+      padding: 2px 6px;
+      color: #4caf6e;
+      border-radius: 4px;
+    }
+    .play-btn:hover { background: #1a3a28; }
+    .play-btn.active { color: #6ddb92; }
+
+    .filename { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .meta { font-size: 0.75rem; color: #555; white-space: nowrap; }
+
+    /* Player bar */
+    #player-bar {
+      border-top: 1px solid #222;
+      padding: 12px 20px;
+      display: none;
+      flex-direction: column;
+      gap: 8px;
+      background: #141414;
+    }
+    #player-bar.visible { display: flex; }
+    #player-meta { font-size: 0.8rem; color: #888; display: flex; align-items: center; gap: 10px; }
+    #player-track { color: #ddd; font-weight: 500; }
+    #live-badge {
+      font-size: 0.68rem;
+      background: #1a3a28;
+      color: #4caf6e;
+      border: 1px solid #2a6a40;
+      border-radius: 10px;
+      padding: 2px 8px;
+    }
+    audio { width: 100%; height: 36px; }
+
+    #error-banner {
+      display: none;
+      background: #3a1515;
+      border: 1px solid #6a2a2a;
+      border-radius: 6px;
+      color: #e88;
+      font-size: 0.8rem;
+      padding: 10px 14px;
+      margin: 12px 20px;
+      align-items: center;
+      gap: 12px;
+    }
+    #error-banner.visible { display: flex; }
+    #error-banner span { flex: 1; }
+
+    .spinner { display: inline-block; animation: spin 1s linear infinite; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>slskd‑stream</h1>
+    <form id="search-form">
+      <input id="search-input" type="text" placeholder="Search Soulseek…" autocomplete="off" autofocus>
+      <button type="submit" class="primary">Search</button>
+    </form>
+  </header>
+
+  <div id="status-bar">Not connected</div>
+
+  <div id="error-banner">
+    <span id="error-text">Peer disconnected.</span>
+    <button id="error-dismiss">Dismiss</button>
+  </div>
+
+  <div id="results"></div>
+
+  <div id="player-bar">
+    <div id="player-meta">
+      <span id="player-track">—</span>
+      <span id="live-badge">● live from peer</span>
+      <span id="player-peer"></span>
+    </div>
+    <audio id="audio-el" controls preload="none"></audio>
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js" crossorigin="anonymous"></script>
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/tests/slskd.Tests.Unit/Stream/StreamControllerTests.cs
+++ b/tests/slskd.Tests.Unit/Stream/StreamControllerTests.cs
@@ -1,0 +1,43 @@
+namespace slskd.Tests.Unit.Stream
+{
+    using slskd.Stream.API;
+    using Xunit;
+
+    public class StreamControllerTests
+    {
+        public class GuessContentType
+        {
+            [Theory]
+            [InlineData("song.mp3",  "audio/mpeg")]
+            [InlineData("song.MP3",  "audio/mpeg")]
+            [InlineData("song.flac", "audio/flac")]
+            [InlineData("song.FLAC", "audio/flac")]
+            [InlineData("song.ogg",  "audio/ogg")]
+            [InlineData("song.m4a",  "audio/mp4")]
+            [InlineData("song.wav",  "audio/wav")]
+            public void Returns_Correct_MimeType_For_Known_Extension(string filename, string expected)
+            {
+                Assert.Equal(expected, StreamController.GuessContentType(filename));
+            }
+
+            [Theory]
+            [InlineData("song.xyz")]
+            [InlineData("song.txt")]
+            [InlineData("noextension")]
+            [InlineData("")]
+            public void Returns_OctetStream_For_Unknown_Extension(string filename)
+            {
+                Assert.Equal("application/octet-stream", StreamController.GuessContentType(filename));
+            }
+
+            [Theory]
+            [InlineData(@"C:\Music\Artist\Album\song.mp3",  "audio/mpeg")]
+            [InlineData(@"C:\Music\Artist\Album\song.flac", "audio/flac")]
+            public void Handles_Windows_Paths_Correctly(string filename, string expected)
+            {
+                // Soulseek filenames are Windows paths — extension must be extracted from the full path
+                Assert.Equal(expected, StreamController.GuessContentType(filename));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New `GET /api/v0/stream/{username}/{**filename}` endpoint that proxies a Soulseek `DownloadAsync` call through an ASP.NET Core `Pipe` directly to the browser as a chunked HTTP audio stream
- New `StreamService` bridges peer TCP download to `PipeWriter` with backpressure (64KB segments, 1MB pause threshold)
- New `StreamHub` SignalR hub at `/hub/stream` broadcasts `streamError` events when a peer disconnects mid-stream
- Vanilla JS frontend (`app.js` + `index.html`): search UI with SignalR live result counts, REST fetch-on-complete for full results, per-peer result grouping, play button, player bar with seek-disabled audio element
- `.gitignore`: untrack `wwwroot/` (Angular build output replaced by static vanilla JS)

**Known follow-up (tracked in design doc):** The 30s absolute timeout on `StreamController` should be extended to 10min (it kills long FLAC streams — fix is next commit). Full multi-source failover, track grouping, status dots, and playlist are the next phase.

## Test Coverage

```
GuessContentType — 13 tests (185 → 198)
├── [★★★] .mp3/.flac/.ogg/.m4a/.wav → correct MIME types
├── [★★★] Case-insensitive (.MP3/.FLAC)
├── [★★★] Unknown extensions → application/octet-stream
└── [★★★] Windows paths (C:\Music\...\song.mp3) — basename extracted correctly

StreamFile + StreamToPipeAsync — integration paths (Pipe/SignalR/Soulseek wiring)
└── [INFORMATIONAL] Manual testing only — no in-process test harness for HTTP + P2P
```

Tests: 185 → 198 (+13 new)

## Pre-Landing Review

No critical issues. Two auto-fixed findings from adversarial review:
- `seeking` event listener accumulated on every `playTrack` call — fixed with `removeEventListener` before re-add
- RFC 7233 invalid `Content-Range: bytes 0-/*` header — fixed to `bytes 0-1/2` (minimal valid WebKit-satisfying 206)

## Design Review

No frontend framework changes — vanilla JS and CSS only. No design review run.

## Adversarial Review

Claude subagent (large diff, 2-pass). Synthesis:
- **Fixed**: `seeking` listener leak, invalid Content-Range header
- **Informational**: `Clients.All` SignalR broadcast (fine for solo use), no stream concurrency cap, SRI hash on CDN script (personal project)
- **Tracked**: 30s absolute timeout bug (next commit per design doc)

## TODOS

No TODOS.md in this repo.

## Test plan

- [x] All xUnit tests pass (198/198, 0 failures)
- [ ] Search for popular artist → results grouped by peer with play buttons
- [ ] Click play → audio streams from peer, player bar visible
- [ ] Safari: Range request → 206 response with valid Content-Range, no stall
- [ ] Peer disconnect → streamError banner appears
- [ ] Play multiple tracks → seeking snapped back correctly (no listener accumulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)