### PR TITLE
Reduce memory pressure when scanning files and directories by using .NET functions returning IEnumerable instead of collections

### DIFF
--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -1257,28 +1257,39 @@ namespace slskd
                         RecurseSubdirectories = true,
                     };
 
-                    var files = System.IO.Directory.GetFiles(directory, "*", options)
-                        .Select(filename => Files.ResolveFileInfo(filename))
-                        .Where(file => file.LastAccessTimeUtc <= DateTime.UtcNow.AddMinutes(-age.Value));
+                    var fileInfo = new DirectoryInfo(directory)
+                        .EnumerateFiles("*", options)
+                        .Where(file =>
+                        {
+                            try
+                            {
+                                return file.LastWriteTimeUtc <= DateTime.UtcNow.AddMinutes(-age.Value);
+                            }
+                            catch (Exception ex)
+                            {
+                                Log.Warning(ex, "Failed to access file {File} during pruning: {Message}", file.Name, ex.Message);
+                                return false;
+                            }
+                        });
 
-                    Log.Debug("Found {Count} files of need of pruning", files.Count());
+                    int errorCount = 0;
+                    int fileCount = 0;
 
-                    int errors = 0;
-
-                    foreach (var file in files)
+                    foreach (var file in fileInfo)
                     {
                         try
                         {
                             file.Delete();
+                            fileCount++;
                         }
                         catch (Exception ex)
                         {
-                            errors++;
+                            errorCount++;
                             Log.Warning(ex, "Failed to prune file {File}: {Message}", file, ex.Message);
                         }
                     }
 
-                    Log.Debug("Pruning complete. Deleted: {Deleted}, Errors: {Errors}", files.Count() - errors, errors);
+                    Log.Debug("Pruning complete. Deleted: {Deleted}, Errors: {Errors}", fileCount, errorCount);
                 }
                 catch (Exception ex)
                 {

--- a/src/slskd/Common/FileSafety.cs
+++ b/src/slskd/Common/FileSafety.cs
@@ -233,6 +233,61 @@ public static class FileSafety
     public static bool IsPathRelative(string path, OperatingSystem? os = null) => !IsPathAbsolute(path, os);
 
     /// <summary>
+    ///     Indicates whether the specified <paramref name="subDirectory"/> is a subdirectory within (or is) the <paramref name="root"/>.
+    /// </summary>
+    /// <param name="root">The potential root path.</param>
+    /// <param name="subDirectory">The path to check.</param>
+    /// <param name="os">An optional operating system override, for testing.</param>
+    /// <returns>A value indicating whether the specified path is a subdirectory of (or is) the root.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if the specified root is null, empty, or consists of only whitespace.</exception>
+    /// <exception cref="ArgumentException">Thrown if the specified root or subdirectories are not absolute or contain traversal segments.</exception>
+    public static bool IsRootDirectoryOf(string root, string subDirectory, OperatingSystem? os = null)
+    {
+        ArgumentNullException.ThrowIfNullOrWhiteSpace(root);
+
+        if (!IsPathAbsolute(root, os))
+        {
+            throw new ArgumentException("Specified root path must be absolute");
+        }
+
+        if (ContainsTraversalSegments(root))
+        {
+            throw new ArgumentException("Specified root path contains traversal segments");
+        }
+
+        if (!IsPathAbsolute(subDirectory, os))
+        {
+            throw new ArgumentException("Specified subdirectory path must be absolute");
+        }
+
+        if (ContainsTraversalSegments(subDirectory))
+        {
+            throw new ArgumentException("Specified subdirectory path contains traversal segments");
+        }
+
+        var stringComparison = StringComparison.Ordinal;
+
+        if (os.HasValue ? os.Value == OperatingSystem.Windows : System.OperatingSystem.IsWindows())
+        {
+            stringComparison = StringComparison.OrdinalIgnoreCase;
+        }
+
+        return subDirectory.TrimEnd('/', '\\').Equals(root.TrimEnd('/', '\\'), stringComparison) ||
+            subDirectory.StartsWith(root.TrimEnd('/', '\\') + Path.DirectorySeparatorChar, stringComparison);
+    }
+
+    /// <summary>
+    ///     Indicates whether the specified <paramref name="root"/> is the parent path of (or is) the <paramref name="subDirectory"/>.
+    /// </summary>
+    /// <param name="subDirectory">The potential subdirectory.</param>
+    /// <param name="root">The path to check.</param>
+    /// <param name="os">An optional operating system override, for testing.</param>
+    /// <returns>A value indicating whether the specified path is the parent of (or is) the subdirectory.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if the specified root is null, empty, or consists of only whitespace.</exception>
+    /// <exception cref="ArgumentException">Thrown if the specified root or subdirectories are not absolute or contain traversal segments.</exception>
+    public static bool IsSubDirectoryOf(string subDirectory, string root, OperatingSystem? os = null) => IsRootDirectoryOf(root, subDirectory, os);
+
+    /// <summary>
     ///     Returns the filename from the specified <paramref name="path"/>, properly
     ///     handling both forward and backslashes and removing invalid characters.
     /// </summary>

--- a/src/slskd/Files/FileService.cs
+++ b/src/slskd/Files/FileService.cs
@@ -67,6 +67,64 @@ namespace slskd.Files
         private IOptionsMonitor<Options> OptionsMonitor { get; }
 
         /// <summary>
+        ///     Resolves an instance of <see cref="FileInfo"/> for the specified <paramref name="info"/>, following
+        ///     any symlinks that may be present to their final target. A non-null return value is guaranteed.
+        /// </summary>
+        /// <param name="info">The FileInfo instance for which to follow symlinks.</param>
+        /// <returns>The resolved FileInfo instance.</returns>
+        /// <exception cref="ArgumentException">Thrown if the specified FileInfo is null.</exception>
+        /// <exception cref="UnauthorizedException">Thrown if the specified or linked file is restricted.</exception>
+        /// <exception cref="IOException">Thrown if the specified or linked file can't be resolved for some reason.</exception>
+        public virtual FileInfo ResolveFileInfo(FileInfo info)
+        {
+            if (info is null)
+            {
+                throw new ArgumentException("The specified FileInfo is null", nameof(info));
+            }
+
+            // if the above didn't throw we are guaranteed a valid instance of FileInfo regardless of whether
+            // the file exists or if it is a symlink. if it doesn't exist it can't be a symlink, so just return it
+            if (!info.Exists)
+            {
+                return info;
+            }
+
+            // LinkTarget is guaranteed to be null if the file isn't a symlink. docs:
+            //  > Gets the target path of the link located in FullName, or null if this FileSystemInfo instance doesn't represent a link.
+            if (info.LinkTarget is null)
+            {
+                return info;
+            }
+
+            // ResolveLinkTarget returns an instance of FileSystemInfo (which is being cast to FileInfo here) as long as
+            // the link itself exists (which we've checked), and regardless of whether the link target itself exists.
+            // we should only get this far if:
+            //   1) the given file exists and
+            //   2) it is a symlink, meaning this line _SHOULD_ be guaranteed to return an instance of FileInfo.
+            try
+            {
+                info = (FileInfo)info.ResolveLinkTarget(returnFinalTarget: true);
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException || ex is SecurityException)
+            {
+                throw new UnauthorizedException($"Access to the linked file '{info.Name}->{info.LinkTarget}' was denied: {ex.Message}", ex);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to resolve FileInfo for linked file '{File}->{Link}': {Message}", info.Name, info.LinkTarget, ex.Message);
+                throw new IOException($"Failed to resolve FileInfo for linked file '{info.Name}->{info.LinkTarget}': {ex.Message}", ex);
+            }
+
+            if (info is null)
+            {
+                Log.Error("Resolved FileInfo for linked file '{File}->{Link}' was unexpectedly null", info.Name, info.LinkTarget);
+                throw new IOException($"An unexpected error was encountered while resolving FileInfo for linked file '{info.Name}->{info.LinkTarget}'");
+            }
+
+            return info;
+        }
+
+        /// <summary>
         ///     Resolves an instance of <see cref="FileInfo"/> for the specified <paramref name="filename"/>, following
         ///     any symlinks that may be present to their final target. A non-null return value is guaranteed.
         /// </summary>
@@ -105,46 +163,7 @@ namespace slskd.Files
                 throw new IOException($"Failed to access file '{filename}': {ex.Message}", ex);
             }
 
