### PR TITLE
Use atomic insert/update when activating conversations

### DIFF
--- a/src/slskd/Messaging/ConversationService.cs
+++ b/src/slskd/Messaging/ConversationService.cs
@@ -398,20 +398,23 @@ namespace slskd.Messaging
 
         private void ActivateConversation(string username)
         {
-            using var context = ContextFactory.CreateDbContext();
-
-            var conversation = context.Conversations.FirstOrDefault(c => c.Username == username);
-
-            if (conversation != default)
+            try
             {
-                conversation.IsActive = true;
-            }
-            else
-            {
-                context.Conversations.Add(new Conversation { Username = username, IsActive = true });
-            }
+                using var context = ContextFactory.CreateDbContext();
 
-            context.SaveChanges();
+                context.Database.ExecuteSql($@"
+                    INSERT INTO Conversations (Username, IsActive)
+                    VALUES ({username}, 1)
+                    ON CONFLICT(Username) DO UPDATE SET IsActive = excluded.IsActive;
+                ");
+
+                Log.Debug("Successfully activated Conversation for {Username}", username);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Failed to activate Conversation for {Username}: {Message}", username, ex.Message);
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
If a user has received private messages while offline the server will send them all upon login, and for each message slskd will "activate" the conversation.

The existing logic has a TOCTOU (Time Of Check, Time Of Update) problem that can cause this update/insert to throw when two threads are attempting to activate/update the conversation at the same time, with the second+ having passed the check for the existence of the row, found none, and then proceeding to `INSERT` when a previous thread had already performed it, causing a unique constraint violation.

This PR changes the logic to use an atomic `INSERT INTO ... ON CONFLICT DO UPDATE` which will execute the same logic inside the SQLite engine atomically.

I considered adding a `SyncRoot` and using it to synchronize this logic, and still might if this doesn't work as expected for some reason.

In reference to this comment (but not the parent issue): https://github.com/slskd/slskd/issues/1836#issuecomment-5582110917