### PR TITLE
fix: Set Cache-Control: no-cache on index.html responses

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -63,6 +63,7 @@ namespace slskd
     using Microsoft.Extensions.FileProviders;
     using Microsoft.Extensions.FileProviders.Physical;
     using Microsoft.IdentityModel.Tokens;
+    using Microsoft.Net.Http.Headers;
     using Microsoft.OpenApi;
     using Prometheus;
     using Prometheus.DotNetRuntime;
@@ -1084,6 +1085,16 @@ namespace slskd
                 RequestPath = string.Empty,
                 EnableDirectoryBrowsing = false,
                 EnableDefaultFiles = true,
+                StaticFileOptions =
+                {
+                    OnPrepareResponse = ctx =>
+                    {
+                        if (ctx.File.Name == "index.html")
+                        {
+                            ctx.Context.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue { NoCache = true };
+                        }
+                    },
+                },
             };
 
             if (!OptionsAtStartup.Headless)

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -1089,7 +1089,7 @@ namespace slskd
                 {
                     OnPrepareResponse = ctx =>
                     {
-                        if (ctx.File.Name == "index.html")
+                        if (ctx.File.Name == "index.html" || ctx.File.Name == "default.html")
                         {
                             ctx.Context.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue { NoCache = true };
                         }


### PR DESCRIPTION
Closes https://github.com/slskd/slskd/issues/1785

Verified localhost response headers (`https://localhost:5031/`):

<img width="634" height="150" alt="image" src="https://github.com/user-attachments/assets/55e91389-3068-4aac-85ab-49c5c4d2dd0c" />