### PR TITLE
Rename retry 'incomplete' setting to 'partial', and default the value to 'resume' (to match docs)

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -74,7 +74,7 @@
 #     slots: 500
 #     speed_limit: 1000
 #     retry:
-#       incomplete: resume # 'overwrite' or 'resume'
+#       partial: resume # 'overwrite' or 'resume'
 #       attempts: 3
 #       delay: 5000 # initial time between retries, in milliseconds
 #       max_delay: 60000 # maximum time between retries, in milliseconds

--- a/docs/config.md
+++ b/docs/config.md
@@ -364,6 +364,8 @@ Failed downloads can be retried automatically up to the configured number of att
 
 By default, partial downloads are resumed based on the size of the file on disk.  Users can choose to always overwrite files if they wish.
 
+Incomplete files are stored in subdirectories including the remote user's username and the name of the containing directory on the remote user's PC, which minimizes (but does not completely eliminate!) the risk that a partial file is resumed incorrectly.  Choosing to always overwrite files eliminates this risk but is less efficient and it increases the risk that the file will fail to fully transfer successfully.
+
 **YAML**
 ```yaml
 transfers:

--- a/docs/config.md
+++ b/docs/config.md
@@ -362,14 +362,14 @@ transfers:
 
 Failed downloads can be retried automatically up to the configured number of attempts.  If an attempt fails initially, the application delays the second attempt by the configured delay, and an exponential backoff is used to compute the delay for all subsequent events, up to the configured maximum delay.
 
-By default, partial downloads are resumed based on the size of the incomplete file.  Users can choose to always overwrite files if they wish.
+By default, partial downloads are resumed based on the size of the file on disk.  Users can choose to always overwrite files if they wish.
 
 **YAML**
 ```yaml
 transfers:
   download:
     retry:
-      incomplete: resume # 'overwrite' or 'resume'
+      partial: resume # 'overwrite' or 'resume'
       attempts: 3
       delay: 5000 # initial time between retries, in milliseconds
       max_delay: 60000 # maximum time between retries, in milliseconds

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1052,10 +1052,10 @@ namespace slskd
                     public int MaxDelay { get; init; } = 60_000;
 
                     /// <summary>
-                    ///     Gets the strategy for handling incomplete files upon retry.
+                    ///     Gets the strategy for handling partial files upon retry.
                     /// </summary>
-                    [Enum(typeof(RetryIncompleteStrategy))]
-                    public string Incomplete { get; init; } = RetryIncompleteStrategy.Overwrite.ToString().ToLowerInvariant();
+                    [Enum(typeof(RetryPartialStrategy))]
+                    public string Partial { get; init; } = RetryPartialStrategy.Resume.ToString().ToLowerInvariant();
                 }
             }
 

--- a/src/slskd/Transfers/Downloads/DownloadService.cs
+++ b/src/slskd/Transfers/Downloads/DownloadService.cs
@@ -1061,14 +1061,14 @@ namespace slskd.Transfers.Downloads
                 var completedTransfer = await Retry.Do(() =>
                     {
                         var incompleteFileInfo = Files.ResolveFileInfo(incompleteFilename);
-                        var incompleteStrategy = retryOptions.Incomplete.ToEnum<RetryIncompleteStrategy>();
+                        var incompleteStrategy = retryOptions.Partial.ToEnum<RetryPartialStrategy>();
 
                         var shouldResume = false;
                         var startOffset = 0L;
 
                         if (incompleteFileInfo.Exists && incompleteFileInfo.Length > 0)
                         {
-                            if (incompleteStrategy == RetryIncompleteStrategy.Resume)
+                            if (incompleteStrategy == RetryPartialStrategy.Resume)
                             {
                                 shouldResume = true;
                                 startOffset = incompleteFileInfo.Length;

--- a/src/slskd/Transfers/Types/RetryPartialStrategy.cs
+++ b/src/slskd/Transfers/Types/RetryPartialStrategy.cs
@@ -1,4 +1,4 @@
-// <copyright file="RetryIncompleteStrategy.cs" company="JP Dillingham">
+// <copyright file="RetryPartialStrategy.cs" company="JP Dillingham">
 //           ▄▄▄▄     ▄▄▄▄     ▄▄▄▄
 //     ▄▄▄▄▄▄█  █▄▄▄▄▄█  █▄▄▄▄▄█  █
 //     █__ --█  █__ --█    ◄█  -  █
@@ -33,9 +33,9 @@
 namespace slskd.Transfers;
 
 /// <summary>
-///     Strategy for retrying incomplete files.
+///     Strategy for retrying partial files.
 /// </summary>
-public enum RetryIncompleteStrategy
+public enum RetryPartialStrategy
 {
     /// <summary>
     ///     Overwrite the existing file.
@@ -43,7 +43,7 @@ public enum RetryIncompleteStrategy
     Overwrite = 0,
 
     /// <summary>
-    ///     Resume the transfer using the size of the incomplete file as the initial offset.
+    ///     Resume the transfer using the size of the partial file as the initial offset.
     /// </summary>
     Resume = 1,
 }


### PR DESCRIPTION
I'm adding some new settings for downloads and am finding the `incomplete` key to be confusing (when retrying the file is always incomplete!) and inconsistent, so I'm renaming it to `partial`.

When renaming things I noticed that the default value was actually `Overwrite`, not `Resume` as the docs stated, so this is corrected as well.

This is a breaking change for anyone that has set this option in their config file.  The fix is to rename `incomplete` to `partial`.