### PR TITLE
Fix bug digesting share aliases when path contains closing square bracket (])

### DIFF
--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -853,7 +853,7 @@ namespace slskd
 
                 (string Raw, string Alias, string Path) Digest(string share)
                 {
-                    var matches = Regex.Matches(share, @"^(!|-){0,1}\[(.*)\](.*)$");
+                    var matches = Regex.Matches(share, @"^(!|-){0,1}\[([^\]]*)\](.*)$");
 
                     if (matches.Any())
                     {

--- a/tests/slskd.Tests.Unit/Core/Options/SharesOptionsTests.cs
+++ b/tests/slskd.Tests.Unit/Core/Options/SharesOptionsTests.cs
@@ -28,6 +28,9 @@ public class SharesOptionsTests
                     Directories = [@"[foo]/bar/[baz]/"]
                 };
 
+                // todo: fix this so that it fully validates on all platforms; currently this fails
+                // validation on Windows and would fail on Linux if i were to use backslashes
+                // the assertion for the alias proves we have fixed an aliasing bug so it's fine for now
                 var results = Validate(options);
 
                 Assert.DoesNotContain(results, r => r.ErrorMessage?.Contains("aliases may not contain path separators") == true);

--- a/tests/slskd.Tests.Unit/Core/Options/SharesOptionsTests.cs
+++ b/tests/slskd.Tests.Unit/Core/Options/SharesOptionsTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Xunit;
+using static slskd.Options;
+
+namespace slskd.Tests.Unit.Core.Options;
+
+public class SharesOptionsTests
+{
+    private static List<ValidationResult> Validate(SharesOptions options)
+    {
+        var context = new ValidationContext(options);
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(options, context, results, validateAllProperties: true);
+        return results;
+    }
+
+    public class Directories
+    {
+        public class Digest
+        {
+            [Fact]
+            public void Alias_Uses_First_Closing_Bracket_When_Path_Contains_Brackets()
+            {
+                // [foo]/bar/[baz]/ should digest to alias "foo" and path "/bar/[baz]"
+                var options = new SharesOptions
+                {
+                    Directories = [@"[foo]/bar/[baz]/"]
+                };
+
+                var results = Validate(options);
+
+                Assert.DoesNotContain(results, r => r.ErrorMessage?.Contains("aliases may not contain path separators") == true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The regular expression that parses share aliases out of the configured path uses a greedy check for the alias terminator `]`, and this breaks if the shared path has a closing square bracket in it, causing a chunk of the path to be grabbed as the alias.  This surfaces as an issue with aliases containing slashes.

This PR changes the regular expression to match the first closing square bracket, and adds a unit test that proves it is fixed.

There are a number of problems with validation related to cross-platform path validation which will be addressed in a different PR.

Closes #1667 