### PR TITLE
Bump dependencies, including Soulseek.NET to 10.0.2

### DIFF
--- a/bin/update-dependencies
+++ b/bin/update-dependencies
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+dotnet tool exec dotnet-outdated-tool -u:prompt

--- a/src/slskd/slskd.csproj
+++ b/src/slskd/slskd.csproj
@@ -47,15 +47,15 @@
     <PackageReference Include="Dapper" Version="2.1.79" />
     <PackageReference Include="FluentFTP" Version="49.0.2" />
     <PackageReference Include="IPAddressRange" Version="6.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.8" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.300">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="10.0.9" />
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
@@ -67,17 +67,17 @@
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="9.0.1" />
     <PackageReference Include="Serilog.Sinks.Http" Version="9.2.1" />
-    <PackageReference Include="Soulseek" Version="10.0.1" />
+    <PackageReference Include="Soulseek" Version="10.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="TagLibSharp" Version="2.3.0" />
     <PackageReference Include="Utility.CommandLine.Arguments" Version="6.0.0" />
     <PackageReference Include="Utility.EnvironmentVariables" Version="1.0.5" />
-    <PackageReference Include="YamlDotNet" Version="18.0.0" />
+    <PackageReference Include="YamlDotNet" Version="18.1.0" />
   </ItemGroup>
 </Project>

--- a/tests/slskd.Tests.Unit/slskd.Tests.Unit.csproj
+++ b/tests/slskd.Tests.Unit/slskd.Tests.Unit.csproj
@@ -5,9 +5,16 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <Target Name="EnforceMoqVersion" BeforeTargets="ResolvePackageAssets">
+    <ItemGroup>
+      <_MoqRef Include="@(PackageReference)" Condition="'%(Identity)' == 'Moq'" />
+    </ItemGroup>
+    <Error Condition="'%(_MoqRef.Version)' != '4.16.1'" Text="Moq is locked to 4.16.1 and must not be upgraded. See https://github.com/moq/moq/issues/1372 for context." />
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
<!--

Per CONTRIBUTING.md:

# Contributing

All contributions must have first been discussed within an Issue or Discussion.  Pull Requests opened without an accompanying Issue are considered to be unsolicited, and unsolicited Pull Requests may be rejected without review and/or converted into an Issue.

## Copyright

By submitting a contribution to this project, you agree to the following:

* You have the legal right to make this contribution and to assign its copyright.
* You irrevocably assign all copyright and related rights in your contribution to the project maintainer(s).
* You grant the project maintainer(s) the right to use, modify, distribute, and relicense your contribution under any license of their choosing.

This application is currently released under the [AGPL 3.0](https://github.com/slskd/slskd/blob/master/LICENSE) license.

## Use of AI in Contributions

If you used AI tools (such as ChatGPT, Copilot, Claude, etc.) to assist with your contribution, you must clearly disclose this in your Pull Request, including:

* Which AI tool(s) you used
* How you used them (e.g., code generation, refactoring suggestions, documentation help)
* Which parts of your contribution were AI-assisted

Contributors are expected to fully understand and take responsibility for all code they submit, regardless of how it was produced.  Contributions made entirely by AI are not welcome and will be rejected.

-->

Also:

* Adds an `update-dependencies` script to make it considerably less painful to review and upgrade packages without Visual Studio
* Pins Moq to 4.16.1 with a build condition due to 4.20 tomfoolery
* Unfortunately does _not_ resolve the SQLite advisory during the build; an SQLite maintainer is still working on bumping the toolchain