### PR TITLE
Tweak favicon URL handling (again)

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -1067,12 +1067,17 @@ namespace slskd
             var urlBase = OptionsAtStartup.Web.UrlBase;
             urlBase = urlBase.StartsWith("/") ? urlBase : "/" + urlBase;
 
-            // use urlBase. this effectively just removes urlBase from the path.
-            // inject urlBase into any html files we serve, and rewrite links to ./static or /static to
-            // prepend the url base.
+            // use urlBase. this effectively just removes urlBase from the path before sending it to the next middleware
             app.UsePathBase(urlBase);
+
+            // rewrite relative html links to ./static or ./favicon.ico to absolute links that include urlBase
+            // this is necessary because SPA routers (like React Router) mess with the browser's current address
             app.UseHTMLRewrite("((\\.)?\\/static)", $"{(urlBase == "/" ? string.Empty : urlBase)}/static");
+            app.UseHTMLRewrite("((\\.)?\\/favicon\\.ico)", $"{(urlBase == "/" ? string.Empty : urlBase)}/favicon.ico");
+
+            // inject urlBase and port into any html files we serve as a window-scoped javascript variable
             app.UseHTMLInjection($"<script>window.urlBase=\"{urlBase}\";window.port={OptionsAtStartup.Web.Port}</script>", excludedRoutes: new[] { "/api", "/swagger" });
+
             Log.Information("Using base url {UrlBase}", urlBase);
 
             // serve static content from the configured path

--- a/src/web/src/components/AppFooter.jsx
+++ b/src/web/src/components/AppFooter.jsx
@@ -1,3 +1,4 @@
+import { urlBase } from '../config';
 import { formatBytes } from '../lib/util';
 import React from 'react';
 import { Icon, Menu } from 'semantic-ui-react';
@@ -69,7 +70,7 @@ const AppFooter = ({
           <img
             alt=""
             className="footer-logo"
-            src="./favicon.ico"
+            src={`${urlBase}/favicon.ico`}
           />
           slskd
           {current && <span className="footer-version">{current}</span>}


### PR DESCRIPTION
The footer `favicon.ico` link breaks on the System page due to the additional route segments; it's probably not noticeable because of caching but it is broken nonetheless.

The favicon link baked into index.html is broken in a similar fashion, and I'm adding an HTML rewrite step to fix that link the same way `./static` routes injected by React are fixed.

Probably not the last time I have to mess with this but we'll see.

### Testing

Note: *must* run from `/dist` after publishing; the React dev server won't surface these issues.

When using a non-empty `urlBase` and with cache disabled via devtools:

* [x] Index favicon loads properly when initial page is `/urlBase`
* [x] Index favicon loads properly when initial page is `/urlBase/system/logs`

Manually edit the index HTML to prevent it from caching the favicon, then ensure:

* [x] Footer icon loads properly when initial page is `/urlBase`
* [x] Footer icon loads properly when initial page is `/urlBase/system/logs`