### PR TITLE
Add pagination to searches and transfers

### DIFF
--- a/src/slskd/Search/API/Controllers/SearchesController.cs
+++ b/src/slskd/Search/API/Controllers/SearchesController.cs
@@ -39,6 +39,7 @@ namespace slskd.Search.API
     using System.Threading.Tasks;
     using Asp.Versioning;
     using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Serilog;
     using SearchQuery = Soulseek.SearchQuery;
@@ -185,17 +186,37 @@ namespace slskd.Search.API
         /// <summary>
         ///     Gets the list of active and completed searches.
         /// </summary>
+        /// <param name="offset">The optional number of searches to skip.</param>
+        /// <param name="limit">The optional maximum number of searches to return.</param>
         /// <returns></returns>
+        /// <response code="400">The offset is less than zero, or the limit is less than one.</response>
         [HttpGet("")]
         [Authorize(Policy = AuthPolicy.Any)]
-        public async Task<IActionResult> GetAll()
+        public async Task<IActionResult> GetAll([FromQuery] int? offset = null, [FromQuery] int? limit = null)
         {
             if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
 
-            var searches = await Searches.ListAsync();
+            if (offset < 0)
+            {
+                return BadRequest("Offset must be greater than or equal to zero");
+            }
+
+            if (limit <= 0)
+            {
+                return BadRequest("Limit must be greater than zero");
+            }
+
+            var paginated = offset.HasValue || limit.HasValue;
+            var searches = paginated
+                ? await Searches.ListAsync(offset ?? 0, limit)
+                : await Searches.ListAsync();
+            var count = paginated ? await Searches.CountAsync() : searches.Count;
+
+            Response.Headers.Append("X-Total-Count", count.ToString());
+
             return Ok(searches);
         }
 

--- a/src/slskd/Search/API/Hubs/SearchHub.cs
+++ b/src/slskd/Search/API/Hubs/SearchHub.cs
@@ -122,8 +122,16 @@ namespace slskd.Search.API
 
         public override async Task OnConnectedAsync()
         {
-            var searches = await Searches.ListAsync();
-            await Clients.Caller.SendAsync(SearchHubMethods.List, searches);
+            var includeInitialListValue = Context.GetHttpContext()?.Request.Query["includeInitialList"].ToString();
+            var includeInitialList = !bool.TryParse(includeInitialListValue, out var parsed) || parsed;
+
+            if (includeInitialList)
+            {
+                var searches = await Searches.ListAsync();
+                await Clients.Caller.SendAsync(SearchHubMethods.List, searches);
+            }
+
+            await base.OnConnectedAsync();
         }
     }
 }

--- a/src/slskd/Search/SearchService.cs
+++ b/src/slskd/Search/SearchService.cs
@@ -57,6 +57,13 @@ namespace slskd.Search
     public interface ISearchService
     {
         /// <summary>
+        ///     Returns the number of searches matching the optional <paramref name="expression"/>.
+        /// </summary>
+        /// <param name="expression">An optional expression used to match searches.</param>
+        /// <returns>The number of matching searches.</returns>
+        Task<int> CountAsync(Expression<Func<Search, bool>> expression = null);
+
+        /// <summary>
         ///     Deletes the specified search.
         /// </summary>
         /// <param name="search">The search to delete.</param>
@@ -78,6 +85,15 @@ namespace slskd.Search
         /// <param name="expression">An optional expression used to match searches.</param>
         /// <returns>The list of searches matching the specified expression, or all searches if no expression is specified.</returns>
         Task<List<Search>> ListAsync(Expression<Func<Search, bool>> expression = null);
+
+        /// <summary>
+        ///     Returns a page of completed and in-progress searches, with responses omitted, in reverse chronological order.
+        /// </summary>
+        /// <param name="offset">The number of searches to skip.</param>
+        /// <param name="limit">The maximum number of searches to return, or null to return all remaining searches.</param>
+        /// <param name="expression">An optional expression used to match searches.</param>
+        /// <returns>The requested page of searches.</returns>
+        Task<List<Search>> ListAsync(int offset, int? limit, Expression<Func<Search, bool>> expression = null);
 
         /// <summary>
         ///     Updates the specified <paramref name="search"/>.
@@ -147,6 +163,22 @@ namespace slskd.Search
         private IHubContext<SearchHub> SearchHub { get; set; }
 
         /// <summary>
+        ///     Returns the number of searches matching the optional <paramref name="expression"/>.
+        /// </summary>
+        /// <param name="expression">An optional expression used to match searches.</param>
+        /// <returns>The number of matching searches.</returns>
+        public async Task<int> CountAsync(Expression<Func<Search, bool>> expression = null)
+        {
+            expression ??= s => true;
+            using var context = ContextFactory.CreateDbContext();
+
+            return await context.Searches
+                .AsNoTracking()
+                .Where(expression)
+                .CountAsync();
+        }
+
+        /// <summary>
         ///     Deletes the specified search.
         /// </summary>
         /// <param name="search">The search to delete.</param>
@@ -213,6 +245,41 @@ namespace slskd.Search
                 .Where(expression)
                 .WithoutResponses()
                 .ToListAsync();
+        }
+
+        /// <summary>
+        ///     Returns a page of completed and in-progress searches, with responses omitted, in reverse chronological order.
+        /// </summary>
+        /// <param name="offset">The number of searches to skip.</param>
+        /// <param name="limit">The maximum number of searches to return, or null to return all remaining searches.</param>
+        /// <param name="expression">An optional expression used to match searches.</param>
+        /// <returns>The requested page of searches.</returns>
+        public async Task<List<Search>> ListAsync(int offset, int? limit, Expression<Func<Search, bool>> expression = null)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(offset);
+
+            if (limit <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be greater than zero");
+            }
+
+            expression ??= s => true;
+            using var context = ContextFactory.CreateDbContext();
+
+            var selector = context.Searches
+                .AsNoTracking()
+                .Where(expression)
+                .WithoutResponses()
+                .OrderByDescending(search => search.StartedAt)
+                .ThenByDescending(search => search.Id)
+                .Skip(offset);
+
+            if (limit.HasValue)
+            {
+                selector = selector.Take(limit.Value);
+            }
+
+            return await selector.ToListAsync();
         }
 
         /// <summary>

--- a/src/slskd/Transfers/API/Controllers/TransfersController.cs
+++ b/src/slskd/Transfers/API/Controllers/TransfersController.cs
@@ -440,30 +440,35 @@ namespace slskd.Transfers.API
         /// <summary>
         ///     Gets all downloads.
         /// </summary>
+        /// <param name="includeRemoved">A value indicating whether to include removed downloads.</param>
+        /// <param name="offset">The optional number of user groups to skip.</param>
+        /// <param name="limit">The optional maximum number of user groups to return.</param>
         /// <returns></returns>
+        /// <response code="400">The offset is less than zero, or the limit is less than one.</response>
         /// <response code="200">The request completed successfully.</response>
         [HttpGet("downloads")]
         [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(200)]
-        public IActionResult GetDownloadsAsync([FromQuery] bool includeRemoved = false)
+        public IActionResult GetDownloadsAsync([FromQuery] bool includeRemoved = false, [FromQuery] int? offset = null, [FromQuery] int? limit = null)
         {
             if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
 
-            var downloads = Transfers.Downloads.List(includeRemoved: includeRemoved);
+            var paginationError = ValidatePagination(offset, limit);
 
-            var response = downloads.GroupBy(t => t.Username).Select(grouping => new UserResponse()
+            if (paginationError is not null)
             {
-                Username = grouping.Key,
-                Directories = grouping.GroupBy(g => g.Filename.DirectoryName()).Select(d => new DirectoryResponse()
-                {
-                    Directory = d.Key,
-                    FileCount = d.Count(),
-                    Files = d.ToList(),
-                }),
-            });
+                return paginationError;
+            }
+
+            var paginated = offset.HasValue || limit.HasValue;
+            var (response, count) = paginated
+                ? GetTransferGroups(TransferDirection.Download, includeRemoved, offset ?? 0, limit)
+                : GetAllTransferGroups(TransferDirection.Download, includeRemoved);
+
+            Response.Headers.Append("X-Total-Count", count.ToString());
 
             return Ok(response);
         }
