### PR TITLE
Enable logging to disk by default, reduce default retention from 180 to 30 days

### DIFF
--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -195,7 +195,7 @@
 #       circuit_breaker: 500 # maximum number of pending search requests
 #       response_file_limit: 500 # maximum number of files to return in a single search response
 # logger:
-#   disk: false
+#   disk: true
 #   no_color: false
 #   loki: ~
 # metrics:

--- a/config/slskd.example.yml
+++ b/config/slskd.example.yml
@@ -195,7 +195,7 @@
 #       circuit_breaker: 500 # maximum number of pending search requests
 #       response_file_limit: 500 # maximum number of files to return in a single search response
 # logger:
-#   disk: true
+#   no_disk: false
 #   no_color: false
 #   loki: ~
 # metrics:

--- a/docs/config.md
+++ b/docs/config.md
@@ -1342,7 +1342,7 @@ Console colors can be disabled via typical application configuration described b
 
 | Command Line       | Environment Variable           | Description                        |
 | ------------------ | ------------------------------ | ---------------------------------- |
-| `--disk-logger`    | `SLSKD_DISK_LOGGER`            | Enable logging to disk             |
+| `--no-disk-logger` | `SLSKD_NO_DISK_LOGGER`         | Disable logging to disk            |
 | `--no-color`       | `SLSKD_NO_COLOR` or `NO_COLOR` | Disable console log colors         |
 
 Logs can optionally be forwarded to external services, and the targets can be expanded to any service supported by a [Serilog Sink](https://github.com/serilog/serilog/wiki/Provided-Sinks). Support for targets is added on an as-needed basis and within reason.

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1458,11 +1458,11 @@ namespace slskd
             /// <summary>
             ///     Gets a value indicating whether to write logs to disk.
             /// </summary>
-            [Argument(default, "disk-logger")]
-            [EnvironmentVariable("DISK_LOGGER")]
-            [Description("enable logging to disk")]
+            [Argument(default, "no-disk-logger")]
+            [EnvironmentVariable("NO_DISK_LOGGER")]
+            [Description("disable logging to disk")]
             [RequiresRestart]
-            public bool Disk { get; init; } = false;
+            public bool Disk { get; init; } = true;
 
             /// <summary>
             ///     Gets a value indicating whether to suppress colorization of console logs.

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1462,7 +1462,7 @@ namespace slskd
             [EnvironmentVariable("NO_DISK_LOGGER")]
             [Description("disable logging to disk")]
             [RequiresRestart]
-            public bool Disk { get; init; } = true;
+            public bool NoDisk { get; init; } = false;
 
             /// <summary>
             ///     Gets a value indicating whether to suppress colorization of console logs.

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1500,8 +1500,8 @@ namespace slskd
             /// <summary>
             ///     Gets the time to retain logs, in days.
             /// </summary>
-            [Range(1, maximum: int.MaxValue)]
-            public int Logs { get; init; } = 180;
+            [Range(7, maximum: int.MaxValue)]
+            public int Logs { get; init; } = 30;
 
             /// <summary>
             ///     Transfer retention options.

--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -512,7 +512,7 @@ namespace slskd
 
             Log.Information("Storing application data in {DataDirectory}", DataDirectory);
 
-            if (OptionsAtStartup.Logger.Disk)
+            if (!OptionsAtStartup.Logger.NoDisk)
             {
                 Log.Information("Saving application logs to {LogDirectory}", LogDirectory);
             }
@@ -1242,7 +1242,7 @@ namespace slskd
                     outputTemplate: (OptionsAtStartup.Debug ? "[{SourceContext}] " : string.Empty) + "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
                 .WriteTo.Async(config =>
                     config.Conditional(
-                        e => OptionsAtStartup.Logger.Disk,
+                        e => !OptionsAtStartup.Logger.NoDisk,
                         config => config.File(
                             Path.Combine(LogDirectory, $"{AppName}-.log"),
                             outputTemplate: (OptionsAtStartup.Debug ? "[{SourceContext}] " : string.Empty) + "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",


### PR DESCRIPTION
I'm working on adding in-app viewing of log files, and to make this work more effectively for the most users, I'm turning storage of logs on disk on by default.  I'm compensating for what might otherwise be an unwelcome change for some people by reducing the default retention from 180 to 30 days, and I think most users will find that 30 days of logs without debugging turned on will turn out to be at most a megabyte or so (I haven't measured but it won't be 100mb or something).

Users can turn this logging off if they don't want it, or they can keep it on and reduce log retention to as few as 7 days.

Ultimately I'm doing this to make it easier for folks to provide me with relevant information when submitting issues.