-            // if the above didn't throw we are guaranteed a valid instance of FileInfo regardless of whether
-            // the file exists or if it is a symlink. if it doesn't exist it can't be a symlink, so just return it
-            if (!info.Exists)
-            {
-                return info;
-            }
-
-            // LinkTarget is guaranteed to be null if the file isn't a symlink. docs:
-            //  > Gets the target path of the link located in FullName, or null if this FileSystemInfo instance doesn't represent a link.
-            if (info.LinkTarget is null)
-            {
-                return info;
-            }
-
-            // ResolveLinkTarget returns an instance of FileSystemInfo (which is being cast to FileInfo here) as long as
-            // the link itself exists (which we've checked), and regardless of whether the link target itself exists.
-            // we should only get this far if:
-            //   1) the given file exists and
-            //   2) it is a symlink, meaning this line _SHOULD_ be guaranteed to return an instance of FileInfo.
-            try
-            {
-                info = (FileInfo)info.ResolveLinkTarget(returnFinalTarget: true);
-            }
-            catch (Exception ex) when (ex is UnauthorizedAccessException || ex is SecurityException)
-            {
-                throw new UnauthorizedException($"Access to the linked file '{filename}->{info.LinkTarget}' was denied: {ex.Message}", ex);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to resolve FileInfo for linked file '{File}->{Link}': {Message}", filename, info.LinkTarget, ex.Message);
-                throw new IOException($"Failed to resolve FileInfo for linked file '{filename}->{info.LinkTarget}': {ex.Message}", ex);
-            }
-
-            if (info is null)
-            {
-                Log.Error("Resolved FileInfo for linked file '{File}->{Link}' was unexpectedly null", filename, info.LinkTarget);
-                throw new IOException($"An unexpected error was encountered while resolving FileInfo for linked file '{filename}->{info.LinkTarget}'");
-            }
-
-            return info;
+            return ResolveFileInfo(info);
         }
 
         /// <summary>

