### PR TITLE
Guard untrusted file paths against traversal attempts (paranoia, not mitigating)

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -572,6 +572,14 @@ namespace slskd
         {
             Metrics.Enqueue.RequestsReceived.Inc(1);
 
+            // it shouldn't be possible for us to be sharing any such files, as share paths are required to be absolute and rooted
+            // if someone is requesting a file like this, something is either really wrong, or they are a bad actor
+            if (FileSafety.ContainsTraversalSegments(filename))
+            {
+                Log.Warning("Suspicious attempt from user {Username} to enqueue a file containing unsafe path segments (one or more of path traversal characters '.' and '..'). Requested file: {File}", username, filename);
+                throw new DownloadEnqueueException("File not shared.");
+            }
+
             /*
                 circuit breaker/failsafe:
 
@@ -1413,6 +1421,14 @@ namespace slskd
         /// <returns>A Task resolving an instance of Soulseek.Directory containing the contents of the requested directory.</returns>
         private async Task<IEnumerable<Soulseek.Directory>> DirectoryContentsResponseResolver(string username, IPEndPoint endpoint, int token, string directory)
         {
+            // we shouldn't be sharing any files with these segments because shares are required to be absolute and rooted
+            // if we see this, something has either gone really wrong, or someone is trying something funny
+            if (FileSafety.ContainsTraversalSegments(directory))
+            {
+                Log.Warning("Suspicious attempt from user {Username} to list a directory containing unsafe path segments (one or more of path traversal characters '.' and '..'). Requested file: {File}", username, directory);
+                return [];
+            }
+
             if (Users.IsBlacklisted(username, endpoint.Address))
             {
                 Log.Information("Returned empty directory listing for blacklisted user {Username} ({IP})", username, endpoint.Address);

--- a/src/slskd/Common/CommonExtensions.cs
+++ b/src/slskd/Common/CommonExtensions.cs
@@ -390,9 +390,10 @@ namespace slskd
         /// <param name="remoteFilename">The fully qualified remote filename to convert.</param>
         /// <param name="baseDirectory">The base directory for the local filename.</param>
         /// <returns>The converted filename.</returns>
+        [Obsolete("Find something more intelligent to do instead of this")]
         public static string ToLocalFilename(this string remoteFilename, string baseDirectory)
         {
-            return Path.Combine(baseDirectory, remoteFilename.ToLocalRelativeFilename());
+            return FileSafety.CombineSafely(baseDirectory, remoteFilename.ToLocalRelativeFilename());
         }
 
         /// <summary>
@@ -445,6 +446,7 @@ namespace slskd
         /// </summary>
         /// <param name="remoteFilename">The fully qualified remote filename to convert.</param>
         /// <returns>The converted filename.</returns>
+        [Obsolete("Find something more intelligent to do instead of this")]
         public static string ToLocalRelativeFilename(this string remoteFilename)
         {
             if (string.IsNullOrWhiteSpace(remoteFilename))
@@ -465,7 +467,7 @@ namespace slskd
             var file = parts.Last().ReplaceInvalidFileNameCharacters();
             var directory = parts.Reverse().Skip(1).Take(1).Single().ReplaceInvalidFileNameCharacters();
 
-            return Path.Combine(directory, file);
+            return FileSafety.CombineSafely(directory, file);
         }
 
         /// <summary>

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -198,6 +198,7 @@ namespace slskd
         [Argument('i', "instance-name")]
         [EnvironmentVariable("INSTANCE_NAME")]
         [Description("optional; a unique name for this instance")]
+        [DisallowedCharacters('/', '\\')]
         [RequiresRestart]
         public string InstanceName { get; init; } = "default";
 
@@ -654,6 +655,7 @@ namespace slskd
                 [Description("the name for this agent")]
                 [StringLength(255, MinimumLength = 1)]
                 [NotNullOrWhiteSpace]
+                [DisallowedCharacters('/', '\\')]
                 [Secret]
                 public string InstanceName { get; init; }
 

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -767,6 +767,7 @@ namespace slskd
             [Argument(default, "incomplete")]
             [EnvironmentVariable("INCOMPLETE_DIR")]
             [Description("path where incomplete downloads are saved")]
+            [AbsolutePath]
             [DirectoryExists(ensureWriteable: true)]
             [RequiresRestart]
             public string Incomplete { get; init; } = Program.DefaultIncompleteDirectory;
@@ -777,6 +778,7 @@ namespace slskd
             [Argument('o', "downloads")]
             [EnvironmentVariable("DOWNLOADS_DIR")]
             [Description("path where downloaded files are saved")]
+            [AbsolutePath]
             [DirectoryExists(ensureWriteable: true)]
             [RequiresRestart]
             public string Downloads { get; init; } = Program.DefaultDownloadsDirectory;

--- a/src/slskd/Files/FileService.cs
+++ b/src/slskd/Files/FileService.cs
@@ -164,7 +164,7 @@ namespace slskd.Files
             }
 
             // important! we must fully expand the given paths with GetFullPath() to resolve a given relative directory, like '..'
-            bool IsAllowed(string path) => AllowedDirectories.Any(allowed => path.StartsWith(allowed));
+            bool IsAllowed(string path) => AllowedDirectories.Any(allowed => path.StartsWith(allowed + Path.DirectorySeparatorChar) || path == allowed);
 
             // if any of the resolved directory paths aren't rooted in one of the allowed directories, forbid the entire request
             if (!directories.All(directory => IsAllowed(directory)))
@@ -222,7 +222,7 @@ namespace slskd.Files
             }
 
             // important! we must fully expand the given paths with GetFullPath() to resolve a given relative directory, like '..'
-            bool IsAllowed(string path) => AllowedDirectories.Any(allowed => path.StartsWith(allowed));
+            bool IsAllowed(string path) => AllowedDirectories.Any(allowed => path.StartsWith(allowed + Path.DirectorySeparatorChar) || path == allowed);
 
             // if any of the resolved file paths aren't rooted in one of the allowed directories, forbid the entire request
             if (!files.All(file => IsAllowed(file)))

--- a/src/slskd/Relay/API/Controllers/RelayController.cs
+++ b/src/slskd/Relay/API/Controllers/RelayController.cs
@@ -149,6 +149,14 @@ namespace slskd.Relay
                 return BadRequest();
             }
 
+            // check the path; the caller has a valid API key but we haven't validated the credential yet, so this is worth
+            // doing here instead of relying on the CombineSafely() backstop
+            if (FileSafety.ContainsTraversalSegments(filename))
+            {
+                Log.Warning("Suspicious attempt to download a file containing unsafe path segments (one or more of path traversal characters '.' and '..'). Requested file: {filename}", filename);
+                return BadRequest();
+            }
+
             Log.Information("Handling file download of {Filename} ({Token}) from a caller claiming to be agent {Agent}", filename, token, agentName);
 
             // note: the token remains valid after the validation attempt, unlike most other endpoints.
@@ -159,7 +167,12 @@ namespace slskd.Relay
                 return Unauthorized();
             }
 
-            var sourceFile = Path.Combine(OptionsMonitor.CurrentValue.Directories.Downloads, filename);
+            // if we get this far, the caller has supplied a valid credential and filename, meaning the request
+            // to download is being made in response to the controller signaling the agent that a download had completed.
+            // it's not possible for the client to download arbitrary files; credentials are computed from a token, and
+            // this token is cached in the controller, so only file downloads that the controller solicited are possible
+            // still, for the abundance of caution, use the CombineSafely method in case the filename has traversal segments
+            var sourceFile = FileSafety.CombineSafely(OptionsMonitor.CurrentValue.Directories.Downloads, filename);
 
             Log.Information("Agent {Agent} authenticated for token {Token}. Sending file {Filename}", agentName, guid, filename);
 
@@ -223,6 +236,14 @@ namespace slskd.Relay
                     if (string.IsNullOrEmpty(filename))
                     {
                         throw new ArgumentException("Upload filename is null or empty");
+                    }
+
+                    // use an abundance of caution; the caller has a valid API key but we haven't validated the credential yet
+                    // this is a really unlikely attack vector and it wouldn't do anything, but we're taking a hard stance on input validation
+                    if (FileSafety.ContainsTraversalSegments(filename))
+                    {
+                        Log.Warning("Suspicious attempt to upload a file containing unsafe path segments (one or more of path traversal characters '.' and '..'). Requested file: {filename}", filename);
+                        return BadRequest();
                     }
 
                     if (stream == null || !stream.CanRead)
@@ -323,8 +344,8 @@ namespace slskd.Relay
                 return Unauthorized();
             }
 
-            Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Program.AppName));
-            var temp = Path.Combine(Path.GetTempPath(), Program.AppName, $"share_{agentName}_{Path.GetRandomFileName()}.db");
+            Directory.CreateDirectory(FileSafety.CombineSafely(Path.GetTempPath(), Program.AppName));
+            var temp = FileSafety.CombineSafely(Path.GetTempPath(), Program.AppName, $"share_{agentName.ReplaceInvalidFileNameCharacters()}_{Path.GetRandomFileName()}.db");
 
             try
             {

--- a/src/slskd/Relay/RelayClient.cs
+++ b/src/slskd/Relay/RelayClient.cs
@@ -370,6 +370,12 @@ namespace slskd.Relay
 
         private async Task HandleFileInfoRequest(string filename, Guid id)
         {
+            if (FileSafety.ContainsTraversalSegments(filename))
+            {
+                Log.Warning("Suspicious attempt to request file info containing unsafe path segments (one or more of path traversal characters '.' and '..'). Requested file: {filename}", filename);
+                await HubConnection.InvokeAsync(nameof(RelayHub.ReturnFileInfo), id, false, 0);
+            }
+
             Log.Information("Relay controller requested file info for {Filename} with ID {Id}", filename, id);
 
             try
@@ -387,8 +393,14 @@ namespace slskd.Relay
             }
         }
 
-        private Task HandleFileUploadRequest(string filename, long startOffset, Guid token)
+        private async Task HandleFileUploadRequest(string filename, long startOffset, Guid token)
         {
+            if (FileSafety.ContainsTraversalSegments(filename))
+            {
+                Log.Warning("Suspicious attempt to request a file upload containing unsafe path segments (one or more of path traversal characters '.' and '..'). Requested file: {filename}", filename);
+                await HubConnection.InvokeAsync(nameof(RelayHub.NotifyFileUploadFailed), token);
+            }
+
             _ = Task.Run(async () =>
             {
                 Log.Information("Relay controller requested file {Filename} with ID {Id}", filename, token);
@@ -442,28 +454,32 @@ namespace slskd.Relay
                     await HubConnection.InvokeAsync(nameof(RelayHub.NotifyFileUploadFailed), token);
                 }
             });
-
-            return Task.CompletedTask;
         }
 
-        private Task HandleNotifyFileDownloadCompleted(string filename, Guid token)
+        private async Task HandleNotifyFileDownloadCompleted(string filename, Guid token)
         {
+            if (FileSafety.ContainsTraversalSegments(filename))
+            {
+                Log.Warning("Suspicious attempt to solicit a file download containing unsafe path segments (one or more of path traversal characters '.' and '..'). Requested file: {filename}", filename);
+                return;
+            }
+
             if (!OptionsMonitor.CurrentValue.Relay.Controller.Downloads)
             {
-                return Task.CompletedTask;
+                return;
             }
 
             Log.Information("Relay controller sent a download notification for {Filename} ({Token})", filename, token);
 
             _ = Task.Run(async () =>
             {
-                var destinationFile = Path.Combine(OptionsMonitor.CurrentValue.Directories.Downloads, filename);
+                var destinationFile = FileSafety.CombineSafely(OptionsMonitor.CurrentValue.Directories.Downloads, filename);
 
                 if (OptionsMonitor.CurrentValue.Relay.Mode.ToEnum<RelayMode>() == RelayMode.Debug)
                 {
                     // if we're debugging, we're referencing the same file for both the controller and agent which will lead to an
                     // access violation. prefix the destination file to avoid this.
-                    destinationFile = Path.Combine(OptionsMonitor.CurrentValue.Directories.Downloads, $"{filename}.relayed");
+                    destinationFile = FileSafety.CombineSafely(OptionsMonitor.CurrentValue.Directories.Downloads, $"{filename}.relayed");
                 }
 
                 // if the controller is Windows and the agent is Linux or vice versa, we need to translate the filename to the
@@ -498,8 +514,6 @@ namespace slskd.Relay
 
                 Log.Information("File {Filename} successfully downloaded to {Destination}", filename, destinationFile);
             });
-
-            return Task.CompletedTask;
         }
 
         private Task HubConnection_Closed(Exception arg)
@@ -579,7 +593,7 @@ namespace slskd.Relay
                 return;
             }
 
-            var temp = Path.Combine(Path.GetTempPath(), Program.AppName, $"share_backup_{Path.GetRandomFileName()}.db");
+            var temp = FileSafety.CombineSafely(Path.GetTempPath(), Program.AppName, $"share_backup_{Path.GetRandomFileName()}.db");
 
             try
             {

--- a/src/slskd/Shares/ShareService.cs
+++ b/src/slskd/Shares/ShareService.cs
@@ -188,7 +188,9 @@ namespace slskd.Shares
                 directories.TryAdd(directory, new Directory(directory));
             }
 
-            var files = repositories.SelectMany(r => r.ListFiles(prefix, includeFullPath: true));
+            var files = repositories.SelectMany(r => r.ListFiles(
+                parentDirectory: prefix,
+                includeFullPath: true)); // includes the full *masked* filename; directory and file name and extension. not the local filename.
 
             var groups = files
                 .GroupBy(file => file.Filename.GetNormalizedDirectoryName())
@@ -280,7 +282,7 @@ namespace slskd.Shares
         /// <returns>The contents of the directory.</returns>
         public Task<Directory> ListDirectoryAsync(string directory)
         {
-            var files = AllRepositories.SelectMany(r => r.ListFiles(directory));
+            var files = AllRepositories.SelectMany(r => r.ListFiles(directory, includeFullPath: false));
 
             return Task.FromResult(new Directory(directory, files));
         }

--- a/src/slskd/Shares/SqliteShareRepository.cs
+++ b/src/slskd/Shares/SqliteShareRepository.cs
@@ -418,7 +418,7 @@ namespace slskd.Shares
 
                 while (reader.Read())
                 {
-                    var filename = reader.GetString(0);
+                    var maskedFilename = reader.GetString(0);
                     var code = reader.GetInt32(1);
                     var size = reader.GetInt64(2);
                     var extension = reader.GetString(3);
@@ -426,9 +426,9 @@ namespace slskd.Shares
 
                     var attributeList = attributeJson.FromJson<List<FileAttribute>>();
 
-                    filename = includeFullPath ? filename : filename.GetNormalizedFileName();
+                    maskedFilename = includeFullPath ? maskedFilename : maskedFilename.GetNormalizedFileName();
 
-                    var file = new Soulseek.File(code, filename, size, extension, attributeList);
+                    var file = new Soulseek.File(code, maskedFilename, size, extension, attributeList);
 
                     results.Add(file);
                 }


### PR DESCRIPTION
More work spun out of #1720; the setting to allow callers to supply a `Destination` caused me to go through and ensure all handling of paths from external sources is a bit paranoid in disallowing traversal segments that would expose files unintentionally.

It's really not possible to exploit the "vulnerabilities" in the relay client as all of the paths are solicited by the controller and any attempt would fail, but detecting the paths and logging a warning will help in case anything changes.

The blocking of traversal segments in enqueue and directory contents requests is also not not feasible as everything is checked against the share, not files on disk.  Someone would have to be doing something deliberately stupid on both the local and remote clients for this to work.  But still, for the abundance of caution and guarding of potential updates, these are detected and rejected on the way in.