@@ -620,32 +625,35 @@ namespace slskd.Transfers.API
         /// <summary>
         ///     Gets all uploads.
         /// </summary>
+        /// <param name="includeRemoved">A value indicating whether to include removed uploads.</param>
+        /// <param name="offset">The optional number of user groups to skip.</param>
+        /// <param name="limit">The optional maximum number of user groups to return.</param>
         /// <returns></returns>
+        /// <response code="400">The offset is less than zero, or the limit is less than one.</response>
         /// <response code="200">The request completed successfully.</response>
         [HttpGet("uploads")]
         [Authorize(Policy = AuthPolicy.Any)]
         [ProducesResponseType(200)]
-        public IActionResult GetUploads([FromQuery] bool includeRemoved = false)
+        public IActionResult GetUploads([FromQuery] bool includeRemoved = false, [FromQuery] int? offset = null, [FromQuery] int? limit = null)
         {
             if (Program.IsRelayAgent)
             {
                 return Forbid();
             }
 
-            // todo: refactor this so it doesn't return the world. start and end time params
-            // should be required.  consider pagination.
-            var uploads = Transfers.Uploads.List(t => true, includeRemoved: includeRemoved);
+            var paginationError = ValidatePagination(offset, limit);
 
-            var response = uploads.GroupBy(t => t.Username).Select(grouping => new UserResponse()
+            if (paginationError is not null)
             {
-                Username = grouping.Key,
-                Directories = grouping.GroupBy(g => g.Filename.DirectoryName()).Select(d => new DirectoryResponse()
-                {
-                    Directory = d.Key,
-                    FileCount = d.Count(),
-                    Files = d.ToList(),
-                }),
-            });
+                return paginationError;
+            }
+
+            var paginated = offset.HasValue || limit.HasValue;
+            var (response, count) = paginated
+                ? GetTransferGroups(TransferDirection.Upload, includeRemoved, offset ?? 0, limit)
+                : GetAllTransferGroups(TransferDirection.Upload, includeRemoved);
+
+            Response.Headers.Append("X-Total-Count", count.ToString());
 
             return Ok(response);
         }
@@ -717,6 +725,83 @@ namespace slskd.Transfers.API
             }
 
             return Ok(upload);
+        }
+
+        private (IEnumerable<UserResponse> Response, int Count) GetAllTransferGroups(TransferDirection direction, bool includeRemoved)
+        {
+            var transfers = direction == TransferDirection.Download
+                ? Transfers.Downloads.List(includeRemoved: includeRemoved)
+                : Transfers.Uploads.List(t => true, includeRemoved: includeRemoved);
+
+            return (GroupTransfers(transfers), transfers.Select(transfer => transfer.Username).Distinct().Count());
+        }
+
+        private (IEnumerable<UserResponse> Response, int Count) GetTransferGroups(TransferDirection direction, bool includeRemoved, int offset, int? limit)
+        {
+            var page = Transfers.Query(transfers =>
+            {
+                var filtered = transfers
+                    .Where(transfer => transfer.Direction == direction)
+                    .Where(transfer => !transfer.Removed || includeRemoved);
+                var groups = filtered
+                    .GroupBy(transfer => transfer.Username)
+                    .Select(group => new
+                    {
+                        Username = group.Key,
+                        LastRequestedAt = group.Max(transfer => transfer.RequestedAt),
+                    });
+                var count = groups.Count();
+                var ordered = groups
+                    .OrderByDescending(group => group.LastRequestedAt)
+                    .ThenBy(group => group.Username)
+                    .Skip(offset);
+
+                if (limit.HasValue)
+                {
+                    ordered = ordered.Take(limit.Value);
+                }
+
+                var usernames = ordered.Select(group => group.Username).ToList();
+                var pageTransfers = filtered
+                    .Where(transfer => usernames.Contains(transfer.Username))
+                    .ToList();
+
+                return (Count: count, Usernames: usernames, Transfers: pageTransfers);
+            });
+
+            var transfersByUsername = page.Transfers.ToLookup(transfer => transfer.Username);
+            var response = page.Usernames.Select(username => GroupTransfers(transfersByUsername[username]).Single());
+
+            return (response, page.Count);
+        }
+
+        private IEnumerable<UserResponse> GroupTransfers(IEnumerable<slskd.Transfers.Transfer> transfers)
+        {
+            return transfers.GroupBy(transfer => transfer.Username).Select(grouping => new UserResponse()
+            {
+                Username = grouping.Key,
+                Directories = grouping.GroupBy(transfer => transfer.Filename.DirectoryName()).Select(directory => new DirectoryResponse()
+                {
+                    Directory = directory.Key,
+                    FileCount = directory.Count(),
+                    Files = directory.ToList(),
+                }),
+            });
+        }
+
+        private BadRequestObjectResult ValidatePagination(int? offset, int? limit)
+        {
+            if (offset < 0)
+            {
+                return BadRequest("Offset must be greater than or equal to zero");
+            }
+
+            if (limit <= 0)
+            {
+                return BadRequest("Limit must be greater than zero");
+            }
+
+            return null;
         }
     }
 }

--- a/src/web/src/components/Search/Search.css
+++ b/src/web/src/components/Search/Search.css
@@ -110,6 +110,12 @@
   width: 5px !important;
 }
 
