### PR TITLE
Add Traffic & File Tickers in Web UI

### DIFF
--- a/src/web/src/components/System/Shares/TrafficStatsTable.jsx
+++ b/src/web/src/components/System/Shares/TrafficStatsTable.jsx
@@ -1,0 +1,66 @@
+import { Table } from 'semantic-ui-react';
+
+const formatBytes = (bytes, decimals = 2) => {
+  if (!Number(bytes)) return '0 Bytes';
+
+  const k = 1_024;
+  const dm = Math.max(0, decimals);
+  const sizes = [
+    'Bytes',
+    'KiB',
+    'MiB',
+    'GiB',
+    'TiB',
+    'PiB',
+    'EiB',
+    'ZiB',
+    'YiB',
+  ];
+
+  const index = Math.floor(Math.log(bytes) / Math.log(k));
+  const scaled = (bytes / k ** index).toFixed(dm);
+  const unit = sizes[index];
+
+  return `${scaled} ${unit}`;
+};
+
+/**
+ * @typedef {object} TrafficStats
+ * @property {number} uploadedFiles - Number of successfully uploaded files
+ * @property {number} uploadedBytes - Number of bytes uploaded
+ * @property {number} downloadedFiles - Number of successfully downloaded files
+ * @property {number} downloadedBytes - Number of bytes downloaded
+ * @param {object} params
+ * @param {TrafficStats} params.stats
+ */
+const TrafficStatsTable = ({ stats }) => {
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell colSpan="2">Traffic Statistics</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>
+            Uploaded (Completed) Files: {stats.uploadedFiles}
+          </Table.Cell>
+          <Table.Cell>
+            Total Upload Traffic: {formatBytes(stats.uploadedBytes)}
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>
+            Downloaded (Completed) Files: {stats.downloadedFiles}
+          </Table.Cell>
+          <Table.Cell>
+            Total Download Traffic: {formatBytes(stats.downloadedBytes)}
+          </Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table>
+  );
+};
+
+export default TrafficStatsTable;

--- a/src/web/src/components/System/Shares/index.jsx
+++ b/src/web/src/components/System/Shares/index.jsx
@@ -1,8 +1,10 @@
 import * as sharesLibrary from '../../../lib/shares';
+import * as transfersLibrary from '../../../lib/transfers';
 import { LoaderSegment, ShrinkableButton, Switch } from '../../Shared';
 import ContentsModal from './ContentsModal';
 import ExclusionTable from './ExclusionTable';
 import ShareTable from './ShareTable';
+import TrafficStatsTable from './TrafficStatsTable';
 import React, { useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
 import { Divider } from 'semantic-ui-react';
@@ -38,6 +40,7 @@ const Shares = ({ state = {}, theme } = {}) => {
   const [working, setWorking] = useState(false);
   const [shares, setShares] = useState([]);
   const [modal, setModal] = useState(false);
+  const [trafficStats, setTrafficStats] = useState({});
 
   const { directories, files, scanPending, scanProgress, scanning } = state;
 
@@ -78,6 +81,30 @@ const Shares = ({ state = {}, theme } = {}) => {
       setTimeout(() => getAll(true), 1_000);
     }
   }, [scanPending, scanning]);
