### PR TITLE
Bump dependencies, change Grafana Loki logging format

### DIFF
--- a/src/slskd/Common/OpenAPI/ContentNegotiationOperationFilter.cs
+++ b/src/slskd/Common/OpenAPI/ContentNegotiationOperationFilter.cs
@@ -36,7 +36,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 /// <summary>

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -1008,6 +1008,7 @@ namespace slskd
                 services.AddSwaggerGen(options =>
                 {
                     options.DescribeAllParametersInCamelCase();
+                    options.CustomSchemaIds(type => type.FullName);
                     options.SwaggerDoc("v0", new OpenApiInfo
                     {
                         Version = "v0",
@@ -1217,6 +1218,7 @@ namespace slskd
                 .MinimumLevel.Override("slskd.Authentication.PassthroughAuthenticationHandler", LogEventLevel.Warning)
                 .MinimumLevel.Override("slskd.Authentication.ApiKeyAuthenticationHandler", LogEventLevel.Warning)
                 .MinimumLevel.Override("Microsoft.EntityFrameworkCore.Database.Command", LogEventLevel.Warning) // bump this down to Information to show SQL
+                .Enrich.WithProperty("App", AppName)
                 .Enrich.WithProperty("InstanceName", OptionsAtStartup.InstanceName)
                 .Enrich.WithProperty("InvocationId", InvocationId)
                 .Enrich.WithProperty("ProcessId", ProcessId)
@@ -1239,9 +1241,7 @@ namespace slskd
                     {
                         if (!string.IsNullOrEmpty(OptionsAtStartup.Logger.Loki))
                         {
-                            config.GrafanaLoki(
-                                OptionsAtStartup.Logger.Loki,
-                                textFormatter: new MessageTemplateTextFormatter("[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"));
+                            config.GrafanaLoki(OptionsAtStartup.Logger.Loki);
                         }
                     })
                 .WriteTo.Sink(new DelegatingSink(logEvent =>

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -62,7 +62,7 @@ namespace slskd
     using Microsoft.Extensions.FileProviders;
     using Microsoft.Extensions.FileProviders.Physical;
     using Microsoft.IdentityModel.Tokens;
-    using Microsoft.OpenApi.Models;
+    using Microsoft.OpenApi;
     using Prometheus.DotNetRuntime;
     using Prometheus.SystemMetrics;
     using Serilog;

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -1235,9 +1235,15 @@ namespace slskd
                             retainedFileTimeLimit: TimeSpan.FromDays(OptionsAtStartup.Retention.Logs))))
                 .WriteTo.Conditional(
                     e => !string.IsNullOrEmpty(OptionsAtStartup.Logger.Loki),
-                    config => config.GrafanaLoki(
-                        OptionsAtStartup.Logger.Loki ?? string.Empty,
-                        textFormatter: new MessageTemplateTextFormatter("[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")))
+                    config =>
+                    {
+                        if (!string.IsNullOrEmpty(OptionsAtStartup.Logger.Loki))
+                        {
+                            config.GrafanaLoki(
+                                OptionsAtStartup.Logger.Loki,
+                                textFormatter: new MessageTemplateTextFormatter("[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"));
+                        }
+                    })
                 .WriteTo.Sink(new DelegatingSink(logEvent =>
                 {
                     string message = default;

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -67,6 +67,7 @@ namespace slskd
     using Prometheus.SystemMetrics;
     using Serilog;
     using Serilog.Events;
+    using Serilog.Formatting.Display;
     using Serilog.Sinks.Grafana.Loki;
     using Serilog.Sinks.SystemConsole.Themes;
     using slskd.Authentication;
@@ -1236,7 +1237,7 @@ namespace slskd
                     e => !string.IsNullOrEmpty(OptionsAtStartup.Logger.Loki),
                     config => config.GrafanaLoki(
                         OptionsAtStartup.Logger.Loki ?? string.Empty,
-                        outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"))
+                        textFormatter: new MessageTemplateTextFormatter("[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")))
                 .WriteTo.Sink(new DelegatingSink(logEvent =>
                 {
                     string message = default;

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -43,41 +43,41 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-    <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
+    <PackageReference Include="Dapper" Version="2.1.79" />
     <PackageReference Include="FluentFTP" Version="49.0.2" />
-    <PackageReference Include="IPAddressRange" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.6" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+    <PackageReference Include="IPAddressRange" Version="6.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.8" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.300">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="8.0.6" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="10.0.8" />
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="8.2.1" />
-    <PackageReference Include="prometheus-net.DotNetRuntime" Version="4.4.0" />
+    <PackageReference Include="prometheus-net.DotNetRuntime" Version="4.4.1" />
     <PackageReference Include="prometheus-net.SystemMetrics" Version="3.1.0" />
-    <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
-    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="7.1.1" />
-    <PackageReference Include="Serilog.Sinks.Http" Version="8.0.0" />
-    <PackageReference Include="Soulseek" Version="10.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Http" Version="9.2.1" />
+    <PackageReference Include="Soulseek" Version="10.0.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
     <PackageReference Include="TagLibSharp" Version="2.3.0" />
     <PackageReference Include="Utility.CommandLine.Arguments" Version="6.0.0" />
     <PackageReference Include="Utility.EnvironmentVariables" Version="1.0.5" />
-    <PackageReference Include="YamlDotNet" Version="15.3.0" />
+    <PackageReference Include="YamlDotNet" Version="18.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/slskd.Tests.Unit/slskd.Tests.Unit.csproj
+++ b/tests/slskd.Tests.Unit/slskd.Tests.Unit.csproj
@@ -7,14 +7,14 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
I neglected to bump packages when I upgraded to .NET 10.  This PR bumps everything except for FluentFTP (it works fine and I don't want to deal with a big refactor) and Moq (the maintainer made some questionable changes a while ago)

The Grafana Loki sync for Serilog had a breaking change and I went down a bit of a rabbit hole making sure it was working properly and that the output made sense.  The logs being captured were human readable but none of the properties were extracted, kind of defeating the purpose of structured logging.  I'm now using the default formatter, which is less nice to look at but is more useful.  If anyone cares about this, feel free to create an issue.