--- a/src/slskd/Shares/ShareScanner.cs
+++ b/src/slskd/Shares/ShareScanner.cs
@@ -286,6 +286,15 @@ namespace slskd.Shares
 
                 foreach (var id in Enumerable.Range(0, WorkerCount))
                 {
+                    // set up a function to reliably resolve the Share given a directory; users can define nested shares,
+                    // so we need to sort to ensure the deepest-nested share is selected first
+                    var sortedShares = Shares.OrderByDescending(s => s.LocalPath.Length);
+
+                    Share ResolveShareFromDirectory(string directory)
+                    {
+                        return sortedShares.First(share => IsSubDirectoryOf(subDirectory: directory, root: share.LocalPath));
+                    }
+
                     workers.Add(new ChannelReader<string>(
                         channel: channel,
                         cancellationToken: cancellationToken,
@@ -296,7 +305,7 @@ namespace slskd.Shares
                             var addedFiles = 0;
                             var filteredFiles = 0;
 
-                            var share = Shares.First(share => directory.StartsWith(share.LocalPath));
+                            var share = ResolveShareFromDirectory(directory);
 
                             repository.InsertDirectory(directory.ReplaceFirst(share.LocalPath, share.RemotePath).NormalizePathForSoulseek(), timestamp);
 

--- a/src/slskd/Shares/ShareScanner.cs
+++ b/src/slskd/Shares/ShareScanner.cs
@@ -199,20 +199,14 @@ namespace slskd.Shares
                 Log.Information("Enumerating shared directories");
                 swSnapshot = sw.ElapsedMilliseconds;
 
-                // derive a list of all directories from all shares. skip hidden and system directories, as well as anything that
-                // can't be accessed due to security restrictions. it's necessary to enumerate these directories up front so we
-                // can deduplicate directories and apply exclusions
-                var unmaskedDirectories = Shares
-                    .SelectMany(share =>
-                    {
-                        try
-                        {
-                            var directories = System.IO.Directory.GetDirectories(share.LocalPath, "*", new EnumerationOptions()
-                            {
-                                AttributesToSkip = FileAttributes.Hidden | FileAttributes.System,
-                                IgnoreInaccessible = true,
-                                RecurseSubdirectories = true,
-                            });
+                // note: there's a safer version of this in the FileSafety class that checks for traversal and navigates
+                // case sensitivity for different operating systems. this version is stripped down for speed, and because
+                // we're not dealing with untrusted data
+                static bool IsSubDirectoryOf(string subDirectory, string root, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase)
+                {
+                    return subDirectory.TrimEnd('/', '\\').Equals(root.TrimEnd('/', '\\'), stringComparison) || // subdirectory literally is the root
+                        subDirectory.StartsWith(root.TrimEnd('/', '\\') + Path.DirectorySeparatorChar, stringComparison);
+                }
 
                             return directories.Where(directory => !filters.Any(filter => filter.IsMatch(directory)));
                         }

--- a/src/slskd/Shares/ShareScanner.cs
+++ b/src/slskd/Shares/ShareScanner.cs
@@ -272,6 +272,18 @@ namespace slskd.Shares
                 var cached = 0;
                 var filtered = 0;
 
+                // set up a function to reliably resolve the Share given a directory; users can define nested shares,
+                // so we need to sort to ensure the deepest-nested share is selected first
+                var sortedShares = Shares
+                    .Where(s => !s.IsExcluded)
+                    .OrderByDescending(s => s.LocalPath.Length)
+                    .ToList();
+
+                Share ResolveShareFromDirectory(string directory)
+                {
+                    return sortedShares.First(share => IsSubDirectoryOf(subDirectory: directory, root: share.LocalPath));
+                }
+
                 // set up a channel to fan out for directory scanning
                 var channel = Channel.CreateBounded<string>(new BoundedChannelOptions(1000)
                 {
@@ -286,15 +298,6 @@ namespace slskd.Shares
 
                 foreach (var id in Enumerable.Range(0, WorkerCount))
                 {
-                    // set up a function to reliably resolve the Share given a directory; users can define nested shares,
-                    // so we need to sort to ensure the deepest-nested share is selected first
-                    var sortedShares = Shares.OrderByDescending(s => s.LocalPath.Length);
-
-                    Share ResolveShareFromDirectory(string directory)
-                    {
-                        return sortedShares.First(share => IsSubDirectoryOf(subDirectory: directory, root: share.LocalPath));
-                    }
-
                     workers.Add(new ChannelReader<string>(
                         channel: channel,
                         cancellationToken: cancellationToken,

--- a/src/slskd/Shares/ShareScanner.cs
+++ b/src/slskd/Shares/ShareScanner.cs
@@ -208,25 +208,64 @@ namespace slskd.Shares
                         subDirectory.StartsWith(root.TrimEnd('/', '\\') + Path.DirectorySeparatorChar, stringComparison);
                 }
 
-                            return directories.Where(directory => !filters.Any(filter => filter.IsMatch(directory)));
-                        }
-                        catch (Exception ex)
+                /*
+                    derive a list of all subdirectories to scan by enumerating the subdirectories within each configured
+                    share recursively, omitting any directory that matches a filter or that exists within an excluded share
+
+                    we don't enumerate excluded shares because 1) the exclusion is a subdirectory of another share and it
+                    will be enumerated once already or 2) the exclusion is not a subdirectory of another share and we don't
+                    want to enumerate its directories just to remove them all. this is probably obvious and kind of a worthless comment
+                */
+                var unmaskedDirectories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var excludedDirectories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                var excludedPaths = Shares.Where(s => s.IsExcluded).Select(s => s.LocalPath).ToHashSet();
+
+                foreach (var share in Shares)
+                {
+                    if (share.IsExcluded)
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        var directories = Directory.EnumerateDirectories(share.LocalPath, "*", new EnumerationOptions()
                         {
-                            Log.Warning("Failed to scan share {Directory}: {Message}", share.LocalPath, ex.Message);
-                            return Array.Empty<string>();
+                            AttributesToSkip = FileAttributes.Hidden | FileAttributes.System | FileAttributes.ReparsePoint,
+                            IgnoreInaccessible = true,
+                            RecurseSubdirectories = true,
+                        });
+
+                        unmaskedDirectories.Add(share.LocalPath);
+
+                        foreach (var directory in directories)
+                        {
+                            if (excludedPaths.Any(excludedPath => IsSubDirectoryOf(subDirectory: directory, root: excludedPath)))
+                            {
+                                excludedDirectories.Add(directory);
+                                Log.Debug("Excluding directory {Directory} because it is a subdirectory of an excluded share", directory);
+                                continue;
+                            }
+
+                            if (filters.Any(f => f.IsMatch(directory)))
+                            {
+                                excludedDirectories.Add(directory);
+                                Log.Debug("Excluding directory {Directory} because it matches one or more share filters", directory);
+                                continue;
+                            }
+
+                            unmaskedDirectories.Add(directory);
                         }
-                    })
-                    .Concat(Shares.Select(share => share.LocalPath)) // include the shares themselves (GetDirectories returns only subdirectories)
-                    .Where(share => System.IO.Directory.Exists(share)) // discard any directories that don't exist.  we already warned about them.
-                    .ToHashSet(); // remove duplicates (in case shares overlap)
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Warning("Failed to scan share {Directory}: {Message}", share.LocalPath, ex.Message);
+                    }
+                }
 
-                var excludedDirectories = unmaskedDirectories
-                    .Where(share => Shares.Where(share => share.IsExcluded).Any(exclusion => share.StartsWith(exclusion.LocalPath)));
-
-                unmaskedDirectories = unmaskedDirectories.Except(excludedDirectories).ToHashSet();
-
-                State.SetValue(state => state with { Directories = unmaskedDirectories.Count, ExcludedDirectories = excludedDirectories.Count() });
-                Log.Information("Found {Directories} shared directories (and {Excluded} were excluded) in {Elapsed}ms.  Starting file scan.", unmaskedDirectories.Count, excludedDirectories.Count(), sw.ElapsedMilliseconds - swSnapshot);
+                State.SetValue(state => state with { Directories = unmaskedDirectories.Count, ExcludedDirectories = excludedDirectories.Count });
+                Log.Information("Found {Directories} shared directories (and {Excluded} were excluded) in {Elapsed}ms.  Starting file scan.", unmaskedDirectories.Count, excludedDirectories.Count, sw.ElapsedMilliseconds - swSnapshot);
                 swSnapshot = sw.ElapsedMilliseconds;
 
                 var current = 0;

--- a/src/slskd/Shares/ShareScanner.cs
+++ b/src/slskd/Shares/ShareScanner.cs
@@ -315,29 +315,29 @@ namespace slskd.Shares
                             {
                                 // enumerate files in this directory only (no subdirectories) exclude hidden and system files and anything
                                 // that can't be accessed due to security restrictions
-                                var newFiles = System.IO.Directory.GetFiles(directory, "*", new EnumerationOptions()
+                                var newFileInfos = new DirectoryInfo(directory).EnumerateFiles("*", new EnumerationOptions()
                                 {
-                                    AttributesToSkip = FileAttributes.Hidden | FileAttributes.System,
+                                    AttributesToSkip = FileAttributes.Hidden | FileAttributes.System | FileAttributes.ReparsePoint,
                                     IgnoreInaccessible = true,
                                     RecurseSubdirectories = false,
                                 });
 
-                                addedFiles = newFiles.Length;
-
                                 // merge the new dictionary with the rest this will overwrite any duplicate keys, but keys are the fully
                                 // qualified name the only time this *should* cause problems is if one of the shares is a subdirectory of another.
-                                foreach (var originalFilename in newFiles)
+                                foreach (var info in newFileInfos)
                                 {
-                                    var info = Files.ResolveFileInfo(originalFilename);
-                                    var file = SoulseekFileFactory.Create(originalFilename, maskedFilename: originalFilename.ReplaceFirst(share.LocalPath, share.RemotePath).NormalizePathForSoulseek());
-
-                                    if (filters.Any(filter => filter.IsMatch(originalFilename)))
+                                    if (filters.Any(filter => filter.IsMatch(info.FullName)))
                                     {
                                         filteredFiles++;
                                         continue;
                                     }
 
-                                    repository.InsertFile(maskedFilename: file.Filename, originalFilename, touchedAt: info.LastWriteTimeUtc, file, timestamp);
+                                    var file = SoulseekFileFactory.Create(
+                                        filename: info.FullName,
+                                        maskedFilename: info.FullName.ReplaceFirst(share.LocalPath, share.RemotePath).NormalizePathForSoulseek());
+
+                                    repository.InsertFile(maskedFilename: file.Filename, originalFilename: info.FullName, touchedAt: info.LastWriteTimeUtc, file, timestamp);
+                                    addedFiles++;
                                 }
                             }
                             catch (Exception ex)

--- a/src/slskd/Shares/Types/Share.cs
+++ b/src/slskd/Shares/Types/Share.cs
@@ -71,6 +71,7 @@ namespace slskd.Shares
         /// <param name="share"></param>
         public Share(string share)
         {
+            share = share.TrimEnd('/', '\\');
             Raw = share;
             IsExcluded = share.StartsWith('-') || share.StartsWith('!');
 

--- a/tests/slskd.Tests.Unit/Common/FileSafety/IsRootDirectoryOfTests.cs
+++ b/tests/slskd.Tests.Unit/Common/FileSafety/IsRootDirectoryOfTests.cs
@@ -1,0 +1,245 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace slskd.Tests.Unit.Common;
+
+public partial class FileSafetyTests
+{
+    public class IsRootDirectoryOfTests
+    {
+        [Fact]
+        public void Root_Null_Throws_ArgumentNullException()
+        {
+            string root = null;
+
+            var ex = Record.Exception(() => FileSafety.IsRootDirectoryOf(root, "C:\\foo"));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentNullException>(ex);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Root_Empty_Or_Whitespace_Throws_ArgumentException(string root)
+        {
+            var ex = Record.Exception(() => FileSafety.IsRootDirectoryOf(root, "C:\\foo"));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentException>(ex);
+        }
+
+        public class Windows
+        {
+            [Theory]
+            [InlineData("foo")]
+            [InlineData("foo\\bar")]
+            [InlineData("foo/bar")]
+            [InlineData("\\foo")]
+            [InlineData("C:")]
+            [InlineData("C:foo")]
+            public void Relative_Root_Throws_ArgumentException(string root)
+            {
+                var ex = Record.Exception(() => FileSafety.IsRootDirectoryOf(root, "C:\\foo", OperatingSystem.Windows));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Theory]
+            [InlineData("C:\\foo\\..")]
+            [InlineData("C:\\foo\\..\\bar")]
+            [InlineData("C:\\foo\\.")]
+            [InlineData("C:\\..")]
+            [InlineData("\\\\foo\\..")]
+            public void Root_With_Traversal_Segments_Throws_ArgumentException(string root)
+            {
+                var ex = Record.Exception(() => FileSafety.IsRootDirectoryOf(root, "C:\\foo", OperatingSystem.Windows));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Theory]
+            [InlineData("foo")]
+            [InlineData("foo\\bar")]
+            [InlineData("\\foo")]
+            [InlineData("C:")]
+            [InlineData("C:foo")]
+            public void Relative_Subdirectory_Throws_ArgumentException(string subdirectory)
+            {
+                var ex = Record.Exception(() => FileSafety.IsRootDirectoryOf("C:\\foo", subdirectory, OperatingSystem.Windows));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Theory]
+            [InlineData("C:\\foo\\..")]
+            [InlineData("C:\\foo\\..\\bar")]
+            [InlineData("C:\\foo\\.")]
+            public void Subdirectory_With_Traversal_Segments_Throws_ArgumentException(string subdirectory)
+            {
+                var ex = Record.Exception(() => FileSafety.IsRootDirectoryOf("C:\\foo", subdirectory, OperatingSystem.Windows));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Theory]
+            [InlineData("C:\\foo", "C:\\foo")]
+            [InlineData("C:\\FOO", "C:\\foo")]
+            [InlineData("C:\\foo", "C:\\FOO")]
+            [InlineData("\\\\foo\\bar", "\\\\foo\\bar")]
+            [InlineData("\\\\FOO\\bar", "\\\\foo\\BAR")]
+            public void Equal_Paths_Are_A_Case_Insensitive_Match(string root, string subdirectory)
+            {
+                Assert.True(FileSafety.IsRootDirectoryOf(root, subdirectory, OperatingSystem.Windows));
+            }
+
+            // the character joining root and subdirectory is always the runtime OS separator
+            // (Path.DirectorySeparatorChar) regardless of the `os` override passed to force
+            // Windows-style absolute-path and case-sensitivity rules, so the expected result
+            // is computed from the actual runtime separator rather than hardcoded - this keeps
+            // the case correct on whichever OS the suite runs on, while still exercising both
+            // slash styles, mixed styles, drive letters, and UNC-style roots via inline data.
+            [Theory]
+            [InlineData("C:\\foo", "C:\\foo\\bar", '\\')]
+            [InlineData("C:\\foo", "C:\\foo/bar", '/')]
+            [InlineData("C:/foo", "C:/foo/bar", '/')]
+            [InlineData("C:/foo", "C:/foo\\bar", '\\')]
+            [InlineData("\\\\foo\\bar", "\\\\foo\\bar\\baz", '\\')]
+            [InlineData("\\\\foo\\bar", "\\\\foo\\bar/baz", '/')]
+            [InlineData("C:\\foo\\", "C:\\foo\\bar", '\\')]
+            [InlineData("C:\\foo/", "C:\\foo\\bar", '\\')]
+            public void Subdirectory_Match_Depends_On_Native_Separator_At_The_Boundary(string root, string subdirectory, char boundarySeparator)
+            {
+                var expected = boundarySeparator == Path.DirectorySeparatorChar;
+
+                Assert.Equal(expected, FileSafety.IsRootDirectoryOf(root, subdirectory, OperatingSystem.Windows));
+            }
+
+            [Theory]
+            [InlineData("C:\\foo", "C:\\foobar")]
+            [InlineData("C:\\foo\\bar", "C:\\foo")]
+            [InlineData("C:\\foo", "C:\\bar")]
+            [InlineData("C:\\foo\\bar", "C:\\foo\\baz")]
+            [InlineData("C:\\foo", "D:\\foo\\bar")]
+            [InlineData("\\\\foo\\bar", "\\\\foo\\barbaz")]
+            public void Non_Subdirectory_Returns_False(string root, string subdirectory)
+            {
+                Assert.False(FileSafety.IsRootDirectoryOf(root, subdirectory, OperatingSystem.Windows));
+            }
+
+            [Fact]
+            public void StartsWith_Check_Is_Case_Insensitive()
+            {
+                var subdirectory = "C:\\FOO" + Path.DirectorySeparatorChar + "bar";
+
+                Assert.True(FileSafety.IsRootDirectoryOf("C:\\foo", subdirectory, OperatingSystem.Windows));
+            }
+        }
+
+        public class Linux
+        {
+            [Theory]
+            [InlineData("foo")]
+            [InlineData("foo/bar")]
+            [InlineData("foo\\bar")]
+            [InlineData("C:\\foo")]
+            [InlineData("\\\\foo\\bar")]
+            public void Relative_Root_Throws_ArgumentException(string root)
+            {
+                var ex = Record.Exception(() => FileSafety.IsRootDirectoryOf(root, "/foo", OperatingSystem.Linux));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Theory]
+            [InlineData("/foo/..")]
+            [InlineData("/foo/../bar")]
+            [InlineData("/foo/.")]
+            [InlineData("/..")]
+            [InlineData("//foo/..")]
+            public void Root_With_Traversal_Segments_Throws_ArgumentException(string root)
+            {
+                var ex = Record.Exception(() => FileSafety.IsRootDirectoryOf(root, "/foo", OperatingSystem.Linux));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Theory]
+            [InlineData("foo")]
+            [InlineData("foo/bar")]
+            [InlineData("C:\\foo")]
+            public void Relative_Subdirectory_Throws_ArgumentException(string subdirectory)
+            {
+                var ex = Record.Exception(() => FileSafety.IsRootDirectoryOf("/foo", subdirectory, OperatingSystem.Linux));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Theory]
+            [InlineData("/foo/..")]
+            [InlineData("/foo/../bar")]
+            [InlineData("/foo/.")]
+            public void Subdirectory_With_Traversal_Segments_Throws_ArgumentException(string subdirectory)
+            {
+                var ex = Record.Exception(() => FileSafety.IsRootDirectoryOf("/foo", subdirectory, OperatingSystem.Linux));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Theory]
+            [InlineData("/foo", "/foo")]
+            [InlineData("//foo/bar", "//foo/bar")]
+            public void Equal_Paths_Match(string root, string subdirectory)
+            {
+                Assert.True(FileSafety.IsRootDirectoryOf(root, subdirectory, OperatingSystem.Linux));
+            }
+
+            [Fact]
+            public void Equal_Paths_Different_Case_Do_Not_Match()
+            {
+                Assert.False(FileSafety.IsRootDirectoryOf("/FOO", "/foo", OperatingSystem.Linux));
+            }
+
+            [Theory]
+            [InlineData("/foo", "/foo/bar", '/')]
+            [InlineData("/foo", "/foo\\bar", '\\')]
+            [InlineData("//foo/bar", "//foo/bar/baz", '/')]
+            [InlineData("//foo/bar", "//foo/bar\\baz", '\\')]
+            [InlineData("/foo/", "/foo/bar", '/')]
+            [InlineData("/foo\\", "/foo/bar", '/')]
+            public void Subdirectory_Match_Depends_On_Native_Separator_At_The_Boundary(string root, string subdirectory, char boundarySeparator)
+            {
+                var expected = boundarySeparator == Path.DirectorySeparatorChar;
+
+                Assert.Equal(expected, FileSafety.IsRootDirectoryOf(root, subdirectory, OperatingSystem.Linux));
+            }
+
+            [Theory]
+            [InlineData("/foo", "/foobar")]
+            [InlineData("/foo/bar", "/foo")]
+            [InlineData("/foo", "/bar")]
+            [InlineData("/foo/bar", "/foo/baz")]
+            public void Non_Subdirectory_Returns_False(string root, string subdirectory)
+            {
+                Assert.False(FileSafety.IsRootDirectoryOf(root, subdirectory, OperatingSystem.Linux));
+            }
+
+            [Fact]
+            public void StartsWith_Check_Is_Case_Sensitive()
+            {
+                var subdirectory = "/FOO" + Path.DirectorySeparatorChar + "bar";
+
+                Assert.False(FileSafety.IsRootDirectoryOf("/foo", subdirectory, OperatingSystem.Linux));
+            }
+        }
+    }
+}

--- a/tests/slskd.Tests.Unit/Common/FileSafety/IsSubDirectoryOfTests.cs
+++ b/tests/slskd.Tests.Unit/Common/FileSafety/IsSubDirectoryOfTests.cs
@@ -1,0 +1,215 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace slskd.Tests.Unit.Common;
+
+public partial class FileSafetyTests
+{
+    public class IsSubDirectoryOfTests
+    {
+        // IsSubDirectoryOf(subdirectory, root) forwards to IsRootDirectoryOf(root, subdirectory),
+        // so `root` (the second parameter here) lands on IsRootDirectoryOf's first parameter and
+        // is the one validated with ArgumentNullException.ThrowIfNullOrWhiteSpace.
+        [Fact]
+        public void Root_Null_Throws_ArgumentNullException()
+        {
+            string root = null;
+
+            var ex = Record.Exception(() => FileSafety.IsSubDirectoryOf("C:\\foo", root));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentNullException>(ex);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Root_Empty_Or_Whitespace_Throws_ArgumentException(string root)
+        {
+            var ex = Record.Exception(() => FileSafety.IsSubDirectoryOf("C:\\foo", root));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentException>(ex);
+        }
+
+        // subdirectory (the first parameter here) is never null-checked directly; it only fails
+        // the "must be absolute" check, so null/empty/whitespace all throw plain ArgumentException.
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Subdirectory_Null_Empty_Or_Whitespace_Throws_ArgumentException_Not_ArgumentNullException(string subdirectory)
+        {
+            var ex = Record.Exception(() => FileSafety.IsSubDirectoryOf(subdirectory, "C:\\foo", OperatingSystem.Windows));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentException>(ex);
+        }
+
+        public class Windows
+        {
+            [Theory]
+            [InlineData("foo")]
+            [InlineData("\\foo")]
+            [InlineData("C:")]
+            [InlineData("C:foo")]
+            public void Relative_Root_Throws_ArgumentException(string root)
+            {
+                var ex = Record.Exception(() => FileSafety.IsSubDirectoryOf("C:\\foo\\bar", root, OperatingSystem.Windows));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Theory]
+            [InlineData("foo")]
+            [InlineData("\\foo")]
+            [InlineData("C:")]
+            [InlineData("C:foo")]
+            public void Relative_Subdirectory_Throws_ArgumentException(string subdirectory)
+            {
+                var ex = Record.Exception(() => FileSafety.IsSubDirectoryOf(subdirectory, "C:\\foo", OperatingSystem.Windows));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Theory]
+            [InlineData("C:\\foo\\..")]
+            [InlineData("C:\\foo\\..\\bar")]
+            [InlineData("C:\\foo\\.")]
+            public void Root_With_Traversal_Segments_Throws_ArgumentException(string root)
+            {
+                var ex = Record.Exception(() => FileSafety.IsSubDirectoryOf("C:\\foo\\bar", root, OperatingSystem.Windows));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Theory]
+            [InlineData("C:\\foo\\..\\bar")]
+            [InlineData("C:\\foo\\.")]
+            public void Subdirectory_With_Traversal_Segments_Throws_ArgumentException(string subdirectory)
+            {
+                var ex = Record.Exception(() => FileSafety.IsSubDirectoryOf(subdirectory, "C:\\foo", OperatingSystem.Windows));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Theory]
+            [InlineData("C:\\foo", "C:\\foo")]
+            [InlineData("C:\\FOO", "C:\\foo")]
+            [InlineData("C:\\foo", "C:\\FOO")]
+            public void Equal_Paths_Are_A_Case_Insensitive_Match(string subdirectory, string root)
+            {
+                Assert.True(FileSafety.IsSubDirectoryOf(subdirectory, root, OperatingSystem.Windows));
+            }
+
+            [Theory]
+            [InlineData("C:\\foo\\bar", "C:\\foo", '\\')]
+            [InlineData("C:\\foo/bar", "C:\\foo", '/')]
+            [InlineData("\\\\foo\\bar\\baz", "\\\\foo\\bar", '\\')]
+            [InlineData("\\\\foo\\bar/baz", "\\\\foo\\bar", '/')]
+            [InlineData("C:\\foo\\bar", "C:\\foo\\", '\\')]
+            public void Match_Depends_On_Native_Separator_At_The_Boundary(string subdirectory, string root, char boundarySeparator)
+            {
+                var expected = boundarySeparator == Path.DirectorySeparatorChar;
+
+                Assert.Equal(expected, FileSafety.IsSubDirectoryOf(subdirectory, root, OperatingSystem.Windows));
+            }
+
+            [Theory]
+            [InlineData("C:\\foobar", "C:\\foo")]
+            [InlineData("C:\\foo", "C:\\foo\\bar")]
+            [InlineData("C:\\bar", "C:\\foo")]
+            [InlineData("C:\\foo\\baz", "C:\\foo\\bar")]
+            public void Not_A_Child_Of_Root_Returns_False(string subdirectory, string root)
+            {
+                Assert.False(FileSafety.IsSubDirectoryOf(subdirectory, root, OperatingSystem.Windows));
+            }
+        }
+
+        public class Linux
+        {
+            [Theory]
+            [InlineData("foo")]
+            [InlineData("C:\\foo")]
+            public void Relative_Root_Throws_ArgumentException(string root)
+            {
+                var ex = Record.Exception(() => FileSafety.IsSubDirectoryOf("/foo/bar", root, OperatingSystem.Linux));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Theory]
+            [InlineData("foo")]
+            [InlineData("C:\\foo")]
+            public void Relative_Subdirectory_Throws_ArgumentException(string subdirectory)
+            {
+                var ex = Record.Exception(() => FileSafety.IsSubDirectoryOf(subdirectory, "/foo", OperatingSystem.Linux));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Theory]
+            [InlineData("/foo/../bar")]
+            [InlineData("/foo/.")]
+            public void Root_With_Traversal_Segments_Throws_ArgumentException(string root)
+            {
+                var ex = Record.Exception(() => FileSafety.IsSubDirectoryOf("/foo/bar", root, OperatingSystem.Linux));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Theory]
+            [InlineData("/foo/../bar")]
+            [InlineData("/foo/.")]
+            public void Subdirectory_With_Traversal_Segments_Throws_ArgumentException(string subdirectory)
+            {
+                var ex = Record.Exception(() => FileSafety.IsSubDirectoryOf(subdirectory, "/foo", OperatingSystem.Linux));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+            [Fact]
+            public void Equal_Paths_Match()
+            {
+                Assert.True(FileSafety.IsSubDirectoryOf("/foo", "/foo", OperatingSystem.Linux));
+            }
+
+            [Fact]
+            public void Equal_Paths_Different_Case_Do_Not_Match()
+            {
+                Assert.False(FileSafety.IsSubDirectoryOf("/FOO", "/foo", OperatingSystem.Linux));
+            }
+
+            [Theory]
+            [InlineData("/foo/bar", "/foo", '/')]
+            [InlineData("/foo\\bar", "/foo", '\\')]
+            [InlineData("//foo/bar/baz", "//foo/bar", '/')]
+            [InlineData("//foo/bar\\baz", "//foo/bar", '\\')]
+            public void Match_Depends_On_Native_Separator_At_The_Boundary(string subdirectory, string root, char boundarySeparator)
+            {
+                var expected = boundarySeparator == Path.DirectorySeparatorChar;
+
+                Assert.Equal(expected, FileSafety.IsSubDirectoryOf(subdirectory, root, OperatingSystem.Linux));
+            }
+
+            [Theory]
+            [InlineData("/foobar", "/foo")]
+            [InlineData("/foo", "/foo/bar")]
+            [InlineData("/bar", "/foo")]
+            [InlineData("/foo/baz", "/foo/bar")]
+            public void Not_A_Child_Of_Root_Returns_False(string subdirectory, string root)
+            {
+                Assert.False(FileSafety.IsSubDirectoryOf(subdirectory, root, OperatingSystem.Linux));
+            }
+        }
+    }
+}


### PR DESCRIPTION
I forget how I got started on this, but I learned recently that .NET offers System.IO functions for searching for files and directories that return `IEnumerable` instead of collections (I probably should have looked before now).  These methods allow for more streaming-like processing instead of building up huge arrays or lists and then operating on them.

This PR switches the scanner over to `IEnumerable`, which will resolve out of memory errors for users with large shares.

I took the opportunity to refactor a few aspects of the share scanner to reduce the amount of disk I/O performed (redundant stats, etc), so users that have shares on network drives should notice a nice performance improvement.