### PR TITLE
fix favicon.ico relative path in footer

### DIFF
--- a/src/web/src/components/AppFooter.jsx
+++ b/src/web/src/components/AppFooter.jsx
@@ -69,7 +69,7 @@ const AppFooter = ({
           <img
             alt=""
             className="footer-logo"
-            src="/favicon.ico"
+            src="./favicon.ico"
           />
           slskd
           {current && <span className="footer-version">{current}</span>}


### PR DESCRIPTION
Hi.

Same as my previous PR #1696 but this time in footer.

In case slskd is hosted not under `/` base URL but rather something like `/slskd`. 