### PR TITLE
Move 'permissions' options under 'destination', improve application of directory mode

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -81,6 +81,8 @@
 #     destination:
 #       subdirectory: ${SOURCE_DIRECTORY} # options: SOURCE_USERNAME, SOURCE_PATH, SOURCE_DIRECTORY, BATCH_ID, BATCH_EXTERNAL_ID, SEARCH_ID, SEARCH_TEXT
 #       exists: rename # 'overwrite' or 'rename'
+#       permissions:
+#         mode: ~ # chmod syntax, e.g. 644, 777. does nothing on Windows. 
 #   groups:
 #     default:
 #       upload:

--- a/docs/config.md
+++ b/docs/config.md
@@ -117,21 +117,11 @@ Users wishing to create files with different permissions can change the umask va
 
 When running within a docker container the environment variable `SLSKD_UMASK` can be used to change the umask for the process within the container, and this will in turn change the resulting file mode on a mounted volume.
 
-Users can optionally configure alternative permissions for files by setting the file permission mode option.  It's not possible to supersede the configured umask value; setting a mode of 777, for example, will have no effect with a umask of 022.
-
-These options have no effect on Windows.
+This option has no effect on Windows.
 
 | Command-Line             | Environment Variable         | Description                                                                      |
 | ------------------------ | -----------------------------| -------------------------------------------------------------------------------- |
 | n/a                      | `SLSKD_UMASK`                | When running within the slskd Docker container, the umask for the process        |
-| `--file-permission-mode` | `SLSKD_FILE_PERMISSION_MODE` | The permissions to apply to newly created files (chmod syntax, non-Windows only) |
-
-#### **YAML**
-```yaml
-permissions:
-  file:
-    mode: 644 # not for Windows, chmod syntax, e.g. 644, 777. can't escalate beyond umask
-```
 
 # Application Directory Configuration
 
@@ -375,6 +365,25 @@ transfers:
       attempts: 3
       delay: 5000 # initial time between retries, in milliseconds
       max_delay: 60000 # maximum time between retries, in milliseconds
