### PR TITLE
Fix a chat/room input issue blocking some users from being able to send messages

### DIFF
--- a/src/web/.eslintrc.js
+++ b/src/web/.eslintrc.js
@@ -5,6 +5,7 @@ const overrides = {
   'no-eq-null': 'off', // noisy
   'react/forbid-component-props': 'off', // noisy
   'react/prop-types': 'off', // noisy
+  'canonical/sort-keys': 'off', // noisy
   'unicorn/no-array-reduce': 'off', // noisy
 };
 

--- a/src/web/src/components/Chat/Chat.jsx
+++ b/src/web/src/components/Chat/Chat.jsx
@@ -144,11 +144,11 @@ class Chat extends Component {
 
   selectConversation = (username) => {
     this.setState(
-      {
+      (previousState) => ({
         active: username,
         loading: true,
-        message: '',
-      },
+        message: previousState.active === username ? previousState.message : '',
+      }),
       async () => {
         const { active, conversations } = this.state;
 

--- a/src/web/src/components/Chat/Chat.jsx
+++ b/src/web/src/components/Chat/Chat.jsx
@@ -20,6 +20,7 @@ const initialState = {
   conversations: {},
   interval: undefined,
   loading: false,
+  message: '',
 };
 
 class Chat extends Component {
@@ -106,21 +107,15 @@ class Chat extends Component {
     await chat.acknowledge({ username });
   };
 
-  sendMessage = async (username, message) => {
-    if (!username || !message || username === '') return;
-    await chat.send({ message, username });
-  };
-
   sendReply = async () => {
-    const { active } = this.state;
-    const message = this.messageRef.current.value;
+    const { active, message } = this.state;
 
     if (!this.validInput()) {
       return;
     }
 
-    await this.sendMessage(active, message);
-    this.messageRef.current.value = '';
+    await chat.send({ username: active, message });
+    this.setState({ message: '' });
 
     // force a refresh to append the message
     // we could probably do this in the browser but we can be lazy
@@ -129,12 +124,7 @@ class Chat extends Component {
 
   validInput = () =>
     (this.state.active || '').length > 0 &&
-    (
-      (this.messageRef &&
-        this.messageRef.current &&
-        this.messageRef.current.value) ||
-      ''
-    ).length > 0;
+    (this.state.message || '').length > 0;
 
   focusInput = () => {
     this.messageRef.current.focus();
@@ -294,7 +284,7 @@ class Chat extends Component {
                               name="send"
                             />
                           ),
-                          onClick: this.sendMessage,
+                          onClick: this.sendReply,
                         }}
                         fluid
                         input={
@@ -302,7 +292,11 @@ class Chat extends Component {
                             autoComplete="off"
                             data-lpignore="true"
                             id="chat-message-input"
+                            onChange={(event) =>
+                              this.setState({ message: event.target.value })
+                            }
                             type="text"
+                            value={this.state.message}
                           />
                         }
                         onKeyUp={(event) =>

--- a/src/web/src/components/Chat/Chat.jsx
+++ b/src/web/src/components/Chat/Chat.jsx
@@ -170,6 +170,12 @@ class Chat extends Component {
             } catch {
               // no-op
             }
+
+            try {
+              this.messageRef.current.focus();
+            } catch {
+              // no-op
+            }
           },
         );
       },

--- a/src/web/src/components/Chat/Chat.jsx
+++ b/src/web/src/components/Chat/Chat.jsx
@@ -147,6 +147,7 @@ class Chat extends Component {
       {
         active: username,
         loading: true,
+        message: '',
       },
       async () => {
         const { active, conversations } = this.state;

--- a/src/web/src/components/Chat/Chat.jsx
+++ b/src/web/src/components/Chat/Chat.jsx
@@ -23,6 +23,32 @@ const initialState = {
   message: '',
 };
 
+const ChatMessageHistory = React.memo(
+  ({ formatTimestamp, messages, selfUsername }) => {
+    return (
+      <>
+        {messages.map((message) => (
+          <List.Content
+            className={`chat-message ${message.direction === 'Out' ? 'chat-message-self' : ''}`}
+            key={`${message.timestamp}+${message.message}`}
+          >
+            <span className="chat-message-time">
+              {formatTimestamp(message.timestamp)}
+            </span>
+            <span className="chat-message-name">
+              {message.direction === 'Out' ? selfUsername : message.username}:
+            </span>
+            <span className="chat-message-message">{message.message}</span>
+          </List.Content>
+        ))}
+        <List.Content id="chat-history-scroll-anchor" />
+      </>
+    );
+  },
+);
+
+ChatMessageHistory.displayName = 'ChatMessageHistory';
+
 class Chat extends Component {
   constructor(props) {
     super(props);
@@ -62,6 +88,13 @@ class Chat extends Component {
   fetchConversations = async () => {
     // fetch all of the active conversations (but no messages)
     let conversations = await chat.getAll();
+
+    // the username '..' breaks nearly everything in slskd because it's a path traversal
+    // sequence and no API endpoints that expect usernames in the path work
+    // rather than letting this sit broken, i'm making the choice to filter it out
+    // eslint-disable-next-line no-warning-comments
+    // todo: remove this filter when the API can handle '..'
+    conversations = conversations.filter((f) => f.username !== '..');
 
     // turn into a map, keyed by username
     // if there are no active conversations, set to an empty map
@@ -257,26 +290,11 @@ class Chat extends Component {
                     <Segment className="chat-history">
                       <Ref innerRef={this.listRef}>
                         <List>
-                          {messages.map((message) => (
-                            <List.Content
-                              className={`chat-message ${message.direction === 'Out' ? 'chat-message-self' : ''}`}
-                              key={`${message.timestamp}+${message.message}`}
-                            >
-                              <span className="chat-message-time">
-                                {this.formatTimestamp(message.timestamp)}
-                              </span>
-                              <span className="chat-message-name">
-                                {message.direction === 'Out'
-                                  ? user.username
-                                  : message.username}
-                                :{' '}
-                              </span>
-                              <span className="chat-message-message">
-                                {message.message}
-                              </span>
-                            </List.Content>
-                          ))}
-                          <List.Content id="chat-history-scroll-anchor" />
+                          <ChatMessageHistory
+                            formatTimestamp={this.formatTimestamp}
+                            messages={messages}
+                            selfUsername={user.username}
+                          />
                         </List>
                       </Ref>
                     </Segment>

--- a/src/web/src/components/Rooms/Rooms.jsx
+++ b/src/web/src/components/Rooms/Rooms.jsx
@@ -39,6 +39,36 @@ const initialState = {
   },
 };
 
+const RoomMessageHistory = React.memo(
+  ({ formatTimestamp, messages, onHandleContextMenu }) => {
+    return (
+      <>
+        {messages.map((message) => (
+          <div
+            key={`${message.timestamp}+${message.message}`}
+            onContextMenu={(clickEvent) =>
+              onHandleContextMenu(clickEvent, message)
+            }
+          >
+            <List.Content
+              className={`room-message ${message.self ? 'room-message-self' : ''}`}
+            >
+              <span className="room-message-time">
+                {formatTimestamp(message.timestamp)}
+              </span>
+              <span className="room-message-name">{message.username}: </span>
+              <span className="room-message-message">{message.message}</span>
+            </List.Content>
+          </div>
+        ))}
+        <List.Content id="room-history-scroll-anchor" />
+      </>
+    );
+  },
+);
+
+RoomMessageHistory.displayName = 'RoomMessageHistory';
+
 class Rooms extends Component {
   constructor(props) {
     super(props);
@@ -325,29 +355,11 @@ class Rooms extends Component {
                       <Segment className="room-history">
                         <Ref innerRef={this.listRef}>
                           <List>
-                            {room.messages.map((message) => (
-                              <div
-                                key={`${message.timestamp}+${message.message}`}
-                                onContextMenu={(clickEvent) =>
-                                  this.handleContextMenu(clickEvent, message)
-                                }
-                              >
-                                <List.Content
-                                  className={`room-message ${message.self ? 'room-message-self' : ''}`}
-                                >
-                                  <span className="room-message-time">
-                                    {this.formatTimestamp(message.timestamp)}
-                                  </span>
-                                  <span className="room-message-name">
-                                    {message.username}:{' '}
-                                  </span>
-                                  <span className="room-message-message">
-                                    {message.message}
-                                  </span>
-                                </List.Content>
-                              </div>
-                            ))}
-                            <List.Content id="room-history-scroll-anchor" />
+                            <RoomMessageHistory
+                              formatTimestamp={this.formatTimestamp}
+                              messages={room.messages}
+                              onHandleContextMenu={this.handleContextMenu}
+                            />
                           </List>
                         </Ref>
                       </Segment>

--- a/src/web/src/components/Rooms/Rooms.jsx
+++ b/src/web/src/components/Rooms/Rooms.jsx
@@ -115,12 +115,12 @@ class Rooms extends Component {
 
   selectRoom = async (roomName) => {
     this.setState(
-      {
+      (previousState) => ({
         active: roomName,
         loading: true,
-        message: '',
+        message: previousState.active === roomName ? previousState.message : '',
         room: initialState.room,
-      },
+      }),
       async () => {
         const { active } = this.state;
 

--- a/src/web/src/components/Rooms/Rooms.jsx
+++ b/src/web/src/components/Rooms/Rooms.jsx
@@ -32,6 +32,7 @@ const initialState = {
   },
   joined: [],
   loading: false,
+  message: '',
   room: {
     messages: [],
     users: [],
@@ -131,6 +132,12 @@ class Rooms extends Component {
           } catch {
             // no-op
           }
+
+          try {
+            this.messageRef.current.focus();
+          } catch {
+            // no-op
+          }
         });
       },
     );
@@ -150,12 +157,7 @@ class Rooms extends Component {
 
   validInput = () =>
     (this.state.active || '').length > 0 &&
-    (
-      (this.messageRef &&
-        this.messageRef.current &&
-        this.messageRef.current.value) ||
-      ''
-    ).length > 0;
+    (this.state.message || '').length > 0;
 
   focusInput = () => {
     this.messageRef.current.focus();
@@ -174,15 +176,14 @@ class Rooms extends Component {
   };
 
   sendMessage = async () => {
-    const { active } = this.state;
-    const message = this.messageRef.current.value;
+    const { active, message } = this.state;
 
     if (!this.validInput()) {
       return;
     }
 
     await rooms.sendMessage({ message, roomName: active });
-    this.messageRef.current.value = '';
+    this.setState({ message: '' });
   };
 
   handleContextMenu = (clickEvent, message) => {
@@ -207,8 +208,12 @@ class Rooms extends Component {
   };
 
   handleReply = () => {
-    this.messageRef.current.value = `[${this.state.contextMenu.message.username}] ${this.state.contextMenu.message.message} --> `;
-    this.focusInput();
+    this.setState(
+      (previousState) => ({
+        message: `[${previousState.contextMenu.message.username}] ${previousState.contextMenu.message.message} --> `,
+      }),
+      () => this.focusInput(),
+    );
   };
 
   handleUserProfile = () => {
@@ -364,7 +369,11 @@ class Rooms extends Component {
                               autoComplete="off"
                               data-lpignore="true"
                               id="room-message-input"
+                              onChange={(event) =>
+                                this.setState({ message: event.target.value })
+                              }
                               type="text"
+                              value={this.state.message}
                             />
                           }
                           onKeyUp={(event) =>

--- a/src/web/src/components/Rooms/Rooms.jsx
+++ b/src/web/src/components/Rooms/Rooms.jsx
@@ -118,6 +118,7 @@ class Rooms extends Component {
       {
         active: roomName,
         loading: true,
+        message: '',
         room: initialState.room,
       },
       async () => {


### PR DESCRIPTION
The React components that back the chat/rooms functionality are pretty old and I think have experienced some 'bit rot' through version updates.  The existing code uses a DOM reference to manage input for these components and this relies (relied? not sure) on timers to trigger a re-render of the page instead of when messages were entered.

This PR updates the related components so that they store unsent messages in the component's state instead.

I realized last minute that I probably used a ref here to avoid triggering a re-render of history on every keystroke.  Now that React has `React.memo()` (maybe it always did and I didn't know?), that's no longer a concern.  I confirmed that typing doesn't cause re-rendering in either screen.

I've also added a hard-coded filter for the username `..` in the chat interface; it's broken and any user that has been messaged by this user has this chat 'stuck' in their interface.  I'll remove the filter when I fix the API.