### PR TITLE
Add comprehensive cross-platform path and filename handling functions

### DIFF
--- a/src/slskd/Common/Compute.cs
+++ b/src/slskd/Common/Compute.cs
@@ -33,6 +33,7 @@
 namespace slskd
 {
     using System;
+    using System.Runtime.InteropServices;
     using System.Security.Cryptography;
     using System.Text;
 
@@ -63,6 +64,26 @@ namespace slskd
         {
             using var sha256 = SHA256.Create();
             return BitConverter.ToString(sha256.ComputeHash(Encoding.UTF8.GetBytes(str))).Replace("-", string.Empty);
+        }
+
+        public static OSPlatform OSPlatform()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return System.Runtime.InteropServices.OSPlatform.Windows;
+            }
+
+            if (OperatingSystem.IsMacOS())
+            {
+                return System.Runtime.InteropServices.OSPlatform.OSX;
+            }
+
+            if (OperatingSystem.IsFreeBSD())
+            {
+                return System.Runtime.InteropServices.OSPlatform.FreeBSD;
+            }
+
+            return System.Runtime.InteropServices.OSPlatform.Linux;
         }
     }
 }

--- a/src/slskd/Common/FileSafety.cs
+++ b/src/slskd/Common/FileSafety.cs
@@ -36,12 +36,34 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 
 /// <summary>
 ///     Utility functions to help safely work with paths from untrusted sources.
 /// </summary>
 public static class FileSafety
 {
+    /// <summary>
+    ///     Invalid filename characters on Unix-like operating systems (Linux, OSX, FreeBSD, etc).
+    /// </summary>
+    public static readonly char[] InvalidFileNameCharactersOnUnix = ['\0', '/'];
+
+    /// <summary>
+    ///     Invalid filename characters on Windows.
+    /// </summary>
+    public static readonly char[] InvalidFileNameCharactersOnWindows =
+    [
+        '\"', '<', '>', '|', '\0',
+        (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,
+        (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20,
+        (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30,
+        (char)31, ':', '*', '?', '\\', '/',
+    ];
+
+    private static readonly Regex DriveRootRegex = new(@"^[a-zA-Z]:[/\\]?", RegexOptions.Compiled); // C: or C:\
+    private static readonly Regex UncRootRegex = new(@"^[/\\]{2}[^/\\]+[/\\]?", RegexOptions.Compiled); // \\server[\] or //server[/], any slash variants
+    private static readonly Regex SoulseekQtRootRegex = new(@"^@@[a-zA-Z0-9]{5,}[\/\\]?", RegexOptions.Compiled); // @@abcde[\|/], a Soulseek Qt share prefix
+
     /// <summary>
     ///     An alternative to <see cref="Path.Combine(string, string)"/> that disallows rooted segments in the second or
     ///     subsequent position, and disallows segments containing path traversal characters "." and "..".
@@ -108,7 +130,7 @@ public static class FileSafety
                 }
             }
 
-            var parts = segment.Split(Path.DirectorySeparatorChar, '\\', '/');
+            var parts = segment.Split('\\', '/');
 
             // ensure the segments we're combining don't contain traversal segments "." or ".."
             // untrusted input could use this to "break out" of the root directory and access sensitive areas
@@ -193,4 +215,275 @@ public static class FileSafety
     /// <param name="os">An optional operating system override, for testing.</param>
     /// <returns>True if the path is relative, false otherwise.</returns>
     public static bool IsPathRelative(string path, OSPlatform? os = null) => !IsPathAbsolute(path, os);
+
+    /// <summary>
+    ///     Returns the filename from the specified <paramref name="path"/>, properly
+    ///     handling both forward and backslashes and removing invalid characters.
+    /// </summary>
+    /// <param name="path">The path from which to extract the filename.</param>
+    /// <param name="sanitize">An optional value indicating that invalid characters should not be replaced.</param>
+    /// <param name="os">An optional operating system override, for testing.</param>
+    /// <returns>The extracted filename.</returns>
+    public static string GetFileNameSafely(string path, bool sanitize = true, OSPlatform? os = null)
+    {
+        if (path is null or "" || path.EndsWith('/') || path.EndsWith('\\'))
+        {
+            return null;
+        }
+
+        if (StripPathRoot(path, os) == string.Empty)
+        {
+            return null;
+        }
+
+        var localPath = LocalizePath(path, os);
+        var segments = localPath.Split('/', '\\');
+
+        return segments
+            .TakeLast(1)
+            .Select(s => sanitize ? SanitizePathSegment(s, os: os) : s)
+            .Single();
+    }
+
+    /// <summary>
+    ///     Returns the full directory name from the specified <paramref name="path"/>, properly handling both
+    ///     forward and backslashes, removing Windows drive, UNC and Soulseek QT root segments, and sanitizing
+    ///     each of the remaining segments.
+    /// </summary>
+    /// <param name="path">The path from which to extract the directory name.</param>
+    /// <param name="retainRoot">An optional value indicating whether to keep the path's root, if present.</param>
+    /// <param name="sanitize">An optional value indicating that path segments should not be sanitized.</param>
+    /// <param name="os">An optional operating system override, for testing.</param>
+    /// <returns>The directory name.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if the specified path is null.</exception>
+    public static string GetDirectoryNameSafely(string path, bool retainRoot = false, bool sanitize = true, OSPlatform? os = null)
+    {
+        if (path is null or "")
+        {
+            return null;
+        }
+
+        // a plain string is assumed to be a file. matches the behavior of the BCL method
+        if (!path.Contains('/') && !path.Contains('\\'))
+        {
+            return null;
+        }
+
+        var leadingSlashCount = path.TakeWhile(c => c == '/' || c == '\\').Count();
+
+        os ??= Compute.OSPlatform();
+        var sep = os.Value == OSPlatform.Windows ? '\\' : '/';
+
+        var local = LocalizePath(path, os)
+            .TrimEnd('/', '\\'); // treat file-less paths the same as files
+
+        var unrooted = StripPathRoot(local, os);
+
+        // were given a root; C:\, //server, @@abcde
+        if (unrooted is null or "")
+        {
+            return null;
+        }
+
+        if (!retainRoot)
+        {
+            local = unrooted;
+        }
+
+        // strip empty segments
+        var segments = local
+            .Split('/', '\\')
+            .Where(s => s is not "")
+            .ToArray();
+
+        // we were given all slashes, a file in the root, or some other case where
+        // only a file or subdirectory remains; no parent directory
+        if (segments.Length <= 1)
+        {
+            return null;
+        }
+
+        var newPath = string.Join(sep, segments
+            .SkipLast(1)
+            .Select(s => sanitize ? SanitizePathSegment(s, os: os) : s));
+
+        if (retainRoot)
+        {
+            // leading slashes are stripped of leading slashes by Split() so we must add them back
+            return new string(sep, leadingSlashCount) + newPath;
+        }
+
+        return newPath;
+    }
+
+    /// <summary>
+    ///     Converts the given path to the local format (normalizes path separators to Path.DirectorySeparatorChar).
+    /// </summary>
+    /// <param name="path">The path to convert.</param>
+    /// <param name="os">An optional operating system override, for testing.</param>
+    /// <returns>The converted path.</returns>
+    public static string LocalizePath(string path, OSPlatform? os = null)
+    {
+        if (path is null)
+        {
+            return null;
+        }
+
+        os ??= Compute.OSPlatform();
+        var sep = os.Value == OSPlatform.Windows ? '\\' : '/';
+
+        return path.Replace('\\', sep).Replace('/', sep);
+    }
+
+    /// <summary>
+    ///     Sanitizes the specified <paramref name="filename"/> (or string intended to be used as or as part of a filename)
+    ///     to make it suitable and safe on the local operating system by stripping all slashes (forward or back) and
+    ///     replacing any invalid characters with the specified <paramref name="replacement"/>.
+    /// </summary>
+    /// <param name="filename">The filename (or string intended to be used as/part of one).</param>
+    /// <param name="replacement">The character to substitute for invalid characters.</param>
+    /// <param name="os">An optional operating system override, for testing.</param>
+    /// <returns>The sanitized filename.</returns>
+    public static string SanitizeFilename(string filename, char replacement = '_', OSPlatform? os = null)
+    {
+        if (filename is null)
+        {
+            return null;
+        }
+
+        if (replacement is '/' or '\\')
+        {
+            throw new ArgumentException($"The provided replacement character '{replacement}' is invalid in filenames");
+        }
+
+        os ??= Compute.OSPlatform();
+
+        var characters = os.Value == OSPlatform.Windows ? InvalidFileNameCharactersOnWindows : InvalidFileNameCharactersOnUnix;
+
+        if (characters.Contains(replacement))
+        {
+            throw new ArgumentException($"The provided replacement character '{replacement}' is invalid on {os}");
+        }
+
+        var sanitized = filename;
+
+        foreach (var c in characters)
+        {
+            sanitized = sanitized.Replace(c, replacement);
+        }
+
+        // regardless of which OS and what characters are disallowed on it, we don't allow slashes in filenames
+        // (or strings that will be used as filenames), otherwise we should/would have used SanitizePath()
+        return sanitized
+            .Replace('/', replacement)
+            .Replace('\\', replacement);
+    }
+
+    /// <summary>
+    ///     Sanitizes the specified <paramref name="segment"/> to make it suitable and safe on the local operating
+    ///     system by stripping all slashes (forward or back) and replacing any invalid characters with the specified
+    ///     <paramref name="replacement"/>.
+    /// </summary>
+    /// <param name="segment">The path segment.</param>
+    /// <param name="replacement">The character to substitute for invalid characters.</param>
+    /// <param name="os">An optional operating system override, for testing.</param>
+    /// <returns>The sanitized path segment.</returns>
+    public static string SanitizePathSegment(string segment, char replacement = '_', OSPlatform? os = null)
+    {
+        var sanitized = SanitizeFilename(segment, replacement, os);
+
+        // is is possible for the result of sanitization to produce path traversal strings,
+        // which would result in traversal when combined (or throw an error because of CombineSafely)
+        // this can happen either because the segment is already periods, or because the replacement
+        // character is a period and the input one or two invalid characters.
+        // if this happens we follow the principle of least surprise and return an empty string
+        // avoid using a period for replacement (don't let users choose) and we won't have this problem
+        if (sanitized is "." or "..")
+        {
+            if (replacement is '.')
+            {
+                return string.Empty;
+            }
+
+            return replacement.ToString();
+        }
+
+        return sanitized;
+    }
+
+    /// <summary>
+    ///     Sanitizes the specified <paramref name="path"/> to make it suitable and safe on the local operating system
+    ///     by converting to the correct slashes, dropping a root (if present), replacing any invalid characters with
+    ///     the specified <paramref name="replacement"/>, and by dropping any path traversal segments.
+    /// </summary>
+    /// <param name="path">The path.</param>
+    /// <param name="replacement">The character to substitute for invalid characters.</param>
+    /// <param name="retainRoot">An optional value indicating whether to keep the path's root, if present.</param>
+    /// <param name="os">An optional operating system override, for testing.</param>
+    /// <returns>The sanitized path.</returns>
+    public static string SanitizePath(string path, char replacement = '_', bool retainRoot = false, OSPlatform? os = null)
+    {
+        if (path is null)
+        {
+            return null;
+        }
+
+        var leadingSlashCount = path.TakeWhile(c => c == '/' || c == '\\').Count();
+
+        os ??= Compute.OSPlatform();
+        var sep = os.Value == OSPlatform.Windows ? '\\' : '/';
+
+        // flip slashes the correct way
+        path = LocalizePath(path, os);
+
+        if (!retainRoot)
+        {
+            // strip C:\ or //server, if present (regardless of slash variant, etc)
+            path = StripPathRoot(path, os);
+        }
+
+        // for each segment, drop nulls (created by double slashes), sanitize, and replace traversal strings
+        var segments = path
+            .Split('/', '\\')
+            .Where(s => s is not "")
+            .Select(s => SanitizePathSegment(s, replacement, os));
+
+        var newPath = string.Join(sep, segments);
+
+        if (retainRoot)
+        {
+            // leading slashes are stripped of leading slashes by Split() so we must add them back
+            return new string(sep, leadingSlashCount) + newPath;
+        }
+
+        return newPath;
+    }
+
+    /// <summary>
+    ///     Removes the root of the specified <paramref name="path"/>, including Window's drive prefix (e.g. C:\),
+    ///     UNC paths on any OS (e.g. \\server on Windows, //server on Linux), and drops the hashed prefix added by
+    ///     Soulseek Qt to hide the path on disk (e.g. @@abcde).
+    /// </summary>
+    /// <param name="path">The path to strip.</param>
+    /// <param name="os">An optional operating system override, for testing.</param>
+    /// <returns>The path with the root stripped, if one was present.</returns>
+    public static string StripPathRoot(string path, OSPlatform? os = null)
+    {
+        if (path is null)
+        {
+            return null;
+        }
+
+        // flip slashes the correct way
+        path = LocalizePath(path, os);
+
+        // strip C:\ or //server, if present (regardless of slash variant)
+        path = DriveRootRegex.Replace(path, string.Empty);
+        path = UncRootRegex.Replace(path, string.Empty);
+
+        // strip @@abcde prefixes used by SoulseekQt to obscure paths
+        path = SoulseekQtRootRegex.Replace(path, string.Empty);
+
+        return path;
+    }
 }

--- a/tests/slskd.Tests.Unit/Common/FileSafety/CombineSafelyTests.cs
+++ b/tests/slskd.Tests.Unit/Common/FileSafety/CombineSafelyTests.cs
@@ -103,6 +103,9 @@ public partial class FileSafetyTests
         [InlineData("用户/音乐")]
         [InlineData("ユーザー/音楽")]
         [InlineData("사용자/음악")]
+        [InlineData("foo\\bar\\baz\\qux\\deeply\\nested")]
+        [InlineData("foo/bar/baz/qux/deeply/nested")]
+        [InlineData("foo/bar\\baz/qux\\deeply/nested")]
         public void Combines_Safe_Segments(string segment)
         {
             var result = FileSafety.CombineSafely(Base, segment);

--- a/tests/slskd.Tests.Unit/Common/FileSafety/GetDirectoryNameSafelyTests.cs
+++ b/tests/slskd.Tests.Unit/Common/FileSafety/GetDirectoryNameSafelyTests.cs
@@ -1,0 +1,272 @@
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace slskd.Tests.Unit.Common;
+
+public partial class FileSafetyTests
+{
+    public class GetDirectoryNameSafelyTests
+    {
+        [Fact]
+        public void Returns_Null_Given_Null()
+        {
+            var result = FileSafety.GetDirectoryNameSafely(null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Returns_Null_Given_Empty()
+        {
+            var result = FileSafety.GetDirectoryNameSafely("");
+
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("\\")]
+        [InlineData("\\\\")]
+        [InlineData("\\\\\\")]
+        [InlineData("/")]
+        [InlineData("//")]
+        [InlineData("///")]
+        [InlineData("/\\/\\\\//////\\")]
+        public void Returns_Null_Given_Only_Slashes(string input)
+        {
+            var result = FileSafety.GetDirectoryNameSafely(input);
+
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("foo")]
+        [InlineData("foo.bar")]
+        public void Returns_Null_Given_Bare_File(string input)
+        {
+            var result = FileSafety.GetDirectoryNameSafely(input);
+
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("C:")]
+        [InlineData("C:\\")]
+        [InlineData("C:/")]
+        [InlineData("/")]
+        [InlineData("\\")]
+        [InlineData("//server")]
+        [InlineData("\\\\server")]
+        public void Returns_Null_Given_Root(string input)
+        {
+            var result = FileSafety.GetDirectoryNameSafely(input);
+
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("C:\\file.txt")]
+        [InlineData("C:/file.txt")]
+        [InlineData("//server/file.txt")]
+        [InlineData("\\\\server\\file.txt")]
+        [InlineData("@@abcde/file.txt")]
+        [InlineData("@@abcde\\file.txt")]
+        public void Returns_Null_When_File_Is_Directly_In_Root_With_RetainRoot_False_Linux(string input)
+        {
+            var result = FileSafety.GetDirectoryNameSafely(input, retainRoot: false, os: OSPlatform.Linux);
+
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("C:\\file.txt")]
+        [InlineData("C:/file.txt")]
+        [InlineData("//server/file.txt")]
+        [InlineData("\\\\server\\file.txt")]
+        [InlineData("@@abcde/file.txt")]
+        [InlineData("@@abcde\\file.txt")]
+        public void Returns_Null_When_File_Is_Directly_In_Root_With_RetainRoot_False_Windows(string input)
+        {
+            var result = FileSafety.GetDirectoryNameSafely(input, retainRoot: false, os: OSPlatform.Windows);
+
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("C:\\file.txt", "C:")]
+        [InlineData("C:/file.txt", "C:")]
+        [InlineData("//server/file.txt", "//server")]
+        [InlineData("\\\\server\\file.txt", "//server")]
+        [InlineData("@@abcde/file.txt", "@@abcde")]
+        [InlineData("@@abcde\\file.txt", "@@abcde")]
+        public void Returns_Root_When_File_Is_Directly_In_Root_With_RetainRoot_True_Linux(string input, string expected)
+        {
+            var result = FileSafety.GetDirectoryNameSafely(input, retainRoot: true, os: OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("C:\\file.txt", "C_")]
+        [InlineData("C:/file.txt", "C_")]
+        [InlineData("//server/file.txt", "\\\\server")]
+        [InlineData("\\\\server\\file.txt", "\\\\server")]
+        [InlineData("@@abcde/file.txt", "@@abcde")]
+        [InlineData("@@abcde\\file.txt", "@@abcde")]
+        public void Returns_Sanitized_Root_When_File_Is_Directly_In_Root_With_RetainRoot_True_Windows(string input, string expected)
+        {
+            var result = FileSafety.GetDirectoryNameSafely(input, retainRoot: true, os: OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Sanitizes_Path_When_Sanitize_True()
+        {
+            var result = FileSafety.GetDirectoryNameSafely("foo/b\0ar/baz", sanitize: true);
+
+            Assert.DoesNotContain('\0', result);
+        }
+
+        [Fact]
+        public void Does_Not_Sanitize_Path_When_Sanitize_False()
+        {
+            var result = FileSafety.GetDirectoryNameSafely("foo/b\0ar/baz", sanitize: false);
+
+            Assert.Contains('\0', result);
+        }
+
+        [Fact]
+        public void Sanitize_Defaults_To_True()
+        {
+            var result = FileSafety.GetDirectoryNameSafely("foo/b\0ar/baz");
+
+            Assert.DoesNotContain('\0', result);
+        }
+
+        [Theory]
+        [InlineData("\\foo\\\\bar\\\\baz", "foo\\bar")]
+        [InlineData("/foo//bar//baz", "foo\\bar")]
+        public void Removes_Empty_Segments_And_Leading_Slashes_Windows(string input, string expected)
+        {
+            var result = FileSafety.GetDirectoryNameSafely(input, sanitize: true, retainRoot: false, os: OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("\\foo\\\\bar\\\\baz", "foo/bar")]
+        [InlineData("/foo//bar//baz", "foo/bar")]
+        public void Removes_Empty_Segments_And_Leading_Slashes_Linux(string input, string expected)
+        {
+            var result = FileSafety.GetDirectoryNameSafely(input, sanitize: true, retainRoot: false, os: OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("fo\0o\\bar", "fo_o")]
+        [InlineData("foo/bar", "foo")]
+        [InlineData("C:\\Music\\song.flac", "Music")]
+        [InlineData("C:/Music/song.flac", "Music")]
+        [InlineData("C:\\M\0usic\\Artist\\song.flac", "M_usic/Artist")]
+        [InlineData("C:\\foo.txt", null)]
+        [InlineData("//server/share/song.flac", "share")]
+        [InlineData("\\\\server\\share\\song.flac", "share")]
+        [InlineData("/abs\0olute/path", "abs_olute")]
+        [InlineData("\\abs\0olute\\path", "abs_olute")]
+        [InlineData("@@abcde\\foo\\bar", "foo")]
+        public void Returns_Unrooted_Sanitized_Directory_Given_Path_With_File_Linux(string input, string expected)
+        {
+            var result = FileSafety.GetDirectoryNameSafely(input, sanitize: true, retainRoot: false, os: OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("fo\0o\\bar", "fo_o")]
+        [InlineData("foo/bar", "foo")]
+        [InlineData("C:\\Music\\song.flac", "Music")]
+        [InlineData("C:/Music/song.flac", "Music")]
+        [InlineData("C:\\M\0usic\\Artist\\song.flac", "M_usic\\Artist")]
+        [InlineData("C:\\foo.txt", null)]
+        [InlineData("//server/share/song.flac", "share")]
+        [InlineData("\\\\server\\share\\song.flac", "share")]
+        [InlineData("/abs\0olute/path", "abs_olute")]
+        [InlineData("\\abs\0olute\\path", "abs_olute")]
+        [InlineData("@@abcde\\foo\\bar", "foo")]
+        public void Returns_Unrooted_Sanitized_Directory_Given_Path_With_File_Windows(string input, string expected)
+        {
+            var result = FileSafety.GetDirectoryNameSafely(input, sanitize: true, retainRoot: false, os: OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("foo\\bar", "foo")]
+        [InlineData("foo/bar", "foo")]
+        [InlineData("C:\\Music\\song.flac", "C_\\Music")]
+        [InlineData("C:/Music/song.flac", "C_\\Music")]
+        [InlineData("C:\\Music\\Artist\\song.flac", "C_\\Music\\Artist")]
+        [InlineData("//server/share/song.flac", "\\\\server\\share")]
+        [InlineData("\\\\server\\share\\song.flac", "\\\\server\\share")]
+        [InlineData("/absolute/path", "\\absolute")]
+        [InlineData("\\absolute\\path", "\\absolute")]
+        [InlineData("@@abcde\\foo\\bar", "@@abcde\\foo")]
+        public void Retains_Path_Root_When_RetainRoot_True_Windows(string input, string expected)
+        {
+            var result = FileSafety.GetDirectoryNameSafely(input, retainRoot: true, os: OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("foo\\bar", "foo")]
+        [InlineData("foo/bar", "foo")]
+        [InlineData("C:\\Music\\song.flac", "C:/Music")]
+        [InlineData("C:/Music/song.flac", "C:/Music")]
+        [InlineData("C:\\Music\\Artist\\song.flac", "C:/Music/Artist")]
+        [InlineData("//server/share/song.flac", "//server/share")]
+        [InlineData("\\\\server\\share\\song.flac", "//server/share")]
+        [InlineData("/absolute/path", "/absolute")]
+        [InlineData("\\absolute\\path", "/absolute")]
+        [InlineData("@@abcde\\foo\\bar", "@@abcde/foo")]
+        public void Retains_Path_Root_When_RetainRoot_True_Linux(string input, string expected)
+        {
+            var result = FileSafety.GetDirectoryNameSafely(input, retainRoot: true, os: OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("C:\\Mu\0sic\\song.flac", "C:\\Mu\0sic")]
+        [InlineData("C:/Music/song.flac", "C:\\Music")]
+        [InlineData("//server/share/song.flac", "\\\\server\\share")]
+        [InlineData("\\\\serv?er\\share\\song.flac", "\\\\serv?er\\share")]
+        [InlineData("/abs\0olute/path", "\\abs\0olute")]
+        [InlineData("\\abs\0olute\\path", "\\abs\0olute")]
+        [InlineData("@@abcde\\fo:o\\bar", "@@abcde\\fo:o")]
+        [InlineData("@@abcde/fo*o/bar", "@@abcde\\fo*o")]
+        public void Returns_Rooted_Unsanitized_If_Directed_Windows(string input, string expected)
+        {
+            var result = FileSafety.GetDirectoryNameSafely(input, sanitize: false, retainRoot: true, os: OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("C:\\Mu\0sic\\song.flac", "C:/Mu\0sic")]
+        [InlineData("C:/Music/song.flac", "C:/Music")]
+        [InlineData("//server/share/song.flac", "//server/share")]
+        [InlineData("\\\\serv?er\\share\\song.flac", "//serv?er/share")]
+        [InlineData("/abs\0olute/path", "/abs\0olute")]
+        [InlineData("\\abs\0olute\\path", "/abs\0olute")]
+        [InlineData("@@abcde\\fo:o\\bar", "@@abcde/fo:o")]
+        [InlineData("@@abcde/fo*o/bar", "@@abcde/fo*o")]
+        public void Returns_Rooted_Unsanitized_If_Directed_Linux(string input, string expected)
+        {
+            var result = FileSafety.GetDirectoryNameSafely(input, sanitize: false, retainRoot: true, os: OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/tests/slskd.Tests.Unit/Common/FileSafety/GetFileNameSafelyTests.cs
+++ b/tests/slskd.Tests.Unit/Common/FileSafety/GetFileNameSafelyTests.cs
@@ -1,0 +1,114 @@
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace slskd.Tests.Unit.Common;
+
+public partial class FileSafetyTests
+{
+    public class GetFileNameSafelyTests
+    {
+        [Fact]
+        public void Returns_Null_Given_Null()
+        {
+            var result = FileSafety.GetFileNameSafely(null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Returns_Null_Given_Empty()
+        {
+            var result = FileSafety.GetFileNameSafely("");
+
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("/")]
+        [InlineData("\\")]
+        [InlineData("C:\\")]
+        [InlineData("C:/")]
+        [InlineData("//")]
+        [InlineData("\\\\")]
+        [InlineData("foo\\")]
+        [InlineData("foo//")]
+        [InlineData("C:\\foo//bar\\")]
+        [InlineData("C:/foo\\bar/")]
+        public void Returns_Null_Given_Path_Ending_In_Separator(string input)
+        {
+            var result = FileSafety.GetFileNameSafely(input);
+
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("//server")]
+        [InlineData("\\\\server")]
+        [InlineData("C:")]
+        [InlineData("@@abcde")]
+        public void Returns_Null_Given_Just_Rooted_Path(string input)
+        {
+            var result = FileSafety.GetFileNameSafely(input);
+
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("foo", "foo")]
+        [InlineData("foo.bar", "foo.bar")]
+        [InlineData("foo\\bar", "bar")]
+        [InlineData("foo/bar", "bar")]
+        [InlineData("C:\\Music\\song.flac", "song.flac")]
+        [InlineData("C:/Music/song.flac", "song.flac")]
+        [InlineData("Music\\Artist\\song.flac", "song.flac")]
+        [InlineData("//server/share/song.flac", "song.flac")]
+        [InlineData("\\\\server\\share\\song.flac", "song.flac")]
+        public void Returns_Filename_Given_Path_With_File(string input, string expected)
+        {
+            var result = FileSafety.GetFileNameSafely(input);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Sanitize_True_Replaces_InvalidCharacters_On_Windows()
+        {
+            var result = FileSafety.GetFileNameSafely("Music\\file:name.flac", sanitize: true, os: OSPlatform.Windows);
+
+            Assert.Equal("file_name.flac", result);
+        }
+
+        [Fact]
+        public void Sanitize_True_Replaces_InvalidCharacters_On_Linux()
+        {
+            var result = FileSafety.GetFileNameSafely("Music\\file\0name.flac", sanitize: true, os: OSPlatform.Linux);
+
+            Assert.Equal("file_name.flac", result);
+        }
+
+        [Fact]
+        public void Sanitize_False_Preserves_InvalidCharacters_On_Windows()
+        {
+            var result = FileSafety.GetFileNameSafely("Music\\file:name.flac", sanitize: false, os: OSPlatform.Windows);
+
+            Assert.Equal("file:name.flac", result);
+        }
+
+        [Fact]
+        public void Sanitize_False_Preserves_InvalidCharacters_On_Linux()
+        {
+            var result = FileSafety.GetFileNameSafely("Music\\file\0name.flac", sanitize: false, os: OSPlatform.Linux);
+
+            Assert.Equal("file\0name.flac", result);
+        }
+
+        [Fact]
+        public void Default_Sanitize_Is_True()
+        {
+            var resultDefault = FileSafety.GetFileNameSafely("Music\\file:name.flac", os: OSPlatform.Windows);
+            var resultExplicit = FileSafety.GetFileNameSafely("Music\\file:name.flac", sanitize: true, os: OSPlatform.Windows);
+
+            Assert.Equal(resultExplicit, resultDefault);
+        }
+    }
+}

--- a/tests/slskd.Tests.Unit/Common/FileSafety/LocalizePathTests.cs
+++ b/tests/slskd.Tests.Unit/Common/FileSafety/LocalizePathTests.cs
@@ -1,0 +1,66 @@
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace slskd.Tests.Unit.Common;
+
+public partial class FileSafetyTests
+{
+    public class LocalizePathTests
+    {
+        [Theory]
+        [InlineData("foo/bar", "foo/bar")]
+        [InlineData("foo\\bar", "foo/bar")]
+        [InlineData("foo/bar/baz", "foo/bar/baz")]
+        [InlineData("foo\\bar/baz", "foo/bar/baz")]
+        [InlineData("foo\\\\bar", "foo//bar")]
+        [InlineData("@@abcde\\foo\\bar\\", "@@abcde/foo/bar/")]
+        [InlineData("@@abcde/foo/bar/", "@@abcde/foo/bar/")]
+        [InlineData("\\\\server\\foo\\", "//server/foo/")]
+        [InlineData("//server/foo/", "//server/foo/")]
+        [InlineData("C:\\Windows\\foo", "C:/Windows/foo")]
+        [InlineData("C:/Windows/foo", "C:/Windows/foo")]
+        [InlineData("", "")]
+        public void Linux_NormalizesToForwardSlash(string input, string expected)
+        {
+            var result = FileSafety.LocalizePath(input, OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("foo/bar", "foo\\bar")]
+        [InlineData("foo\\bar", "foo\\bar")]
+        [InlineData("foo/bar/baz", "foo\\bar\\baz")]
+        [InlineData("foo\\bar/baz", "foo\\bar\\baz")]
+        [InlineData("foo//bar", "foo\\\\bar")]
+        [InlineData("@@abcde\\foo\\bar\\", "@@abcde\\foo\\bar\\")]
+        [InlineData("@@abcde/foo/bar/", "@@abcde\\foo\\bar\\")]
+        [InlineData("\\\\server\\foo\\", "\\\\server\\foo\\")]
+        [InlineData("//server/foo/", "\\\\server\\foo\\")]
+        [InlineData("C:\\Windows\\foo", "C:\\Windows\\foo")]
+        [InlineData("C:/Windows/foo", "C:\\Windows\\foo")]
+        [InlineData("", "")]
+        public void Windows_NormalizesToBackslash(string input, string expected)
+        {
+            var result = FileSafety.LocalizePath(input, OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void NullOs_UsesPlatformDefault_DoesNotThrow()
+        {
+            var result = FileSafety.LocalizePath("foo/bar");
+
+            Assert.False(string.IsNullOrEmpty(result));
+        }
+
+        [Fact]
+        public void Returns_Null_Given_Null_Path()
+        {
+            var result = FileSafety.LocalizePath(null);
+
+            Assert.Null(result);
+        }
+    }
+}

--- a/tests/slskd.Tests.Unit/Common/FileSafety/SanitizeFilenameTests.cs
+++ b/tests/slskd.Tests.Unit/Common/FileSafety/SanitizeFilenameTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace slskd.Tests.Unit.Common;
+
+public partial class FileSafetyTests
+{
+    public class SanitizeFilenameTests
+    {
+        [Theory]
+        [InlineData('/')]
+        [InlineData('\\')]
+        public void Throws_Given_Slash_As_Replacement(char replacement)
+        {
+            var ex = Record.Exception(() => FileSafety.SanitizeFilename("file", replacement));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentException>(ex);
+            Assert.Contains("invalid in filenames", ex.Message);
+        }
+
+        [Fact]
+        public void Throws_Given_OsInvalid_Replacement_On_Unix()
+        {
+            // '\0' is invalid on Unix but not caught by the slash guard
+            var ex = Record.Exception(() => FileSafety.SanitizeFilename("file", '\0', OSPlatform.Linux));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentException>(ex);
+            Assert.Contains("invalid on", ex.Message);
+        }
+
+        [Fact]
+        public void Throws_Given_OsInvalid_Replacement_On_Windows()
+        {
+            // '*' is invalid on Windows but not caught by the slash guard
+            var ex = Record.Exception(() => FileSafety.SanitizeFilename("file", '*', OSPlatform.Windows));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentException>(ex);
+            Assert.Contains("invalid on", ex.Message);
+        }
+
+        [Fact]
+        public void NullOs_UsesPlatformDefault_DoesNotThrow()
+        {
+            var result = FileSafety.SanitizeFilename("safe_file.flac");
+
+            Assert.NotNull(result);
+        }
+
+        [Theory]
+        [InlineData("clean", "clean")]
+        [InlineData("file.flac", "file.flac")]
+        [InlineData("My Artist - My Album", "My Artist - My Album")]
+        [InlineData("Ünïcödé", "Ünïcödé")]
+        [InlineData("пользователь", "пользователь")]
+        public void Linux_ReturnsUnchanged_Given_Safe_Filename(string input, string expected)
+        {
+            var result = FileSafety.SanitizeFilename(input, '_', OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("file\0name", "file_name")]
+        [InlineData("\0leading", "_leading")]
+        [InlineData("trailing\0", "trailing_")]
+        public void Linux_Replaces_NullByte(string input, string expected)
+        {
+            var result = FileSafety.SanitizeFilename(input, '_', OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("has/slash", "has_slash")]
+        [InlineData("has\\backslash", "has_backslash")]
+        [InlineData("has/both\\types", "has_both_types")]
+        public void Linux_Replaces_Slashes(string input, string expected)
+        {
+            var result = FileSafety.SanitizeFilename(input, '_', OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("/home/user/foo", "_home_user_foo")]
+        [InlineData("//server/share", "__server_share")]
+        [InlineData("C:\\Windows\\file.ext", "C:_Windows_file.ext")]
+        [InlineData("\\\\server\\share", "__server_share")]
+        public void Linux_Sanitizes_Full_Paths(string input, string expected)
+        {
+            var result = FileSafety.SanitizeFilename(input, '_', OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Linux_Uses_Custom_Replacement()
+        {
+            var result = FileSafety.SanitizeFilename("has/slash", '-', OSPlatform.Linux);
+
+            Assert.Equal("has-slash", result);
+        }
+
+        [Theory]
+        [InlineData("file\"name", "file_name")]
+        [InlineData("file<name>", "file_name_")]
+        [InlineData("file|name", "file_name")]
+        [InlineData("file:name", "file_name")]
+        [InlineData("file*name", "file_name")]
+        [InlineData("file?name", "file_name")]
+        [InlineData("file\\name", "file_name")]
+        [InlineData("file/name", "file_name")]
+        public void Windows_Replaces_InvalidCharacters(string input, string expected)
+        {
+            var result = FileSafety.SanitizeFilename(input, '_', OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("/home/user/foo", "_home_user_foo")]
+        [InlineData("//server/share", "__server_share")]
+        [InlineData("C:\\Windows\\file.ext", "C__Windows_file.ext")]
+        [InlineData("\\\\server\\share", "__server_share")]
+        public void Windows_Sanitizes_Full_Paths(string input, string expected)
+        {
+            var result = FileSafety.SanitizeFilename(input, '_', OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Windows_Replaces_ControlCharacters()
+        {
+            var input = "file\x01\x1fname";
+            var result = FileSafety.SanitizeFilename(input, '_', OSPlatform.Windows);
+
+            Assert.Equal("file__name", result);
+        }
+
+        [Theory]
+        [InlineData("clean", "clean")]
+        [InlineData("file.flac", "file.flac")]
+        [InlineData("My Artist", "My Artist")]
+        public void Windows_ReturnsUnchanged_Given_Safe_Filename(string input, string expected)
+        {
+            var result = FileSafety.SanitizeFilename(input, '_', OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Returns_Null_Given_Null()
+        {
+            var result = FileSafety.SanitizeFilename(null);
+
+            Assert.Null(result);
+        }
+    }
+}

--- a/tests/slskd.Tests.Unit/Common/FileSafety/SanitizePathSegmentTests.cs
+++ b/tests/slskd.Tests.Unit/Common/FileSafety/SanitizePathSegmentTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace slskd.Tests.Unit.Common;
+
+public partial class FileSafetyTests
+{
+    public class SanitizePathSegmentTests
+    {
+        [Theory]
+        [InlineData('/')]
+        [InlineData('\\')]
+        public void Throws_Given_Slash_As_Replacement(char replacement)
+        {
+            var ex = Record.Exception(() => FileSafety.SanitizePathSegment("segment", replacement));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentException>(ex);
+            Assert.Contains("invalid in filenames", ex.Message);
+        }
+
+        [Theory]
+        [InlineData(".")]
+        [InlineData("..")]
+        public void Replaces_Traversal_Segments_With_Replacement(string input)
+        {
+            var s = FileSafety.SanitizePathSegment(input, '_');
+
+            Assert.Equal("_", s);
+        }
+
+        [Theory]
+        [InlineData(".")]
+        [InlineData("..")]
+        public void Returns_Empty_String_When_Replacement_Is_Period_And_Result_Would_Be_Traversal(string input)
+        {
+            var s = FileSafety.SanitizePathSegment(input, '.');
+
+            Assert.Equal("", s);
+        }
+
+        [Theory]
+        [InlineData("a.")]
+        [InlineData("..b")]
+        [InlineData("c..d")]
+        public void Preserves_Periods_In_Segment_If_Not_Traversal(string input)
+        {
+            var s = FileSafety.SanitizePathSegment(input, '_');
+
+            Assert.Equal(input, s);
+        }
+
+        [Fact]
+        public void Respects_Replacement_Character()
+        {
+            var s = FileSafety.SanitizePathSegment("\0\0\0", replacement: '!');
+
+            Assert.Equal("!!!", s);
+        }
+
+        [Theory]
+        [InlineData("clean", "clean")]
+        [InlineData("Artist - Album", "Artist - Album")]
+        [InlineData("Ünïcödé", "Ünïcödé")]
+        [InlineData("пользователь", "пользователь")]
+        public void Linux_ReturnsUnchanged_Given_Safe_Segment(string input, string expected)
+        {
+            var result = FileSafety.SanitizePathSegment(input, '_', OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("has/slash", "has_slash")]
+        [InlineData("has\\backslash", "has_backslash")]
+        [InlineData("has/both\\types", "has_both_types")]
+        public void Linux_Replaces_Slashes(string input, string expected)
+        {
+            var result = FileSafety.SanitizePathSegment(input, '_', OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("file:name", "file_name")]
+        [InlineData("file*name", "file_name")]
+        [InlineData("file?name", "file_name")]
+        [InlineData("file\"name", "file_name")]
+        [InlineData("file/name", "file_name")]
+        [InlineData("file\\name", "file_name")]
+        public void Windows_Replaces_InvalidCharacters(string input, string expected)
+        {
+            var result = FileSafety.SanitizePathSegment(input, '_', OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Returns_Null_Given_Null()
+        {
+            var result = FileSafety.SanitizePathSegment(null);
+
+            Assert.Null(result);
+        }
+    }
+}

--- a/tests/slskd.Tests.Unit/Common/FileSafety/SanitizePathTests.cs
+++ b/tests/slskd.Tests.Unit/Common/FileSafety/SanitizePathTests.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace slskd.Tests.Unit.Common;
+
+public partial class FileSafetyTests
+{
+    public class SanitizePathTests
+    {
+        [Fact]
+        public void NullOs_UsesPlatformDefault_DoesNotThrow()
+        {
+            var result = FileSafety.SanitizePath("foo/bar");
+
+            Assert.NotNull(result);
+        }
+
+        [Theory]
+        [InlineData("foo/bar", "foo/bar")]
+        [InlineData("foo\\bar", "foo/bar")]
+        [InlineData("Artist/Album/song.flac", "Artist/Album/song.flac")]
+        [InlineData("Ünïcödé/пользователь", "Ünïcödé/пользователь")]
+        public void Linux_NormalizesSlashes(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, os: OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("foo/bar", "foo\\bar")]
+        [InlineData("foo\\bar", "foo\\bar")]
+        [InlineData("Artist/Album/song.flac", "Artist\\Album\\song.flac")]
+        public void Windows_NormalizesSlashes(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, os: OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("C:\\Music\\Artist", "Music\\Artist")]
+        [InlineData("C:/Music/Artist", "Music\\Artist")]
+        [InlineData("D:\\path\\to\\file", "path\\to\\file")]
+        [InlineData("Z:\\", "")]
+        public void Windows_Strips_DriveRoot(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, os: OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("C:\\Music\\Artist", "Music/Artist")]
+        [InlineData("C:/Music/Artist", "Music/Artist")]
+        [InlineData("D:\\path", "path")]
+        public void Linux_Strips_DriveRoot(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, os: OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("\\\\server\\share\\Music", "share\\Music")]
+        [InlineData("\\\\server\\Music", "Music")]
+        [InlineData("\\\\192.168.1.1\\share\\folder", "share\\folder")]
+        public void Windows_Strips_UncRoot(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, os: OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("//server/share/Music", "share/Music")]
+        [InlineData("//server/Music", "Music")]
+        [InlineData("//192.168.1.1/share/folder", "share/folder")]
+        public void Linux_Strips_UncRoot(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, os: OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("@@abcde/Music/Artist", "Music/Artist")]
+        [InlineData("@@abcdefgh/Music", "Music")]
+        [InlineData("@@abcde\\Music\\Artist", "Music/Artist")]
+        public void Linux_Strips_SoulseekQtPrefix(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, os: OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("@@abcde\\Music\\Artist", "Music\\Artist")]
+        [InlineData("@@abcdefgh\\Music", "Music")]
+        [InlineData("@@abcde/Music/Artist", "Music\\Artist")]
+        public void Windows_Strips_SoulseekQtPrefix(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, os: OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("@@abc/Music")]    // only 3 alphanumeric chars — does not match
+        [InlineData("@@abcd/Music")]   // only 4 — does not match
+        public void DoesNotStrip_SoulseekQtPrefix_When_Prefix_Too_Short(string input)
+        {
+            var result = FileSafety.SanitizePath(input, os: OSPlatform.Linux);
+
+            Assert.StartsWith("@@", result);
+        }
+
+        [Theory]
+        [InlineData("foo/../bar", "foo/_/bar")]
+        [InlineData("foo/./bar", "foo/_/bar")]
+        [InlineData("../etc", "_/etc")]
+        [InlineData("./tmp", "_/tmp")]
+        [InlineData("foo/..", "foo/_")]
+        [InlineData("foo/.", "foo/_")]
+        public void Linux_Replaces_TraversalSegments(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, os: OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("foo\\..\\bar", "foo\\_\\bar")]
+        [InlineData("foo\\.\\bar", "foo\\_\\bar")]
+        [InlineData("..\\etc", "_\\etc")]
+        public void Windows_Replaces_TraversalSegments(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, os: OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Linux_Replaces_InvalidFilenameChars_In_Segments()
+        {
+            var result = FileSafety.SanitizePath("seg\0ment/file\0name", os: OSPlatform.Linux);
+
+            Assert.Equal("seg_ment/file_name", result);
+        }
+
+        [Fact]
+        public void Windows_Replaces_InvalidFilenameChars_In_Segments()
+        {
+            var result = FileSafety.SanitizePath("seg*ment\\file:name", os: OSPlatform.Windows);
+
+            Assert.Equal("seg_ment\\file_name", result);
+        }
+
+        [Fact]
+        public void Uses_Custom_Replacement()
+        {
+            var result = FileSafety.SanitizePath("foo/../bar", replacement: '-', os: OSPlatform.Linux);
+
+            Assert.Equal("foo/-/bar", result);
+        }
+
+        [Fact]
+        public void Returns_Null_Given_Null_Path()
+        {
+            var result = FileSafety.SanitizePath(null);
+
+            Assert.Null(result);
+        }
+
+        // --- retainRoot: true ---
+        // These verify that SanitizePath honours retainRoot. The UNC and single-slash absolute
+        // cases are EXPECTED TO FAIL: SanitizePath filters empty segments produced by splitting on
+        // leading slashes, so "//server/share" becomes "server/share" — the root is silently lost.
+        // Drive-letter and @@-prefix cases pass because they produce no empty segments.
+
+
+        [Theory]
+        [InlineData("C:/Music/Artist", "C:/Music/Artist")]
+        [InlineData("C:\\Music\\Artist", "C:/Music/Artist")]
+        public void Linux_RetainsDriveRoot_When_RetainRoot_True(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, retainRoot: true, os: OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("C:\\Music\\Artist", "C_\\Music\\Artist")]
+        [InlineData("C:/Music/Artist", "C_\\Music\\Artist")]
+        public void Windows_RetainsDriveRoot_When_RetainRoot_True(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, retainRoot: true, os: OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("@@abcde/Music/Artist", "@@abcde/Music/Artist")]
+        [InlineData("@@abcde\\Music\\Artist", "@@abcde/Music/Artist")]
+        public void Linux_RetainsSoulseekQtPrefix_When_RetainRoot_True(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, retainRoot: true, os: OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("@@abcde\\Music\\Artist", "@@abcde\\Music\\Artist")]
+        [InlineData("@@abcde/Music/Artist", "@@abcde\\Music\\Artist")]
+        public void Windows_RetainsSoulseekQtPrefix_When_RetainRoot_True(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, retainRoot: true, os: OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("//server/share/Music", "//server/share/Music")]
+        [InlineData("//server/Music", "//server/Music")]
+        [InlineData("\\\\server\\share\\Music", "//server/share/Music")]
+        [InlineData("\\\\server\\Music", "//server/Music")]
+        public void Linux_RetainsUncRoot_When_RetainRoot_True(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, retainRoot: true, os: OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("/absolute/Music", "/absolute/Music")]
+        [InlineData("/single", "/single")]
+        [InlineData("\\absolute\\Music", "/absolute/Music")]
+        [InlineData("\\single", "/single")]
+        public void Linux_RetainsAbsoluteRoot_When_RetainRoot_True(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, retainRoot: true, os: OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("\\\\server\\share\\Music", "\\\\server\\share\\Music")]
+        [InlineData("\\\\server\\Music", "\\\\server\\Music")]
+        [InlineData("//server/share/Music", "\\\\server\\share\\Music")]
+        [InlineData("//server/Music", "\\\\server\\Music")]
+        public void Windows_RetainsUncRoot_When_RetainRoot_True(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, retainRoot: true, os: OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("\\absolute\\Music", "\\absolute\\Music")]
+        [InlineData("/absolute/Music", "\\absolute\\Music")]
+        public void Windows_RetainsDriveRelativeRoot_When_RetainRoot_True(string input, string expected)
+        {
+            var result = FileSafety.SanitizePath(input, retainRoot: true, os: OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/tests/slskd.Tests.Unit/Common/FileSafety/StripPathRootTests.cs
+++ b/tests/slskd.Tests.Unit/Common/FileSafety/StripPathRootTests.cs
@@ -1,0 +1,158 @@
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace slskd.Tests.Unit.Common;
+
+public partial class FileSafetyTests
+{
+    public class StripPathRootTests
+    {
+        [Fact]
+        public void NullOs_UsesPlatformDefault_DoesNotThrow()
+        {
+            var result = FileSafety.StripPathRoot("foo/bar");
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void Returns_Null_Given_Null_Path()
+        {
+            var result = FileSafety.StripPathRoot(null);
+
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("C:\\Music\\Artist", "Music/Artist")]
+        [InlineData("C:/Music/Artist", "Music/Artist")]
+        [InlineData("D:\\path\\to\\file", "path/to/file")]
+        [InlineData("Z:\\", "")]
+        [InlineData("Z:/", "")]
+        [InlineData("Z:", "")]              // bare drive letter, no separator
+        [InlineData("c:\\Music", "Music")]  // lowercase drive letter
+        [InlineData("A:/single", "single")]
+        public void Linux_Strips_DriveRoot(string input, string expected)
+        {
+            var result = FileSafety.StripPathRoot(input, OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("C:\\Music\\Artist", "Music\\Artist")]
+        [InlineData("C:/Music/Artist", "Music\\Artist")]
+        [InlineData("D:\\path\\to\\file", "path\\to\\file")]
+        [InlineData("Z:\\", "")]
+        [InlineData("Z:", "")]
+        [InlineData("c:\\Music", "Music")]
+        public void Windows_Strips_DriveRoot(string input, string expected)
+        {
+            var result = FileSafety.StripPathRoot(input, OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("//server/share/Music", "share/Music")]
+        [InlineData("//server/Music", "Music")]
+        [InlineData("//192.168.1.1/share/folder", "share/folder")]
+        [InlineData("//server", "")]   // no path after server
+        public void Linux_Strips_UncRoot(string input, string expected)
+        {
+            var result = FileSafety.StripPathRoot(input, OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("\\\\server\\share\\Music", "share\\Music")]
+        [InlineData("\\\\server\\Music", "Music")]
+        [InlineData("\\\\192.168.1.1\\share\\folder", "share\\folder")]
+        [InlineData("\\\\server", "")]   // no path after server
+        public void Windows_Strips_UncRoot(string input, string expected)
+        {
+            var result = FileSafety.StripPathRoot(input, OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("@@abcde/Music/Artist", "Music/Artist")]
+        [InlineData("@@abcdefgh/Music", "Music")]
+        [InlineData("@@abcde\\Music\\Artist", "Music/Artist")]
+        public void Linux_Strips_SoulseekQtPrefix(string input, string expected)
+        {
+            var result = FileSafety.StripPathRoot(input, OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("@@abcde\\Music\\Artist", "Music\\Artist")]
+        [InlineData("@@abcdefgh\\Music", "Music")]
+        [InlineData("@@abcde/Music/Artist", "Music\\Artist")]
+        public void Windows_Strips_SoulseekQtPrefix(string input, string expected)
+        {
+            var result = FileSafety.StripPathRoot(input, OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("@@abc/Music")]    // only 3 alphanumeric chars — does not match
+        [InlineData("@@abcd/Music")]   // only 4 — does not match
+        public void DoesNotStrip_SoulseekQtPrefix_When_Prefix_Too_Short(string input)
+        {
+            var result = FileSafety.StripPathRoot(input, OSPlatform.Linux);
+
+            Assert.StartsWith("@@", result);
+        }
+
+        [Theory]
+        [InlineData("Music/Artist", "Music/Artist")]
+        [InlineData("Artist/Album/song.flac", "Artist/Album/song.flac")]
+        [InlineData("just_a_filename.flac", "just_a_filename.flac")]
+        [InlineData("", "")]
+        [InlineData("foo", "foo")]
+        public void Linux_ReturnsUnchanged_Given_Relative_Path(string input, string expected)
+        {
+            var result = FileSafety.StripPathRoot(input, OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("Music\\Artist", "Music\\Artist")]
+        [InlineData("Artist\\Album\\song.flac", "Artist\\Album\\song.flac")]
+        [InlineData("just_a_filename.flac", "just_a_filename.flac")]
+        [InlineData("foo", "foo")]
+        public void Windows_ReturnsUnchanged_Given_Relative_Path(string input, string expected)
+        {
+            var result = FileSafety.StripPathRoot(input, OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("/home/user/Music", "/home/user/Music")]
+        [InlineData("/Music", "/Music")]
+        [InlineData("/single", "/single")]
+        public void Linux_ReturnsUnchanged_Given_Single_ForwardSlash_Prefix(string input, string expected)
+        {
+            var result = FileSafety.StripPathRoot(input, OSPlatform.Linux);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("\\Music", "\\Music")]
+        [InlineData("\\home\\user", "\\home\\user")]
+        public void Windows_ReturnsUnchanged_Given_Single_BackwardSlash_Prefix(string input, string expected)
+        {
+            var result = FileSafety.StripPathRoot(input, OSPlatform.Windows);
+
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
Because both Windows-style (backslashes) and Linux-style (forward slashes) can be encountered on the Soulseek network, and because:

1. The .NET runtime's `System.IO.Path` namespace only handles whatever type matches the host operating system and,
2. Because this behavior is completely opaque and un-testable and,
3. `Path.Combine` fails in spectacular ways, such as completely re-rooting segments if they start with a slash and,
4. Several other `Path.` functions honor path-traversal segments that can cause (as the name implies) path traversal

I was forced to re-implement a lot of the functions myself over the past _several weeks_.

This PR contains what is hopefully everything that will be needed, and the tests and logic hopefully cover all of the scenarios that might be encountered.

I'm aware that there are a bunch of really wacky paths supported by Windows, but they should all be treated as UNC paths and will therefore be handled safely (or will error).

Changes cherry-picked from #1746 