+```
+
+## Destination
+
+### Permissions
+
+On [Unix-like](https://en.wikipedia.org/wiki/Unix-like) operating systems, downloaded files will be created according to the [umask](https://en.wikipedia.org/wiki/Umask) of the process (see [Permissions](#permissions) for more info).
+
+Users can optionally configure alternative permissions by setting the permission mode option which, when enabled, effectively causes slskd to `chmod` files and directories with the configured mode immediately after creation.
+
+This option has no effect on Windows.
+
+#### **YAML**
+```yaml
+transfers:
+  download:
+    destination:
+      permissions:
+        mode: 644 # chmod syntax, e.g. 644, 777.  has no effect on Windows
 ```
 
 ## Global Upload Limits

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -235,11 +235,8 @@ namespace slskd
         [Validate]
         public RelayOptions Relay { get; init; } = new RelayOptions();
 
-        /// <summary>
-        ///     Gets permission options.
-        /// </summary>
-        [Validate]
-        public PermissionsOptions Permissions { get; init; } = new PermissionsOptions();
+        [Obsolete("temporary sentinel to warn users about breaking change.  use Transfers.Download.Destination.Permissions instead.")]
+        public object Permissions { get; init; } = null;
 
         /// <summary>
         ///     Gets directory options.
@@ -363,6 +360,11 @@ namespace slskd
             if (Integration is not null)
             {
                 results.Add(new ValidationResult("The 'integration' key has been renamed to 'integrations'.  Add an 's' to the end of the key to remove this error (no other changes were made)"));
+            }
+
+            if (Permissions is not null)
+            {
+                results.Add(new ValidationResult("The 'permissions' keys have been moved under a new 'destination' key under transfers -> download, and the behavior has changed.  See https://github.com/slskd/slskd/pull/1756 for details"));
             }
 #pragma warning restore CS0618 // Type or member is obsolete
 

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1082,6 +1082,43 @@ namespace slskd
                     /// </summary>
                     [Enum(typeof(DestinationExistsStrategy))]
                     public string Exists { get; init; } = DestinationExistsStrategy.Rename.ToString().ToLowerInvariant();
+
+                    /// <summary>
+                    ///     Gets the permissions to apply to downloaded files and directories.
+                    /// </summary>
+                    [Validate]
+                    public DestinationPermissionsOptions Permissions { get; init; } = new DestinationPermissionsOptions();
+
+                    /// <summary>
+                    ///     Download destination permission options.
+                    /// </summary>
+                    public class DestinationPermissionsOptions : IValidatableObject
+                    {
+                        /// <summary>
+                        ///     Gets the permissions to apply to newly created files.
+                        /// </summary>
+                        /// <remarks>
+                        ///     Applicable to non-Windows operating systems, only.
+                        /// </remarks>
+                        public string Mode { get; init; }
+
+                        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+                        {
+                            var results = new List<ValidationResult>();
+
+                            if (!string.IsNullOrEmpty(Mode))
+                            {
+                                var regEx = new Regex("^[0-7]{3,4}$", RegexOptions.Compiled);
+
+                                if (!regEx.IsMatch(Mode))
+                                {
+                                    results.Add(new ValidationResult($"Field {nameof(Mode)} is invalid. Specify a three- or four-character string consisting of only 0-7 (chmod syntax, [0]000-[7]777, inclusive)"));
+                                }
+                            }
+
+                            return results;
+                        }
+                    }
                 }
             }
 

--- a/src/slskd/Files/FileService.cs
+++ b/src/slskd/Files/FileService.cs
@@ -389,13 +389,15 @@ namespace slskd.Files
 
             var path = Path.GetDirectoryName(filename);
 
-            UnixFileMode? unixCreateMode = options?.UnixCreateMode ?? OptionsMonitor.CurrentValue.Permissions.File.Mode?.ToUnixFileMode();
+            UnixFileMode? unixCreateMode = options?.UnixCreateMode ?? OptionsMonitor.CurrentValue.Transfers.Download.Destination.Permissions.Mode?.ToUnixFileMode();
 
             if (!Directory.Exists(path))
             {
                 if (!OperatingSystem.IsWindows() && unixCreateMode.HasValue)
                 {
-                    Directory.CreateDirectory(path, unixCreateMode.Value.WithExecuteFlagsForEachReadFlag());
+                    var mode = unixCreateMode.Value.WithExecuteFlagsForEachReadFlag();
+                    Directory.CreateDirectory(path, unixCreateMode: mode);
+                    File.SetUnixFileMode(path, mode: mode);
                 }
                 else
                 {
@@ -469,13 +471,15 @@ namespace slskd.Files
                 throw new FileNotFoundException($"The specified source file does not exist", fileName: sourceFilename);
             }
 
-            UnixFileMode? unixCreateMode = unixFileMode ?? OptionsMonitor.CurrentValue.Permissions.File.Mode?.ToUnixFileMode();
+            UnixFileMode? unixCreateMode = unixFileMode ?? OptionsMonitor.CurrentValue.Transfers.Download.Destination.Permissions.Mode?.ToUnixFileMode();
 
             if (!Directory.Exists(destinationDirectory))
             {
                 if (!OperatingSystem.IsWindows() && unixCreateMode.HasValue)
                 {
-                    Directory.CreateDirectory(destinationDirectory, unixCreateMode.Value.WithExecuteFlagsForEachReadFlag());
+                    var mode = unixCreateMode.Value.WithExecuteFlagsForEachReadFlag();
+                    Directory.CreateDirectory(destinationDirectory, unixCreateMode: mode);
+                    File.SetUnixFileMode(destinationDirectory, mode: mode);
                 }
                 else
                 {

--- a/src/slskd/Transfers/Downloads/DownloadService.cs
+++ b/src/slskd/Transfers/Downloads/DownloadService.cs
@@ -1218,8 +1218,8 @@ namespace slskd.Transfers.Downloads
                     }),
                     disposeOutputStreamOnCompletion: true);
 
-                UnixFileMode? unixFileMode = !string.IsNullOrEmpty(OptionsMonitor.CurrentValue.Permissions.File.Mode)
-                    ? OptionsMonitor.CurrentValue.Permissions.File.Mode.ToUnixFileMode()
+                UnixFileMode? unixFileMode = !string.IsNullOrEmpty(OptionsMonitor.CurrentValue.Transfers.Download.Destination.Permissions.Mode)
+                    ? OptionsMonitor.CurrentValue.Transfers.Download.Destination.Permissions.Mode.ToUnixFileMode()
                     : null;
 
                 /*


### PR DESCRIPTION
When I originally added the option to explicitly set the unix file mode of downloaded files and directories, I used a method that causes the effective mode to be influenced by the application's umask.  This meant that if someone specified `777`, the file would have the desired permissions but the directory would end up with something else, typically `755` (`022` being a common default umask)

I recently realized that I can explicitly set the mode of directories as well as files by calling `File.SetUnixFileMode`, which is pretty poorly named.  Though on unix, directories are files, too.  So _technically_ it's accurate.  Anyway..

After I added the download destination options in #1746, that group of options became a much better home for this option than in the top-level `permission` key, so I'm moving it.

As with other recently moved/deprecated keys, I am adding a fake validation error to alert users to the move.  In addition to moving the option, the behavior is changed and users need to reconsider their desired mode, knowing that it now correctly applies to directories as well as files.

Docs:

### Permissions

On [Unix-like](https://en.wikipedia.org/wiki/Unix-like) operating systems, downloaded files will be created according to the [umask](https://en.wikipedia.org/wiki/Umask) of the process (see [Permissions](#permissions) for more info).

Users can optionally configure alternative permissions by setting the permission mode option which, when enabled, effectively causes slskd to `chmod` files and directories with the configured mode immediately after creation.

This option has no effect on Windows.

#### **YAML**
```yaml
transfers:
  download:
    destination:
      permissions:
        mode: 644 # chmod syntax, e.g. 644, 777.  has no effect on Windows
```

## Testing

* [x] Validation error when old permissions key is used
* [x] Files and directories are created with the expected mode