### PR TITLE
Cancel downloads when their enqueue attempt times out

### DIFF
--- a/src/slskd/Transfers/Downloads/DownloadService.cs
+++ b/src/slskd/Transfers/Downloads/DownloadService.cs
@@ -550,6 +550,12 @@ namespace slskd.Transfers.Downloads
                                 {
                                     Log.Warning("Download of {Filename} from {Username} failed to enqueue remotely after hard time limit of {Duration} seconds. State transition history: {History}", transfer.Filename, username, maxTimeToWaitForEnqueueRequestAck.TotalSeconds, string.Join(", ", transitions));
                                     enqueuedTcs.TrySetException(new TimeoutException($"Download failed to enqueue remotely after hard time limit of {maxTimeToWaitForEnqueueRequestAck.TotalSeconds} secs"));
+
+                                    // cancel the download attempt so that it doesn't keep running and cause the internal
+                                    // state of slskd to diverge from the internal state of Soulseek.NET.
+                                    // the transfer record is recorded as being cancelled when this happens and there's not
+                                    // an easy/good way to stop it.
+                                    cts.Cancel();
                                 });
 
                                 // satisfies conditions #1 and #2


### PR DESCRIPTION
It's currently possible for an attempt to enqueue a file to time out and return stating that the attempt failed, and for the associated download to eventually go on to succeed.  There's a hard-coded 3 minute timeout on enqueue requests.

This problem, when it happens, eventually corrects itself because the download operation will move the associated transfer record out of a `Completed, TimedOut` state back into an active one if it does eventually start, so this PR is unlikely to solve any active issues.