+
+  useEffect(() => {
+    const bytesTransferred = (statuses) =>
+      Object.values(statuses).reduce(
+        (accumulator, current) => current.totalBytes + accumulator,
+        0,
+      );
+    const fetchStats = async () => {
+      const statsResponse = await transfersLibrary.getStats();
+      const stats = statsResponse.data;
+      const uploadedFiles = stats.Upload?.Succeeded?.count ?? 0;
+      const downloadedFiles = stats.Download?.Succeeded?.count ?? 0;
+      const uploadedBytes = bytesTransferred(stats.Upload);
+      const downloadedBytes = bytesTransferred(stats.Download);
+      setTrafficStats({
+        uploadedBytes,
+        uploadedFiles,
+        downloadedBytes,
+        downloadedFiles,
+      });
+    };
+
+    fetchStats();
+  }, []);
 
   const rescan = async () => {
     try {
@@ -151,6 +178,7 @@ const Shares = ({ state = {}, theme } = {}) => {
           shares={shared}
         />
         <ExclusionTable exclusions={excluded} />
+        <TrafficStatsTable stats={trafficStats} />
       </Switch>
       <ContentsModal
         onClose={() => setModal(false)}

--- a/src/web/src/lib/transfers.js
+++ b/src/web/src/lib/transfers.js
@@ -61,3 +61,26 @@ export const isStateCancellable = (state) =>
   ].find((s) => s === state);
 
 export const isStateRemovable = (state) => state.includes('Completed');
+
+/**
+ * @typedef {object} TransferSummary
+ * @property {number} totalBytes - Total number of bytes transferred
+ * @property {number} count - Number of transfers
+ * @property {number} distinctUsers - Number of distinct users
+ * @property {number} averageSpeed - Average transfer speed
+ * @property {number} averageWait - Average wait time
+ * @property {number} averageDuration - Average transfer duration
+ * @typedef {object} TransferStateSummaries
+ * @property {TransferSummary} Aborted - Aborted transfers
+ * @property {TransferSummary} Cancelled - Cancelled transfers
+ * @property {TransferSummary} Errored - Errored transfers
+ * @property {TransferSummary} Rejected - Rejected transfers
+ * @property {TransferSummary} Succeeded - Successful transferse
+ * @returns {Promise<{Upload: TransferStateSummaries, Download: TransferStateSummaries}>}
+ */
+export const getStats = () => {
+  const startTime = '0001-01-01 00:00:00Z';
+  return api.get(
+    `/telemetry/reports/transfers/summary?start=${encodeURIComponent(startTime)}`,
+  );
+};


### PR DESCRIPTION
Closes #710

this implementation is maybe a bit hacky, as it uses the `/telemetry/reports/transfers/summary` endpoint, which turns out to have all the information needed to replicate the UI in the issue.
the endpoint doesn't expose the date of the oldest record however, so that isn't included currently.
i see two approaches to tackle this, either
1. extend `TransferSummary` with a `EarliestRecordTime` property, or
2. make a dedicated endpoint for traffic data.

i personally think the second approach is cleaner, since it appears that `TransferSummary` is produced in multiple places, but i'd like your input on that.
in case of the second approach, we also need to figure out where to put the endpoint, since it doesn't really feel like it fits nicely with any of the current endpoints (`/telemetry` seems to be for public endpoints, `transfers` could maybe work?)

i'm also not a huge fan of placing it under `/system/shares` in the UI, since it seems quite unrelated to the other things on that page.
maybe in the future there should be a dedicated page for showing stats (maybe making `/system/info` look more user-friendly, since it seems to already show a lot of interesting statistics)

<!--

Per CONTRIBUTING.md:

# Contributing

All contributions must have first been discussed within an Issue or Discussion.  Pull Requests opened without an accompanying Issue are considered to be unsolicited, and unsolicited Pull Requests may be rejected without review and/or converted into an Issue.

## Copyright

By submitting a contribution to this project, you agree to the following:

* You have the legal right to make this contribution and to assign its copyright.
* You irrevocably assign all copyright and related rights in your contribution to the project maintainer(s).
* You grant the project maintainer(s) the right to use, modify, distribute, and relicense your contribution under any license of their choosing.

This application is currently released under the [AGPL 3.0](https://github.com/slskd/slskd/blob/master/LICENSE) license.

## Use of AI in Contributions

If you used AI tools (such as ChatGPT, Copilot, Claude, etc.) to assist with your contribution, you must clearly disclose this in your Pull Request, including:

* Which AI tool(s) you used
* How you used them (e.g., code generation, refactoring suggestions, documentation help)
* Which parts of your contribution were AI-assisted

Contributors are expected to fully understand and take responsibility for all code they submit, regardless of how it was produced.  Contributions made entirely by AI are not welcome and will be rejected.

-->