### PR TITLE
Update x509 generation/validation to resolve warnings, deprecate old permissions objects

### DIFF
--- a/src/slskd/Common/Cryptography/X509.cs
+++ b/src/slskd/Common/Cryptography/X509.cs
@@ -64,7 +64,7 @@ namespace slskd.Cryptography
                 new DateTimeOffset(DateTime.UtcNow.AddDays(-1)),
                 new DateTimeOffset(DateTime.UtcNow.AddDays(36500)));
 
-            return new X509Certificate2(certificate.Export(X509ContentType.Pkcs12, password), password, x509KeyStorageFlags);
+            return X509CertificateLoader.LoadPkcs12(certificate.Export(X509ContentType.Pkcs12, password), password, x509KeyStorageFlags);
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace slskd.Cryptography
 
             try
             {
-                _ = new X509Certificate2(fileName, password);
+                _ = X509CertificateLoader.LoadPkcs12FromFile(fileName, password);
                 return true;
             }
             catch (Exception ex)

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -706,57 +706,6 @@ namespace slskd
         }
 
         /// <summary>
-        ///     Permission options.
-        /// </summary>
-        public class PermissionsOptions
-        {
-            /// <summary>
-            ///     Gets file permission options.
-            /// </summary>
-            [Validate]
-            public FileOptions File { get; init; } = new FileOptions();
-
-            /// <summary>
-            ///     File permission options.
-            /// </summary>
-            public class FileOptions : IValidatableObject
-            {
-                /// <summary>
-                ///     Gets the permissions to apply to newly created files.
-                /// </summary>
-                /// <remarks>
-                ///     Applicable to non-Windows operating systems, only.
-                /// </remarks>
-                [Argument(default, "file-permission-mode")]
-                [EnvironmentVariable("FILE_PERMISSION_MODE")]
-                [Description("the permissions to apply to newly created files (chmod syntax, non-Windows only)")]
-                public string Mode { get; init; }
-
-                /// <summary>
-                ///     Extended validation.
-                /// </summary>
-                /// <param name="validationContext"></param>
-                /// <returns></returns>
-                public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-                {
-                    var results = new List<ValidationResult>();
-
-                    if (!string.IsNullOrEmpty(Mode))
-                    {
-                        var regEx = new Regex("^[0-7]{3,4}$", RegexOptions.Compiled);
-
-                        if (!regEx.IsMatch(Mode))
-                        {
-                            results.Add(new ValidationResult($"Field {nameof(Mode)} is invalid. Specify a three- or four-character string consisting of only 0-7 (chmod syntax, [0]000-[7]777, inclusive)"));
-                        }
-                    }
-
-                    return results;
-                }
-            }
-        }
-
-        /// <summary>
         ///     Directory options.
         /// </summary>
         public class DirectoriesOptions

--- a/tests/slskd.Tests.Unit/Files/FileServiceTests.cs
+++ b/tests/slskd.Tests.Unit/Files/FileServiceTests.cs
@@ -155,11 +155,17 @@ namespace slskd.Tests.Unit.Files
 
             OptionsMonitorMock.Setup(o => o.CurrentValue).Returns(new Options
             {
-                Permissions = new Options.PermissionsOptions
+                Transfers = new Options.TransfersOptions
                 {
-                    File = new Options.PermissionsOptions.FileOptions
+                    Download = new Options.TransfersOptions.GlobalDownloadOptions
                     {
-                        Mode = mode,
+                        Destination = new Options.TransfersOptions.GlobalDownloadOptions.DestinationOptions
+                        {
+                            Permissions = new Options.TransfersOptions.GlobalDownloadOptions.DestinationOptions.DestinationPermissionsOptions
+                            {
+                                Mode = mode,
+                            }
+                        }
                     }
                 }
             });
