### PR TITLE
Fix bug in default destination subdirectory expression (add missing '$')

### DIFF
--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1075,7 +1075,7 @@ namespace slskd
                     [RelativePath(OperatingSystem.All)]
                     [NonTraversingPath]
                     [String(AllowNull = true, AllowEmpty = false, AllowWhiteSpace = false, MinimumLength = 1)]
-                    public string Subdirectory { get; init; } = "{SOURCE_DIRECTORY}";
+                    public string Subdirectory { get; init; } = "${SOURCE_DIRECTORY}";
 
                     /// <summary>
                     ///     Gets the strategy for handling existing files on disk.


### PR DESCRIPTION
Prefixing tokens for the destination subdirectory was a last minute change to avoid the need for users to use single quotes around the value in their yaml file.  When I did this, I forgot to update the default value in the Options class.  This PR fixes it.