### PR TITLE
Remove mouseover color on table rows

### DIFF
--- a/src/web/src/semantic-ui/site/collections/table.overrides
+++ b/src/web/src/semantic-ui/site/collections/table.overrides
@@ -7,6 +7,17 @@
 }
 
 /*--------------
+     Selectable
+---------------*/
+
+.ui.selectable.table tbody tr:hover,
+.ui.table tbody tr td.selectable:hover,
+.ui.selectable.inverted.table tbody tr:hover,
+.ui.inverted.table tbody tr td.selectable:hover {
+  background: transparent !important;
+}
+
+/*--------------
      Negative
 ---------------*/
 


### PR DESCRIPTION
The directory tree was converted to use a `Table` component in #1789, and I decided after the fact that I don't care for the table rows being highlighted on mouseover.  This PR adds an override to disable this behavior.