@@ -204,11 +210,17 @@ namespace slskd.Tests.Unit.Files
 
             OptionsMonitorMock.Setup(o => o.CurrentValue).Returns(new Options
             {
-                Permissions = new Options.PermissionsOptions
+                Transfers = new Options.TransfersOptions
                 {
-                    File = new Options.PermissionsOptions.FileOptions
+                    Download = new Options.TransfersOptions.GlobalDownloadOptions
                     {
-                        Mode = mode,
+                        Destination = new Options.TransfersOptions.GlobalDownloadOptions.DestinationOptions
+                        {
+                            Permissions = new Options.TransfersOptions.GlobalDownloadOptions.DestinationOptions.DestinationPermissionsOptions
+                            {
+                                Mode = mode,
+                            }
+                        }
                     }
                 }
             });
@@ -262,11 +274,17 @@ namespace slskd.Tests.Unit.Files
 
             OptionsMonitorMock.Setup(o => o.CurrentValue).Returns(new Options
             {
-                Permissions = new Options.PermissionsOptions
+                Transfers = new Options.TransfersOptions
                 {
-                    File = new Options.PermissionsOptions.FileOptions
+                    Download = new Options.TransfersOptions.GlobalDownloadOptions
                     {
-                        Mode = mode,
+                        Destination = new Options.TransfersOptions.GlobalDownloadOptions.DestinationOptions
+                        {
+                            Permissions = new Options.TransfersOptions.GlobalDownloadOptions.DestinationOptions.DestinationPermissionsOptions
+                            {
+                                Mode = mode,
+                            }
+                        }
                     }
                 }
             });
@@ -316,11 +334,17 @@ namespace slskd.Tests.Unit.Files
 
             OptionsMonitorMock.Setup(o => o.CurrentValue).Returns(new Options
             {
-                Permissions = new Options.PermissionsOptions
+                Transfers = new Options.TransfersOptions
                 {
-                    File = new Options.PermissionsOptions.FileOptions
+                    Download = new Options.TransfersOptions.GlobalDownloadOptions
                     {
-                        Mode = mode,
+                        Destination = new Options.TransfersOptions.GlobalDownloadOptions.DestinationOptions
+                        {
+                            Permissions = new Options.TransfersOptions.GlobalDownloadOptions.DestinationOptions.DestinationPermissionsOptions
+                            {
+                                Mode = mode,
+                            }
+                        }
                     }
                 }
             });
@@ -367,11 +391,17 @@ namespace slskd.Tests.Unit.Files
 
             OptionsMonitorMock.Setup(o => o.CurrentValue).Returns(new Options
             {
-                Permissions = new Options.PermissionsOptions
+                Transfers = new Options.TransfersOptions
                 {
-                    File = new Options.PermissionsOptions.FileOptions
+                    Download = new Options.TransfersOptions.GlobalDownloadOptions
                     {
-                        Mode = optionsMode,
+                        Destination = new Options.TransfersOptions.GlobalDownloadOptions.DestinationOptions
+                        {
+                            Permissions = new Options.TransfersOptions.GlobalDownloadOptions.DestinationOptions.DestinationPermissionsOptions
+                            {
+                                Mode = optionsMode,
+                            }
+                        }
                     }
                 }
             });
@@ -401,11 +431,17 @@ namespace slskd.Tests.Unit.Files
 
             OptionsMonitorMock.Setup(o => o.CurrentValue).Returns(new Options
             {
-                Permissions = new Options.PermissionsOptions
+                Transfers = new Options.TransfersOptions
                 {
-                    File = new Options.PermissionsOptions.FileOptions
+                    Download = new Options.TransfersOptions.GlobalDownloadOptions
                     {
-                        Mode = optionsMode,
+                        Destination = new Options.TransfersOptions.GlobalDownloadOptions.DestinationOptions
+                        {
+                            Permissions = new Options.TransfersOptions.GlobalDownloadOptions.DestinationOptions.DestinationPermissionsOptions
+                            {
+                                Mode = optionsMode,
+                            }
+                        }
                     }
                 }
             });


### PR DESCRIPTION
With .NET 10 came a change to x509 logic, and you're now supposed to use an `X509CertificateLoader` instead of instantiating `X509Certificate2` (would love to know what transpired to lead to the `2` on the end).

I also neglected to remove the options classes related to the deprecated `Permissions` option, so I'm doing that now, and updating unit tests to reflect that.