### PR TITLE
Fix bug preventing a user from initiating a chat

### DIFF
--- a/src/web/src/components/Chat/Chat.jsx
+++ b/src/web/src/components/Chat/Chat.jsx
@@ -217,7 +217,7 @@ class Chat extends Component {
   };
 
   initiateConversation = async (username, message) => {
-    await this.sendMessage(username, message);
+    await chat.send({ username, message });
     await this.fetchConversations();
     this.selectConversation(username);
   };

--- a/src/web/src/components/Chat/SendMessageModal.jsx
+++ b/src/web/src/components/Chat/SendMessageModal.jsx
@@ -1,10 +1,9 @@
 import './Chat.css';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Button, Form, Header, Icon, Input, Modal } from 'semantic-ui-react';
 
-const usernameRef = React.createRef();
-
 const SendMessageModal = ({ initiateConversation, ...rest }) => {
+  const usernameRef = useRef();
   const [open, setOpen] = React.useState(false);
   const [username, setUsername] = React.useState('');
   const [message, setMessage] = React.useState('');


### PR DESCRIPTION
Closes #1777 

The `sendMessage` function was removed from the `Chat` component in #1719 and replaced with `chat.send`, but I only replaced one of the two `sendMessage` calls.