### PR TITLE
Add a debug API controller and a /transfers endpoint to return SoulseekClient's transfer lists

### DIFF
--- a/src/slskd/Core/API/Controllers/ApplicationController.cs
+++ b/src/slskd/Core/API/Controllers/ApplicationController.cs
@@ -148,6 +148,7 @@ namespace slskd.Core.API
         ///     Forces garbage collection.
         /// </summary>
         /// <returns></returns>
+        [ApiExplorerSettings(IgnoreApi = true)]
         [HttpPost("gc")]
         [Authorize(Policy = AuthPolicy.Any)]
         public IActionResult CollectGarbage()
@@ -157,6 +158,7 @@ namespace slskd.Core.API
             return Ok();
         }
 
+        [ApiExplorerSettings(IgnoreApi = true)]
         [HttpGet("dump")]
         [Authorize(Policy = AuthPolicy.Any)]
         public async Task<IActionResult> DumpMemory()
@@ -167,6 +169,7 @@ namespace slskd.Core.API
             return PhysicalFile(file, "application/octet-stream", "slskd.dmp");
         }
 
+        [ApiExplorerSettings(IgnoreApi = true)]
         [HttpPost("loopback")]
         [Authorize(Policy = AuthPolicy.Any)]
         public IActionResult Loopback([FromBody] object body)

--- a/src/slskd/Core/API/Controllers/DebugController.cs
+++ b/src/slskd/Core/API/Controllers/DebugController.cs
@@ -1,0 +1,73 @@
+// <copyright file="DebugController.cs" company="JP Dillingham">
+//           ▄▄▄▄     ▄▄▄▄     ▄▄▄▄
+//     ▄▄▄▄▄▄█  █▄▄▄▄▄█  █▄▄▄▄▄█  █
+//     █__ --█  █__ --█    ◄█  -  █
+//     █▄▄▄▄▄█▄▄█▄▄▄▄▄█▄▄█▄▄█▄▄▄▄▄█
+//   ┍━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ━━━━ ━  ━┉   ┉     ┉
+//   │ Copyright (c) JP Dillingham.
+//   │
+//   │ This program is free software: you can redistribute it and/or modify
+//   │ it under the terms of the GNU Affero General Public License as published
+//   │ by the Free Software Foundation, version 3.
+//   │
+//   │ This program is distributed in the hope that it will be useful,
+//   │ but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   │ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   │ GNU Affero General Public License for more details.
+//   │
+//   │ You should have received a copy of the GNU Affero General Public License
+//   │ along with this program.  If not, see https://www.gnu.org/licenses/.
+//   │
+//   │ This program is distributed with Additional Terms pursuant to Section 7
+//   │ of the AGPLv3.  See the LICENSE file in the root directory of this
+//   │ project for the complete terms and conditions.
+//   │
+//   │ https://slskd.org
+//   │
+//   ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ╌ ╌╌╌╌ ╌
+//   │ SPDX-FileCopyrightText: JP Dillingham
+//   │ SPDX-License-Identifier: AGPL-3.0-only
+//   ╰───────────────────────────────────────────╶──── ─ ─── ─  ── ──┈  ┈
+// </copyright>
+
+namespace slskd.Core.API
+{
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Mvc;
+    using Soulseek;
+
+    /// <summary>
+    ///     Debug.
+    /// </summary>
+    [ApiExplorerSettings(IgnoreApi = true)]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [ApiVersion("0")]
+    [ApiController]
+    [Produces("application/json")]
+    [Consumes("application/json")]
+    public class DebugController : ControllerBase
+    {
+        public DebugController(ISoulseekClient soulseekClient)
+        {
+            Client = soulseekClient;
+        }
+
+        private ISoulseekClient Client { get; }
+
+        [HttpGet("transfers")]
+        [Authorize(Policy = AuthPolicy.Any)]
+        [ProducesResponseType(typeof(Transfer), 200)]
+        public IActionResult Transfers()
+        {
+            return Ok(new
+            {
+                Soulseek = new
+                {
+                    Client.Uploads,
+                    Client.Downloads,
+                },
+            });
+        }
+    }
+}


### PR DESCRIPTION
A user in Discord reported a case where the count of enqueued transfers in the footer didn't match what was shown in slskd's UI, which indicates that slskd's database had diverged from the internal list of transfers in the Soulseek.NET library.  There's currently no way to see what Soulseek.NET is tracking, so this endpoint provides a way.

Users who notice that their metrics aren't right can make an HTTP GET request to `/debug/transfers` and then search slskd's logs for the files to see what happened, if they'd like to file a bug report and provide that context.

Here's a `curl`:

```bash
curl --request GET \
  --url http://<your ip:your port>/api/v0/debug/transfers
```

Note that you'll probably need to provide an `Authorization: Bearer <JWT from your browser>` or `X-API-Key: <one of your API keys>` header to satisfy authentication.  The request above is to an instance with auth turned off.