+.search-pagination {
+  display: flex;
+  justify-content: center;
+  margin: 1em 0;
+}
+
 .search-detail-header-segment {
   margin-top: 15px !important;
   height: 78px !important;

--- a/src/web/src/components/Search/Searches.jsx
+++ b/src/web/src/components/Search/Searches.jsx
@@ -9,23 +9,65 @@ import SearchList from './List/SearchList';
 import React, { useEffect, useRef, useState } from 'react';
 import { useHistory, useParams, useRouteMatch } from 'react-router-dom';
 import { toast } from 'react-toastify';
-import { Button, Icon, Input, Segment } from 'semantic-ui-react';
+import { Button, Icon, Input, Pagination, Segment } from 'semantic-ui-react';
 import { v4 as uuidv4 } from 'uuid';
+
+const PER_PAGE = 100;
 
 const Searches = ({ server } = {}) => {
   const [connecting, setConnecting] = useState(true);
   const [error, setError] = useState(undefined);
+  const [loading, setLoading] = useState(false);
+  const [loadingSearch, setLoadingSearch] = useState(false);
+  const [page, setPage] = useState(1);
   const [searches, setSearches] = useState({});
+  const [selectedSearch, setSelectedSearch] = useState(undefined);
+  const [totalCount, setTotalCount] = useState(0);
 
   const [removing, setRemoving] = useState(false);
   const [stopping, setStopping] = useState(false);
   const [creating, setCreating] = useState(false);
 
   const inputRef = useRef();
+  const pageRef = useRef(page);
 
   const { id: searchId } = useParams();
   const history = useHistory();
   const match = useRouteMatch();
+  const listUrl = match.url.replace(`/${searchId}`, '');
+  const totalPages = Math.ceil(totalCount / PER_PAGE);
+
+  const fetchPage = async (requestedPage = pageRef.current) => {
+    try {
+      setLoading(true);
+
+      const { searches: items, totalCount: count } = await library.getAll({
+        limit: PER_PAGE,
+        offset: (requestedPage - 1) * PER_PAGE,
+      });
+      const lastPage = Math.max(1, Math.ceil(count / PER_PAGE));
+
+      setTotalCount(count);
+
+      if (requestedPage > lastPage) {
+        setPage(lastPage);
+        return;
+      }
+
+      setSearches(
+        items.reduce((accumulator, search) => {
+          accumulator[search.id] = search;
+          return accumulator;
+        }, {}),
+      );
+      setError(undefined);
+    } catch (fetchError) {
+      console.error(fetchError);
+      setError(fetchError);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const onConnecting = () => {
     setConnecting(true);
@@ -33,7 +75,6 @@ const Searches = ({ server } = {}) => {
 
   const onConnected = () => {
     setConnecting(false);
-    setError(undefined);
   };
 
   const onConnectionError = (connectionError) => {
@@ -41,45 +82,48 @@ const Searches = ({ server } = {}) => {
     setError(connectionError);
   };
 
-  const onUpdate = (update) => {
-    setSearches(update);
-    onConnected();
-  };
-
   useEffect(() => {
     onConnecting();
 
-    const searchHub = createSearchHubConnection();
+    const searchHub = createSearchHubConnection({
+      includeInitialList: false,
+    });
 
-    searchHub.on('list', (searchesEvent) => {
-      onUpdate(
-        searchesEvent.reduce((accumulator, search) => {
-          accumulator[search.id] = search;
-          return accumulator;
-        }, {}),
-      );
-      onConnected();
+    searchHub.on('list', () => {
+      fetchPage();
     });
 
     searchHub.on('update', (search) => {
-      onUpdate((old) => ({ ...old, [search.id]: search }));
+      setSearches((old) =>
+        old[search.id] ? { ...old, [search.id]: search } : old,
+      );
+      setSelectedSearch((old) => (old?.id === search.id ? search : old));
     });
 
     searchHub.on('delete', (search) => {
-      onUpdate((old) => {
-        delete old[search.id];
-        return { ...old };
+      setSelectedSearch((old) => {
+        if (old?.id === search.id) {
+          history.replace(listUrl);
+          return undefined;
+        }
+
+        return old;
       });
+
+      fetchPage();
     });
 
-    searchHub.on('create', (search) => {
-      onUpdate((old) => ({ ...old, [search.id]: search }));
+    searchHub.on('create', () => {
+      fetchPage();
     });
 
     searchHub.onreconnecting((connectionError) =>
       onConnectionError(connectionError?.message ?? 'Disconnected'),
     );
-    searchHub.onreconnected(() => onConnected());
+    searchHub.onreconnected(async () => {
+      await fetchPage();
+      onConnected();
+    });
     searchHub.onclose((connectionError) =>
       onConnectionError(connectionError?.message ?? 'Disconnected'),
     );
@@ -88,6 +132,8 @@ const Searches = ({ server } = {}) => {
       try {
         onConnecting();
         await searchHub.start();
+        await fetchPage();
+        onConnected();
       } catch (connectionError) {
         toast.error(connectionError?.message ?? 'Failed to connect');
         onConnectionError(connectionError?.message ?? 'Failed to connect');
@@ -100,6 +146,58 @@ const Searches = ({ server } = {}) => {
       searchHub.stop();
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    pageRef.current = page;
+
+    if (!connecting) {
+      fetchPage(page);
+    }
+  }, [page]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchSearch = async () => {
+      if (!searchId || searches[searchId]) {
+        return;
+      }
+
+      try {
+        setLoadingSearch(true);
+        const search = await library.getStatus({ id: searchId });
+
+        if (!cancelled) {
+          setSelectedSearch(search);
+        }
+      } catch (fetchError) {
+        if (!cancelled) {
+          toast.error(
+            fetchError?.response?.data ??
+              fetchError?.message ??
+              'Search not found',
+          );
+          history.replace(listUrl);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingSearch(false);
+        }
+      }
+    };
+
+    if (!searchId) {
+      setSelectedSearch(undefined);
+    } else if (searches[searchId]) {
+      setSelectedSearch(searches[searchId]);
+    } else if (selectedSearch?.id !== searchId) {
+      fetchSearch();
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [searchId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // create a new search, and optionally navigate to it to display the details
   // we do this if the user clicks the search icon, or repeats an existing search
@@ -119,10 +217,13 @@ const Searches = ({ server } = {}) => {
         // we are probably repeating an existing search; the input isn't mounted.  no-op.
       }
 
+      pageRef.current = 1;
+      setPage(1);
+      await fetchPage(1);
       setCreating(false);
 
       if (navigate) {
-        history.push(`${match.url.replace(`/${searchId}`, '')}/${id}`);
+        history.push(`${listUrl}/${id}`);
       }
     } catch (createError) {
       console.error(createError);
@@ -139,15 +240,20 @@ const Searches = ({ server } = {}) => {
       setRemoving(true);
 
       await library.remove({ id: search.id });
-      setSearches((old) => {
-        delete old[search.id];
-        return { ...old };
-      });
+
+      if (search.id === searchId) {
+        setSelectedSearch(undefined);
+        history.replace(listUrl);
+      }
+
+      await fetchPage();
 
       setRemoving(false);
-    } catch (error_) {
-      console.error(error_);
-      toast.error(error?.response?.data ?? error?.message ?? error);
+    } catch (removeError) {
+      console.error(removeError);
+      toast.error(
+        removeError?.response?.data ?? removeError?.message ?? removeError,
+      );
       setRemoving(false);
     }
   };
@@ -169,7 +275,7 @@ const Searches = ({ server } = {}) => {
     }
   };
 
-  if (connecting) {
+  if (connecting || (searchId && loadingSearch)) {
     return <LoaderSegment />;
   }
 
@@ -180,7 +286,9 @@ const Searches = ({ server } = {}) => {
   // if searchId is not null, there's an id in the route.
   // display the details for the search, if there is one
   if (searchId) {
-    if (searches[searchId]) {
+    const search = searches[searchId] ?? selectedSearch;
+
+    if (search?.id === searchId) {
       return (
         <SearchDetail
           creating={creating}
@@ -189,15 +297,13 @@ const Searches = ({ server } = {}) => {
           onRemove={remove}
           onStop={stop}
           removing={removing}
-          search={searches[searchId]}
+          search={search}
           stopping={stopping}
         />
       );
     }
 
-    // if the searchId doesn't match a search we know about, chop
-    // the id off of the url and force navigation back to the list
-    history.replace(match.url.replace(`/${searchId}`, ''));
+    return <LoaderSegment />;
   }
 
   inputRef?.current?.inputRef?.current.focus();
@@ -249,7 +355,18 @@ const Searches = ({ server } = {}) => {
           size="big"
         />
       </Segment>
-      {Object.keys(searches).length === 0 ? (
+      {totalPages > 1 && (
+        <div className="search-pagination">
+          <Pagination
+            activePage={page}
+            onPageChange={(_event, data) => setPage(data.activePage)}
+            totalPages={totalPages}
+          />
+        </div>
+      )}
+      {loading ? (
+        <LoaderSegment />
+      ) : Object.keys(searches).length === 0 ? (
         <PlaceholderSegment
           caption="No searches to display"
           icon="search"

--- a/src/web/src/components/Search/Searches.test.jsx
+++ b/src/web/src/components/Search/Searches.test.jsx
@@ -1,0 +1,184 @@
+/* eslint-disable n/global-require, react/prop-types */
+
+import { createSearchHubConnection } from '../../lib/hubFactory';
+import * as searchesLibrary from '../../lib/searches';
+import Searches from './Searches';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { MemoryRouter, Route } from 'react-router-dom';
+
+jest.mock('../../lib/hubFactory', () => ({
+  createSearchHubConnection: jest.fn(),
+}));
+
+jest.mock('../../lib/searches', () => ({
+  create: jest.fn(),
+  getAll: jest.fn(),
+  getStatus: jest.fn(),
+  remove: jest.fn(),
+  stop: jest.fn(),
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: { error: jest.fn() },
+}));
+
+jest.mock('uuid', () => ({ v4: () => 'new-search-id' }));
+
+jest.mock('semantic-ui-react', () => {
+  const Wrapper = ({ children }) => <div>{children}</div>;
+  const Input = require('react').forwardRef((_props, ref) => (
+    <input ref={ref} />
+  ));
+
+  return {
+    Button: Wrapper,
+    Icon: Wrapper,
+    Input,
+    Pagination: ({ activePage, onPageChange }) => (
+      <button
+        id="next-page"
+        onClick={() => onPageChange({}, { activePage: activePage + 1 })}
+        type="button"
+      >
+        Next
+      </button>
+    ),
+    Segment: Wrapper,
+  };
+});
+
+jest.mock('../Shared/ErrorSegment', () => ({ caption }) => (
+  <div>{`Error: ${caption}`}</div>
+));
+jest.mock('../Shared/LoaderSegment', () => () => <div>Loading</div>);
+jest.mock('../Shared/PlaceholderSegment', () => ({ caption }) => (
+  <div>{caption}</div>
+));
+jest.mock('./Detail/SearchDetail', () => ({ search }) => (
+  <div id="search-detail">{`${search.id}:${search.searchText}`}</div>
+));
+jest.mock('./List/SearchList', () => ({ searches }) => (
+  <div id="search-list">{Object.keys(searches).join(',')}</div>
+));
+
+const flush = async () => {
+  await act(async () => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  });
+};
+
+describe('Searches pagination', () => {
+  let container;
+  let handlers;
+  let hub;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+    handlers = {};
+    hub = {
+      on: jest.fn((name, handler) => {
+        handlers[name] = handler;
+      }),
+      onclose: jest.fn(),
+      onreconnected: jest.fn(),
+      onreconnecting: jest.fn(),
+      start: jest.fn().mockResolvedValue(undefined),
+      stop: jest.fn().mockResolvedValue(undefined),
+    };
+    createSearchHubConnection.mockReturnValue(hub);
+  });
+
+  afterEach(() => {
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container);
+    });
+    container.remove();
+    jest.clearAllMocks();
+  });
+
+  it('loads pages and clamps the page after the total count shrinks', async () => {
+    expect.hasAssertions();
+    searchesLibrary.getAll.mockResolvedValue({
+      searches: [{ id: 'page', searchText: 'Page' }],
+      totalCount: 201,
+    });
+
+    act(() => {
+      ReactDOM.render(
+        <MemoryRouter initialEntries={['/searches']}>
+          <Route path="/searches/:id?">
+            <Searches server={{ isConnected: true }} />
+          </Route>
+        </MemoryRouter>,
+        container,
+      );
+    });
+    await flush();
+
+    act(() => container.querySelector('#next-page').click());
+    await flush();
+
+    expect(searchesLibrary.getAll).toHaveBeenCalledWith({
+      limit: 100,
+      offset: 100,
+    });
+    expect(container.querySelector('#search-list').textContent).toContain(
+      'page',
+    );
+
+    searchesLibrary.getAll.mockResolvedValue({
+      searches: [{ id: 'remaining', searchText: 'Remaining' }],
+      totalCount: 1,
+    });
+    await act(async () => handlers.delete({ id: 'unrelated' }));
+    await flush();
+
+    expect(searchesLibrary.getAll).toHaveBeenLastCalledWith({
+      limit: 100,
+      offset: 0,
+    });
+    expect(container.querySelector('#search-list').textContent).toBe(
+      'remaining',
+    );
+  });
+
+  it('loads a direct detail URL and applies live updates', async () => {
+    expect.hasAssertions();
+    searchesLibrary.getAll.mockResolvedValue({ searches: [], totalCount: 0 });
+    searchesLibrary.getStatus.mockResolvedValue({
+      id: 'old-search',
+      searchText: 'Original',
+    });
+
+    act(() => {
+      ReactDOM.render(
+        <MemoryRouter initialEntries={['/searches/old-search']}>
+          <Route path="/searches/:id?">
+            <Searches server={{ isConnected: true }} />
+          </Route>
+        </MemoryRouter>,
+        container,
+      );
+    });
+    await flush();
+    await flush();
+
+    expect(searchesLibrary.getStatus).toHaveBeenCalledWith({
+      id: 'old-search',
+    });
+    expect(container.querySelector('#search-detail').textContent).toContain(
+      'Original',
+    );
+
+    act(() => handlers.update({ id: 'old-search', searchText: 'Updated' }));
+
+    expect(container.querySelector('#search-detail').textContent).toContain(
+      'Updated',
+    );
+  });
+});

--- a/src/web/src/components/Transfers/Transfers.css
+++ b/src/web/src/components/Transfers/Transfers.css
@@ -56,3 +56,9 @@
   display: inline;
   margin-left: auto;
 }
+
+.transfers-pagination {
+  display: flex;
+  justify-content: center;
+  margin: 1em 0;
+}

--- a/src/web/src/components/Transfers/Transfers.jsx
+++ b/src/web/src/components/Transfers/Transfers.jsx
@@ -5,10 +5,86 @@ import TransferGroup from './TransferGroup';
 import TransfersHeader from './TransfersHeader';
 import React, { useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-toastify';
+import { Pagination } from 'semantic-ui-react';
+
+const PER_PAGE = 100;
+
+const flattenTransfers = (transfers) =>
+  transfers.reduce(
+    (users, user) =>
+      users.concat(
+        user.directories.reduce(
+          (directories, directory) => directories.concat(directory.files),
+          [],
+        ),
+      ),
+    [],
+  );
+
+const getRetryableFiles = ({ files, retryOption }) => {
+  switch (retryOption) {
+    case 'Errored':
+      return files.filter((file) =>
+        [
+          'Completed, TimedOut',
+          'Completed, Errored',
+          'Completed, Rejected',
+        ].includes(file.state),
+      );
+    case 'Cancelled':
+      return files.filter((file) => file.state === 'Completed, Cancelled');
+    case 'All':
+      return files.filter((file) =>
+        transfersLibrary.isStateRetryable(file.state),
+      );
+    default:
+      return [];
+  }
+};
+
+const getCancellableFiles = ({ cancelOption, files }) => {
+  switch (cancelOption) {
+    case 'All':
+      return files.filter((file) =>
+        transfersLibrary.isStateCancellable(file.state),
+      );
+    case 'Queued':
+      return files.filter((file) =>
+        ['Queued, Locally', 'Queued, Remotely'].includes(file.state),
+      );
+    case 'In Progress':
+      return files.filter((file) => file.state === 'InProgress');
+    default:
+      return [];
+  }
+};
+
+const getRemovableFiles = ({ files, removeOption }) => {
+  switch (removeOption) {
+    case 'Succeeded':
+      return files.filter((file) => file.state === 'Completed, Succeeded');
+    case 'Errored':
+      return files.filter((file) =>
+        [
+          'Completed, TimedOut',
+          'Completed, Errored',
+          'Completed, Rejected',
+        ].includes(file.state),
+      );
+    case 'Cancelled':
+      return files.filter((file) => file.state === 'Completed, Cancelled');
+    case 'Completed':
+      return files.filter((file) => file.state.includes('Completed'));
+    default:
+      return [];
+  }
+};
 
 const Transfers = ({ direction, server }) => {
   const [connecting, setConnecting] = useState(true);
+  const [page, setPage] = useState(1);
   const [transfers, setTransfers] = useState([]);
+  const [totalCount, setTotalCount] = useState(0);
 
   const [retrying, setRetrying] = useState(false);
   const [cancelling, setCancelling] = useState(false);
@@ -16,8 +92,22 @@ const Transfers = ({ direction, server }) => {
 
   const fetch = async () => {
     try {
-      const response = await transfersLibrary.getAll({ direction });
-      setTransfers(response);
+      const { totalCount: count, transfers: items } =
+        await transfersLibrary.getAll({
+          direction,
+          limit: PER_PAGE,
+          offset: (page - 1) * PER_PAGE,
+        });
+      const lastPage = Math.max(1, Math.ceil(count / PER_PAGE));
+
+      setTotalCount(count);
+
+      if (page > lastPage) {
+        setPage(lastPage);
+        return;
+      }
+
+      setTransfers(items);
     } catch (error) {
       console.error(error);
       toast.error(error?.response?.data ?? error?.message ?? error);
@@ -38,7 +128,7 @@ const Transfers = ({ direction, server }) => {
     return () => {
       clearInterval(interval);
     };
-  }, [direction]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [direction, page]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useMemo(() => {
     // this is used to prevent weird update issues if switching
@@ -48,7 +138,15 @@ const Transfers = ({ direction, server }) => {
     // before the connecting animation shows.  this memo fires the instant
     // the direction prop changes, preventing this flash.
     setConnecting(true);
+    setPage(1);
   }, [direction]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const getAllFiles = async () => {
+    const response = await transfersLibrary.getAll({ direction });
+    return flattenTransfers(response.transfers).filter(
+      (file) => file.direction.toLowerCase() === direction,
+    );
+  };
 
   const retry = async ({ file, suppressStateChange = false }) => {
     const { filename, size, username } = file;
@@ -75,6 +173,20 @@ const Transfers = ({ direction, server }) => {
       ),
     );
     setRetrying(false);
+    await fetch();
+  };
+
+  const retryAllMatching = async ({ retryOption }) => {
+    setRetrying(true);
+
+    try {
+      const files = await getAllFiles();
+      await retryAll(getRetryableFiles({ files, retryOption }));
+    } catch (error) {
+      console.error(error);
+      toast.error(error?.response?.data ?? error?.message ?? error);
+      setRetrying(false);
+    }
   };
 
   const cancel = async ({ file, suppressStateChange = false }) => {
@@ -99,6 +211,20 @@ const Transfers = ({ direction, server }) => {
       ),
     );
     setCancelling(false);
+    await fetch();
+  };
+
+  const cancelAllMatching = async ({ cancelOption }) => {
+    setCancelling(true);
+
+    try {
+      const files = await getAllFiles();
+      await cancelAll(getCancellableFiles({ cancelOption, files }));
+    } catch (error) {
+      console.error(error);
+      toast.error(error?.response?.data ?? error?.message ?? error);
+      setCancelling(false);
+    }
   };
 
   const remove = async ({ file, suppressStateChange = false }) => {
@@ -123,6 +249,20 @@ const Transfers = ({ direction, server }) => {
       ),
     );
     setRemoving(false);
+    await fetch();
+  };
+
+  const removeAllMatching = async ({ removeOption }) => {
+    setRemoving(true);
+
+    try {
+      const files = await getAllFiles();
+      await removeAll(getRemovableFiles({ files, removeOption }));
+    } catch (error) {
+      console.error(error);
+      toast.error(error?.response?.data ?? error?.message ?? error);
+      setRemoving(false);
+    }
   };
 
   if (connecting) {
@@ -134,14 +274,23 @@ const Transfers = ({ direction, server }) => {
       <TransfersHeader
         cancelling={cancelling}
         direction={direction}
-        onCancelAll={cancelAll}
-        onRemoveAll={removeAll}
-        onRetryAll={retryAll}
+        onCancelAll={cancelAllMatching}
+        onRemoveAll={removeAllMatching}
+        onRetryAll={retryAllMatching}
         removing={removing}
         retrying={retrying}
         server={server}
         transfers={transfers}
       />
+      {totalCount > PER_PAGE && (
+        <div className="transfers-pagination">
+          <Pagination
+            activePage={page}
+            onPageChange={(_event, data) => setPage(data.activePage)}
+            totalPages={Math.ceil(totalCount / PER_PAGE)}
+          />
+        </div>
+      )}
       {transfers.length === 0 ? (
         <PlaceholderSegment
           caption={`No ${direction}s to display`}

--- a/src/web/src/components/Transfers/Transfers.test.jsx
+++ b/src/web/src/components/Transfers/Transfers.test.jsx
@@ -1,0 +1,131 @@
+/* eslint-disable react/prop-types */
+
+import * as transfersLibrary from '../../lib/transfers';
+import Transfers from './Transfers';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+
+jest.mock('../../lib/transfers', () => ({
+  cancel: jest.fn().mockResolvedValue(undefined),
+  download: jest.fn().mockResolvedValue(undefined),
+  getAll: jest.fn(),
+  isStateCancellable: (state) => state === 'Queued, Locally',
+  isStateRemovable: (state) => state.includes('Completed'),
+  isStateRetryable: (state) => state.includes('Completed'),
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: { error: jest.fn() },
+}));
+
+jest.mock('semantic-ui-react', () => ({
+  Pagination: () => <div>Pagination</div>,
+}));
+
+jest.mock('../Shared', () => ({
+  LoaderSegment: () => <div>Loading</div>,
+  PlaceholderSegment: ({ caption }) => <div>{caption}</div>,
+}));
+
+jest.mock('./TransferGroup', () => ({ user }) => <div>{user.username}</div>);
+
+jest.mock('./TransfersHeader', () => ({ onRemoveAll }) => (
+  <button
+    id="remove-all"
+    onClick={() => onRemoveAll({ removeOption: 'Completed' })}
+    type="button"
+  >
+    Remove all
+  </button>
+));
+
+const group = (username, id, state) => ({
+  directories: [
+    {
+      directory: 'music',
+      files: [
+        {
+          direction: 'Download',
+          filename: `${username}.mp3`,
+          id,
+          state,
+          username,
+        },
+      ],
+    },
+  ],
+  username,
+});
+
+const flush = async () => {
+  await act(async () => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  });
+};
+
+describe('Transfers pagination', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+    transfersLibrary.getAll.mockImplementation(({ limit }) =>
+      Promise.resolve(
+        limit
+          ? {
+              totalCount: 101,
+              transfers: [
+                group('visible', 'visible-id', 'Completed, Succeeded'),
+              ],
+            }
+          : {
+              totalCount: 2,
+              transfers: [
+                group('visible', 'visible-id', 'Completed, Succeeded'),
+                group('hidden', 'hidden-id', 'Completed, Cancelled'),
+              ],
+            },
+      ),
+    );
+  });
+
+  afterEach(() => {
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container);
+    });
+    container.remove();
+    jest.clearAllMocks();
+  });
+
+  it('uses an unpaged request for full-scope bulk actions', async () => {
+    expect.hasAssertions();
+    act(() => {
+      ReactDOM.render(
+        <Transfers
+          direction="download"
+          server={{ isConnected: true }}
+        />,
+        container,
+      );
+    });
+    await flush();
+
+    act(() => container.querySelector('#remove-all').click());
+    await flush();
+    await flush();
+
+    expect(transfersLibrary.getAll).toHaveBeenCalledWith({
+      direction: 'download',
+    });
+    expect(transfersLibrary.cancel).toHaveBeenCalledTimes(2);
+    expect(transfersLibrary.cancel).toHaveBeenCalledWith({
+      direction: 'download',
+      id: 'hidden-id',
+      remove: true,
+      username: 'hidden',
+    });
+  });
+});

--- a/src/web/src/components/Transfers/TransfersHeader.jsx
+++ b/src/web/src/components/Transfers/TransfersHeader.jsx
@@ -1,63 +1,7 @@
-import { isStateCancellable, isStateRetryable } from '../../lib/transfers';
 import { Div, Nbsp } from '../Shared';
 import ShrinkableDropdownButton from '../Shared/ShrinkableDropdownButton';
 import React, { useMemo, useState } from 'react';
 import { Icon, Segment } from 'semantic-ui-react';
-
-const getRetryableFiles = ({ files, retryOption }) => {
-  switch (retryOption) {
-    case 'Errored':
-      return files.filter((file) =>
-        [
-          'Completed, TimedOut',
-          'Completed, Errored',
-          'Completed, Rejected',
-        ].includes(file.state),
-      );
-    case 'Cancelled':
-      return files.filter((file) => file.state === 'Completed, Cancelled');
-    case 'All':
-      return files.filter((file) => isStateRetryable(file.state));
-    default:
-      return [];
-  }
-};
-
-const getCancellableFiles = ({ cancelOption, files }) => {
-  switch (cancelOption) {
-    case 'All':
-      return files.filter((file) => isStateCancellable(file.state));
-    case 'Queued':
-      return files.filter((file) =>
-        ['Queued, Locally', 'Queued, Remotely'].includes(file.state),
-      );
-    case 'In Progress':
-      return files.filter((file) => file.state === 'InProgress');
-    default:
-      return [];
-  }
-};
-
-const getRemovableFiles = ({ files, removeOption }) => {
-  switch (removeOption) {
-    case 'Succeeded':
-      return files.filter((file) => file.state === 'Completed, Succeeded');
-    case 'Errored':
-      return files.filter((file) =>
-        [
-          'Completed, TimedOut',
-          'Completed, Errored',
-          'Completed, Rejected',
-        ].includes(file.state),
-      );
-    case 'Cancelled':
-      return files.filter((file) => file.state === 'Completed, Cancelled');
-    case 'Completed':
-      return files.filter((file) => file.state.includes('Completed'));
-    default:
-      return [];
-  }
-};
 
 const TransfersHeader = ({
   cancelling = false,
@@ -115,7 +59,7 @@ const TransfersHeader = ({
           loading={retrying}
           mediaQuery="(max-width: 715px)"
           onChange={(_, data) => setRetryOption(data.value)}
-          onClick={() => onRetryAll(getRetryableFiles({ files, retryOption }))}
+          onClick={() => onRetryAll({ retryOption })}
           options={[
             { key: 'errored', text: 'Errored', value: 'Errored' },
             { key: 'cancelled', text: 'Cancelled', value: 'Cancelled' },
@@ -132,9 +76,7 @@ const TransfersHeader = ({
           loading={cancelling}
           mediaQuery="(max-width: 715px)"
           onChange={(_, data) => setCancelOption(data.value)}
-          onClick={() =>
-            onCancelAll(getCancellableFiles({ cancelOption, files }))
-          }
+          onClick={() => onCancelAll({ cancelOption })}
           options={[
             { key: 'all', text: 'All', value: 'All' },
             { key: 'queued', text: 'Queued', value: 'Queued' },
@@ -150,9 +92,7 @@ const TransfersHeader = ({
           loading={removing}
           mediaQuery="(max-width: 715px)"
           onChange={(_, data) => setRemoveOption(data.value)}
-          onClick={() =>
-            onRemoveAll(getRemovableFiles({ files, removeOption }))
-          }
+          onClick={() => onRemoveAll({ removeOption })}
           options={[
             { key: 'succeeded', text: 'Succeeded', value: 'Succeeded' },
             { key: 'errored', text: 'Errored', value: 'Errored' },

--- a/src/web/src/lib/hubFactory.js
+++ b/src/web/src/lib/hubFactory.js
@@ -25,8 +25,14 @@ export const createApplicationHubConnection = () =>
 export const createLogsHubConnection = () =>
   createHubConnection({ url: `${hubBaseUrl}/logs` });
 
-export const createSearchHubConnection = () =>
-  createHubConnection({ url: `${hubBaseUrl}/search` });
+export const createSearchHubConnection = ({ includeInitialList } = {}) => {
+  const query =
+    includeInitialList === undefined
+      ? ''
+      : `?includeInitialList=${includeInitialList}`;
+
+  return createHubConnection({ url: `${hubBaseUrl}/search${query}` });
+};
 
 export const createMetricsHubConnection = () =>
   createHubConnection({ url: `${hubBaseUrl}/metrics` });

--- a/src/web/src/lib/searches.js
+++ b/src/web/src/lib/searches.js
@@ -1,7 +1,23 @@
 import api from './api';
 
-export const getAll = async () => {
-  return (await api.get('/searches')).data;
+export const getAll = async ({ limit, offset } = {}) => {
+  const parameters = new URLSearchParams();
+
+  if (offset !== undefined) parameters.append('offset', offset);
+  if (limit !== undefined) parameters.append('limit', limit);
+
+  const query = parameters.toString();
+  const response = await api.get(`/searches${query ? `?${query}` : ''}`);
+  const searches = response.data;
+  const parsedTotalCount = Number.parseInt(
+    response.headers?.['x-total-count'],
+    10,
+  );
+  const totalCount = Number.isNaN(parsedTotalCount)
+    ? searches.length
+    : parsedTotalCount;
+
+  return { searches, totalCount };
 };
 
 export const stop = ({ id }) => {

--- a/src/web/src/lib/searches.test.js
+++ b/src/web/src/lib/searches.test.js
@@ -1,4 +1,54 @@
+import api from './api';
 import * as search from './searches';
+
+jest.mock('./api', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+
+describe('getAll', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps the unpaged request compatible', async () => {
+    expect.hasAssertions();
+    api.get.mockResolvedValue({
+      data: [{ id: 'one' }],
+      headers: { 'x-total-count': '1' },
+    });
+
+    await expect(search.getAll()).resolves.toEqual({
+      searches: [{ id: 'one' }],
+      totalCount: 1,
+    });
+    expect(api.get).toHaveBeenCalledWith('/searches');
+  });
+
+  it('appends pagination and returns the total count', async () => {
+    expect.hasAssertions();
+    api.get.mockResolvedValue({
+      data: [{ id: 'two' }],
+      headers: { 'x-total-count': '250' },
+    });
+
+    await expect(search.getAll({ limit: 100, offset: 100 })).resolves.toEqual({
+      searches: [{ id: 'two' }],
+      totalCount: 250,
+    });
+    expect(api.get).toHaveBeenCalledWith('/searches?offset=100&limit=100');
+  });
+
+  it('uses the response length when the total count header is absent', async () => {
+    expect.hasAssertions();
+    api.get.mockResolvedValue({ data: [{}, {}], headers: {} });
+
+    await expect(search.getAll({ limit: 100, offset: 0 })).resolves.toEqual({
+      searches: [{}, {}],
+      totalCount: 2,
+    });
+  });
+});
 
 describe('filterResponse', () => {
   it('removes VBR files if "iscbr" is specified', () => {

--- a/src/web/src/lib/transfers.js
+++ b/src/web/src/lib/transfers.js
@@ -1,16 +1,31 @@
 import api from './api';
 
-export const getAll = async ({ direction }) => {
-  const response = (
-    await api.get(`/transfers/${encodeURIComponent(direction)}s`)
-  ).data;
+export const getAll = async ({ direction, limit, offset }) => {
+  const parameters = new URLSearchParams();
 
-  if (!Array.isArray(response)) {
-    console.warn('got non-array response from transfers API', response);
+  if (offset !== undefined) parameters.append('offset', offset);
+  if (limit !== undefined) parameters.append('limit', limit);
+
+  const query = parameters.toString();
+  const response = await api.get(
+    `/transfers/${encodeURIComponent(direction)}s${query ? `?${query}` : ''}`,
+  );
+  const transfers = response.data;
+
+  if (!Array.isArray(transfers)) {
+    console.warn('got non-array response from transfers API', transfers);
     return undefined;
   }
 
-  return response;
+  const parsedTotalCount = Number.parseInt(
+    response.headers?.['x-total-count'],
+    10,
+  );
+  const totalCount = Number.isNaN(parsedTotalCount)
+    ? transfers.length
+    : parsedTotalCount;
+
+  return { totalCount, transfers };
 };
 
 export const download = ({ username, files = [] }) => {

--- a/src/web/src/lib/transfers.test.js
+++ b/src/web/src/lib/transfers.test.js
@@ -1,0 +1,57 @@
+import api from './api';
+import * as transfers from './transfers';
+
+jest.mock('./api', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+
+describe('getAll', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps the unpaged request compatible', async () => {
+    expect.hasAssertions();
+    api.get.mockResolvedValue({
+      data: [{ username: 'alice' }],
+      headers: { 'x-total-count': '1' },
+    });
+
+    await expect(transfers.getAll({ direction: 'download' })).resolves.toEqual({
+      totalCount: 1,
+      transfers: [{ username: 'alice' }],
+    });
+    expect(api.get).toHaveBeenCalledWith('/transfers/downloads');
+  });
+
+  it('appends pagination and returns the user-group count', async () => {
+    expect.hasAssertions();
+    api.get.mockResolvedValue({
+      data: [{ username: 'bob' }],
+      headers: { 'x-total-count': '205' },
+    });
+
+    await expect(
+      transfers.getAll({ direction: 'upload', limit: 100, offset: 100 }),
+    ).resolves.toEqual({
+      totalCount: 205,
+      transfers: [{ username: 'bob' }],
+    });
+    expect(api.get).toHaveBeenCalledWith(
+      '/transfers/uploads?offset=100&limit=100',
+    );
+  });
+
+  it('uses the response length when the total count header is absent', async () => {
+    expect.hasAssertions();
+    api.get.mockResolvedValue({
+      data: [{ username: 'alice' }, { username: 'bob' }],
+      headers: {},
+    });
+
+    await expect(
+      transfers.getAll({ direction: 'download', limit: 100, offset: 0 }),
+    ).resolves.toMatchObject({ totalCount: 2 });
+  });
+});

--- a/tests/slskd.Tests.Unit/Search/SearchServicePaginationTests.cs
+++ b/tests/slskd.Tests.Unit/Search/SearchServicePaginationTests.cs
@@ -1,0 +1,155 @@
+namespace slskd.Tests.Unit.Search;
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Moq;
+using slskd.Search;
+using slskd.Search.API;
+using Soulseek;
+using Xunit;
+
+public class SearchServicePaginationTests : IDisposable
+{
+    private readonly SqliteConnection _anchor;
+    private readonly DbContextOptions<SearchDbContext> _contextOptions;
+    private readonly SearchService _service;
+
+    public SearchServicePaginationTests()
+    {
+        var connectionString = $"Data Source=search_{Guid.NewGuid():N};Mode=Memory;Cache=Shared";
+        _anchor = new SqliteConnection(connectionString);
+        _anchor.Open();
+        _contextOptions = new DbContextOptionsBuilder<SearchDbContext>()
+            .UseSqlite(connectionString)
+            .Options;
+
+        using var context = new SearchDbContext(_contextOptions);
+        context.Database.EnsureCreated();
+
+        var contextFactory = new Mock<IDbContextFactory<SearchDbContext>>();
+        contextFactory
+            .Setup(factory => factory.CreateDbContext())
+            .Returns(() => new SearchDbContext(_contextOptions));
+
+        _service = new SearchService(
+            new Mock<IHubContext<SearchHub>>().Object,
+            new Mock<IOptionsMonitor<slskd.Options>>().Object,
+            new Mock<ISoulseekClient>().Object,
+            contextFactory.Object);
+    }
+
+    public void Dispose()
+    {
+        _anchor.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task ListAsync_Returns_A_Deterministic_Page()
+    {
+        var timestamp = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var oldest = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var tiedFirst = Guid.Parse("00000000-0000-0000-0000-000000000003");
+        var tiedSecond = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var newest = Guid.Parse("00000000-0000-0000-0000-000000000004");
+
+        Insert(oldest, timestamp.AddMinutes(-1));
+        Insert(tiedSecond, timestamp);
+        Insert(tiedFirst, timestamp);
+        Insert(newest, timestamp.AddMinutes(1));
+
+        var page = await _service.ListAsync(offset: 1, limit: 2);
+
+        Assert.Equal(new[] { tiedFirst, tiedSecond }, page.Select(search => search.Id));
+    }
+
+    [Fact]
+    public async Task ListAsync_Allows_Offset_Without_Limit()
+    {
+        var timestamp = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        Insert(Guid.Parse("00000000-0000-0000-0000-000000000001"), timestamp);
+        Insert(Guid.Parse("00000000-0000-0000-0000-000000000002"), timestamp.AddMinutes(1));
+        Insert(Guid.Parse("00000000-0000-0000-0000-000000000003"), timestamp.AddMinutes(2));
+
+        var page = await _service.ListAsync(offset: 1, limit: null);
+
+        Assert.Equal(2, page.Count);
+    }
+
+    [Fact]
+    public async Task CountAsync_Applies_The_Filter()
+    {
+        var timestamp = DateTime.UtcNow;
+        Insert(Guid.NewGuid(), timestamp, "keep one");
+        Insert(Guid.NewGuid(), timestamp, "keep two");
+        Insert(Guid.NewGuid(), timestamp, "omit");
+
+        var count = await _service.CountAsync(search => search.SearchText.StartsWith("keep"));
+
+        Assert.Equal(2, count);
+    }
+
+    private void Insert(Guid id, DateTime startedAt, string searchText = "search")
+    {
+        using var context = new SearchDbContext(_contextOptions);
+        context.Searches.Add(new slskd.Search.Search
+        {
+            Id = id,
+            SearchText = searchText,
+            StartedAt = startedAt,
+        });
+        context.SaveChanges();
+    }
+}
+
+public class SearchesControllerPaginationTests
+{
+    [Fact]
+    public async Task GetAll_Without_Pagination_Uses_The_Existing_List_And_Adds_Count()
+    {
+        var searches = new[]
+        {
+            new slskd.Search.Search { Id = Guid.NewGuid(), SearchText = "one" },
+            new slskd.Search.Search { Id = Guid.NewGuid(), SearchText = "two" },
+        }.ToList();
+        var service = new Mock<ISearchService>();
+        service
+            .Setup(searchService => searchService.ListAsync(It.IsAny<Expression<Func<slskd.Search.Search, bool>>>()))
+            .ReturnsAsync(searches);
+        var controller = CreateController(service.Object);
+
+        var result = Assert.IsType<OkObjectResult>(await controller.GetAll());
+
+        Assert.Same(searches, result.Value);
+        Assert.Equal("2", controller.Response.Headers["X-Total-Count"]);
+        service.Verify(searchService => searchService.CountAsync(It.IsAny<Expression<Func<slskd.Search.Search, bool>>>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(-1, null)]
+    [InlineData(null, 0)]
+    public async Task GetAll_Rejects_Invalid_Pagination(int? offset, int? limit)
+    {
+        var controller = CreateController(new Mock<ISearchService>().Object);
+
+        var result = await controller.GetAll(offset, limit);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    private static SearchesController CreateController(ISearchService service)
+    {
+        return new SearchesController(service, new Mock<IOptionsSnapshot<slskd.Options>>().Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+    }
+}

--- a/tests/slskd.Tests.Unit/Transfers/API/TransfersControllerPaginationTests.cs
+++ b/tests/slskd.Tests.Unit/Transfers/API/TransfersControllerPaginationTests.cs
@@ -1,0 +1,168 @@
+namespace slskd.Tests.Unit.Transfers.API;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Moq;
+using slskd.Transfers;
+using slskd.Transfers.API;
+using slskd.Transfers.Downloads;
+using slskd.Transfers.Uploads;
+using slskd.Users;
+using Soulseek;
+using Xunit;
+using Transfer = slskd.Transfers.Transfer;
+
+public class TransfersControllerPaginationTests : IDisposable
+{
+    private readonly SqliteConnection _anchor;
+    private readonly DbContextOptions<TransfersDbContext> _contextOptions;
+    private readonly Mock<IDownloadService> _downloads = new();
+    private readonly TransfersController _controller;
+
+    public TransfersControllerPaginationTests()
+    {
+        var connectionString = $"Data Source=transfers_{Guid.NewGuid():N};Mode=Memory;Cache=Shared";
+        _anchor = new SqliteConnection(connectionString);
+        _anchor.Open();
+        _contextOptions = new DbContextOptionsBuilder<TransfersDbContext>()
+            .UseSqlite(connectionString)
+            .Options;
+
+        using var context = new TransfersDbContext(_contextOptions);
+        context.Database.EnsureCreated();
+
+        var contextFactory = new Mock<IDbContextFactory<TransfersDbContext>>();
+        contextFactory
+            .Setup(factory => factory.CreateDbContext())
+            .Returns(() => new TransfersDbContext(_contextOptions));
+        var transferService = new TransferService(
+            contextFactory.Object,
+            new Mock<IUploadService>().Object,
+            _downloads.Object);
+
+        _controller = new TransfersController(
+            transferService,
+            new Mock<IUserService>().Object,
+            new Mock<IOptionsSnapshot<slskd.Options>>().Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+    }
+
+    public void Dispose()
+    {
+        _anchor.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void GetDownloads_Pages_Complete_User_Groups_By_Newest_Activity()
+    {
+        var now = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        for (var i = 0; i < 101; i++)
+        {
+            Insert(TransferDirection.Download, "alice", now, $"alice\\album\\{i}.mp3");
+        }
+
+        Insert(TransferDirection.Download, "bob", now.AddMinutes(-1), "bob\\album\\file.mp3");
+        Insert(TransferDirection.Download, "removed", now.AddMinutes(1), "removed\\file.mp3", removed: true);
+
+        var result = Assert.IsType<OkObjectResult>(_controller.GetDownloadsAsync(includeRemoved: false, offset: 0, limit: 1));
+        var users = Assert.IsAssignableFrom<IEnumerable<UserResponse>>(result.Value).ToList();
+        var files = users.Single().Directories.SelectMany(directory => directory.Files).ToList();
+
+        Assert.Equal("alice", users.Single().Username);
+        Assert.Equal(101, files.Count);
+        Assert.Equal("2", _controller.Response.Headers["X-Total-Count"]);
+    }
+
+    [Fact]
+    public void GetUploads_Applies_IncludeRemoved_Before_Counting()
+    {
+        var now = DateTime.UtcNow;
+        Insert(TransferDirection.Upload, "alice", now, "alice\\file.mp3");
+        Insert(TransferDirection.Upload, "bob", now.AddMinutes(1), "bob\\file.mp3", removed: true);
+
+        var withoutRemoved = Assert.IsType<OkObjectResult>(_controller.GetUploads(includeRemoved: false, offset: 0, limit: 100));
+        var visibleUsers = Assert.IsAssignableFrom<IEnumerable<UserResponse>>(withoutRemoved.Value).ToList();
+
+        Assert.Single(visibleUsers);
+        Assert.Equal("1", _controller.Response.Headers["X-Total-Count"]);
+
+        _controller.Response.Headers.Clear();
+        var withRemoved = Assert.IsType<OkObjectResult>(_controller.GetUploads(includeRemoved: true, offset: 0, limit: 100));
+        var allUsers = Assert.IsAssignableFrom<IEnumerable<UserResponse>>(withRemoved.Value).ToList();
+
+        Assert.Equal(2, allUsers.Count);
+        Assert.Equal("2", _controller.Response.Headers["X-Total-Count"]);
+    }
+
+    [Fact]
+    public void GetDownloads_Returns_An_Empty_Out_Of_Range_Page_With_The_Total_Count()
+    {
+        Insert(TransferDirection.Download, "alice", DateTime.UtcNow, "file.mp3");
+
+        var result = Assert.IsType<OkObjectResult>(_controller.GetDownloadsAsync(offset: 10, limit: 100));
+        var users = Assert.IsAssignableFrom<IEnumerable<UserResponse>>(result.Value).ToList();
+
+        Assert.Empty(users);
+        Assert.Equal("1", _controller.Response.Headers["X-Total-Count"]);
+    }
+
+    [Fact]
+    public void GetDownloads_Without_Pagination_Uses_The_Existing_List()
+    {
+        var transfers = new List<Transfer>
+        {
+            CreateTransfer(TransferDirection.Download, "alice", DateTime.UtcNow, "file.mp3"),
+        };
+        _downloads
+            .Setup(service => service.List(It.IsAny<Expression<Func<Transfer, bool>>>(), false))
+            .Returns(transfers);
+
+        var result = Assert.IsType<OkObjectResult>(_controller.GetDownloadsAsync());
+        var users = Assert.IsAssignableFrom<IEnumerable<UserResponse>>(result.Value).ToList();
+
+        Assert.Equal("alice", users.Single().Username);
+        Assert.Equal("1", _controller.Response.Headers["X-Total-Count"]);
+    }
+
+    [Theory]
+    [InlineData(-1, null)]
+    [InlineData(null, 0)]
+    public void GetDownloads_Rejects_Invalid_Pagination(int? offset, int? limit)
+    {
+        var result = _controller.GetDownloadsAsync(offset: offset, limit: limit);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    private void Insert(TransferDirection direction, string username, DateTime requestedAt, string filename, bool removed = false)
+    {
+        using var context = new TransfersDbContext(_contextOptions);
+        context.Transfers.Add(CreateTransfer(direction, username, requestedAt, filename, removed));
+        context.SaveChanges();
+    }
+
+    private static Transfer CreateTransfer(TransferDirection direction, string username, DateTime requestedAt, string filename, bool removed = false)
+    {
+        return new Transfer
+        {
+            Id = Guid.NewGuid(),
+            Direction = direction,
+            Username = username,
+            Filename = filename,
+            RequestedAt = requestedAt,
+            Removed = removed,
+            Size = 1,
+        };
+    }
+}


### PR DESCRIPTION
Adds optional, backward-compatible pagination to searches, downloads, and uploads. The UI loads 100 searches or transfer user groups per page while preserving live updates, grouped transfers, and global bulk actions.

Includes backend and frontend tests for paging, counts, page clamping, direct search loading, and bulk actions.

This PR was made because my browser crashes on page load of /searches or /uploads, and this is a huge annoyance :(

Closes #1143

Codex (GPT 5.6 Sol) was used to made this contribution. I tested it manually on my personal slskd instance - works fine (published image `ghcr.io/cofob/slskd:pagination`).

Screenshots:
<img width="1463" height="838" alt="Screenshot 2026-08-16 at 23 23 39" src="https://github.com/user-attachments/assets/a1c5fc89-c5f4-4a1f-afbb-11eca2647b30" />
<img width="1462" height="838" alt="Screenshot 2026-08-16 at 23 24 51" src="https://github.com/user-attachments/assets/79d1207b-9510-421a-a35b-31babaceb5fc" />
